### PR TITLE
Release 0.1.13

### DIFF
--- a/app/components/page-sections/referrals/ReferralLinksTable.tsx
+++ b/app/components/page-sections/referrals/ReferralLinksTable.tsx
@@ -60,8 +60,8 @@ export default function ReferralLinksTable() {
         }
       }),
       columnHelper.accessor("reward", {
-        header: "Credits Earned",
-        cell: (info) => `${info.getValue()} Credits`
+        header: "hALPHA EARNED",
+        cell: (info) => `${info.getValue()} hAlpha`
       }),
       columnHelper.display({
         id: "copy",

--- a/app/components/page-sections/referrals/index.tsx
+++ b/app/components/page-sections/referrals/index.tsx
@@ -26,7 +26,7 @@ const Referrals: React.FC = () => {
           <ReferralLinkCard />
           <DetailsCard
             icon={UserSquare}
-            title="Total Referrals`"
+            title="Total Referrals"
             value={data ? data.totalReferrals : "---"}
           />
           <DetailsCard
@@ -36,7 +36,7 @@ const Referrals: React.FC = () => {
           />
           <DetailsCard
             icon={WalletAdd}
-            title="Total Alpha Earned "
+            title="Total hAlpha Earned "
             value={totalCredits.toString()}
           />
         </div>

--- a/app/components/ui/alt-table/Th.tsx
+++ b/app/components/ui/alt-table/Th.tsx
@@ -43,7 +43,7 @@ export function Th<TData, TValue>(props: ThProps<TData, TValue>) {
         )}
       >
         {canSort ? (
-          <button className="relative flex h-fit w-fit whitespace-nowrap uppercase">
+          <button className={cn("relative flex h-fit w-fit whitespace-nowrap", header.column.columnDef.header !== "hALPHA EARNED" && "uppercase")}>
             {flexRender(header.column.columnDef.header, header.getContext())}
             {sortOrder && (
               <ChevronDown

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "hippius",
     "private": true,
-    "version": "0.1.12",
+    "version": "0.1.13",
     "type": "module",
     "scripts": {
         "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Hippius"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Hippius"
-version = "0.1.12"
+version = "0.1.13"
 description = "Hippius Desktop App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schema.tauri.app/config/2",
     "productName": "Hippius",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "identifier": "hippius.com",
     "build": {
         "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
### Notable Changes
* Referral rewards now use **hAlpha** everywhere for consistent wording.
* Cleaner referral table headers for easier reading.

### Referrals
* “Credits”/“Alpha” renamed to **hAlpha** across referral pages.
* Cards now show **Total hAlpha Earned**.