### PR TITLE
Release 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "hippius",
     "private": true,
-    "version": "0.1.8",
+    "version": "0.1.9",
     "type": "module",
     "scripts": {
         "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Hippius"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Hippius"
-version = "0.1.8"
+version = "0.1.9"
 description = "Hippius Desktop App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,19 @@
         "opener:default",
         "fs:default",
         {
+            "identifier": "opener:allow-open-path",
+            "allow": [{
+                "path": "/**/*",
+                "recursive": true
+            }],
+            "options": {
+                "ask": {
+                    "message": "Hippius App would like to open your syncing files folder",
+                    "title": "Allow folder access"
+                }
+            }
+        },
+        {
             "identifier": "fs:allow-exists",
             "allow": [{
                 "path": "$APPLOCALDATA/hippius-desktop.db"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schema.tauri.app/config/2",
     "productName": "Hippius",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "identifier": "hippius.com",
     "build": {
         "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
### Notable Changes

### Folder Access Prompt
* The app can now ask for permission to open any folder you choose.
* You’ll see a clear system prompt; approve once per folder.
* Your choice is remembered for that folder.
* Safer access when opening custom locations or a new sync folder.