### PR TITLE
Release 0.1.29

### DIFF
--- a/app/components/page-sections/files-folder/index.tsx
+++ b/app/components/page-sections/files-folder/index.tsx
@@ -38,6 +38,7 @@ import { getFolderPathArray } from "@/app/utils/folderPathUtils";
 import AddFolderToFolderButton from "@/components/page-sections/files/ipfs/AddFolderToFolderButton";
 import { useUrlParams } from "@/app/utils/hooks/useUrlParams";
 import { FileSelectionProvider } from "@/app/contexts/FileSelectionContext";
+import { usePagination } from "@/lib/hooks";
 
 interface FileEntry {
   file_name: string;
@@ -63,7 +64,6 @@ interface FolderViewProps {
 export default function FolderView({
   folderCid,
   folderName = "Folder",
-  folderActualName = "Folder",
   mainFolderActualName,
   subFolderPath,
 }: FolderViewProps) {
@@ -97,6 +97,14 @@ export default function FolderView({
     });
   }, [files, searchTerm, selectedFileTypes, selectedDate, selectedFileSize]);
 
+  // Shared pagination state between list and card views
+  const {
+    paginatedData,
+    setCurrentPage,
+    currentPage,
+    totalPages
+  } = usePagination(filteredData, 12);
+
   useEffect(() => {
     const newActiveFilters = generateActiveFilters(
       selectedFileTypes,
@@ -108,7 +116,14 @@ export default function FolderView({
 
   useEffect(() => {
     setShouldResetPagination(true);
-  }, [searchTerm, selectedFileTypes, selectedDate, selectedFileSize]);
+  }, [searchTerm, selectedFileTypes, selectedDate, selectedFileSize, viewMode]);
+
+  // Handle pagination reset
+  useEffect(() => {
+    if (shouldResetPagination) {
+      setCurrentPage(1);
+    }
+  }, [shouldResetPagination, setCurrentPage]);
 
   const loadFolderContents = useCallback(
     async (showLoading = true) => {
@@ -193,7 +208,6 @@ export default function FolderView({
     [
       folderCid,
       folderName,
-      folderActualName,
       mainFolderActualName,
       subFolderPath,
       isPrivateFolder,
@@ -474,7 +488,7 @@ export default function FolderView({
                 isLoading={false}
                 isFetching={false}
                 filteredData={filteredData}
-                displayedData={filteredData}
+                displayedData={paginatedData}
                 searchTerm={searchTerm}
                 activeFilters={activeFilters}
                 viewMode={viewMode}
@@ -489,6 +503,9 @@ export default function FolderView({
                 handleApplyFilters={handleApplyFilters}
                 handleResetFilters={handleResetFilters}
                 isPrivateView={isPrivateFolder}
+                currentPage={currentPage}
+                totalPages={totalPages}
+                setCurrentPage={setCurrentPage}
               />
             )}
           </>

--- a/app/components/page-sections/files/ipfs/FilesContent.tsx
+++ b/app/components/page-sections/files/ipfs/FilesContent.tsx
@@ -61,6 +61,9 @@ interface FilesContentProps {
   error?: unknown;
   isPrivateView: boolean;
   addButtonRef?: React.RefObject<{ openWithFiles(files: FileList): void }>;
+  currentPage: number;
+  totalPages: number;
+  setCurrentPage: (page: number) => void;
 }
 
 const FilesContent: FC<FilesContentProps> = ({
@@ -85,6 +88,9 @@ const FilesContent: FC<FilesContentProps> = ({
   error,
   isPrivateView,
   addButtonRef,
+  currentPage,
+  totalPages,
+  setCurrentPage,
 }) => {
   const [isDragging, setIsDragging] = useState(false);
   const [animateCloud, setAnimateCloud] = useState(false);
@@ -282,12 +288,16 @@ const FilesContent: FC<FilesContentProps> = ({
           isRecentFiles={isRecentFiles}
           showUnpinnedDialog={false}
           files={displayedData}
+          allFiles={filteredData}
           resetPagination={shouldResetPagination}
           onPaginationReset={handlePaginationReset}
           searchTerm={searchTerm}
           handleFileDownload={handleFileDownload}
           activeFilters={activeFilters}
           sharedState={sharedState}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          setCurrentPage={setCurrentPage}
         />
       );
     } else {
@@ -302,6 +312,9 @@ const FilesContent: FC<FilesContentProps> = ({
           searchTerm={searchTerm}
           activeFilters={activeFilters}
           sharedState={sharedState}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          setCurrentPage={setCurrentPage}
         />
       );
     }

--- a/app/components/page-sections/files/ipfs/card-view/index.tsx
+++ b/app/components/page-sections/files/ipfs/card-view/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import usePagination from "@/lib/hooks/use-pagination";
+
 import { getFilePartsFromFileName } from "@/lib/utils/getFilePartsFromFileName";
 import { getFileTypeFromExtension } from "@/lib/utils/getTileTypeFromExtension";
 import { decodeHexCid } from "@/lib/utils/decodeHexCid";
@@ -51,6 +51,9 @@ interface CardViewProps {
     file: FormattedUserIpfsFile,
     polkadotAddress: string
   ) => void;
+  currentPage: number;
+  totalPages: number;
+  setCurrentPage: (page: number) => void;
 }
 
 const CardView: FC<CardViewProps> = ({
@@ -61,7 +64,10 @@ const CardView: FC<CardViewProps> = ({
   searchTerm = "",
   activeFilters = [],
   sharedState,
-  handleFileDownload
+  handleFileDownload,
+  currentPage,
+  totalPages,
+  setCurrentPage
 }) => {
   const router = useRouter();
   const { polkadotAddress } = useWalletAuth();
@@ -132,16 +138,8 @@ const CardView: FC<CardViewProps> = ({
     safeFiles.length === 0 &&
     (searchTerm || (activeFilters && activeFilters.length > 0));
 
-  const {
-    paginatedData: data,
-    setCurrentPage,
-    currentPage,
-    totalPages
-  } = usePagination(safeFiles, 12);
-
   useEffect(() => {
     if (resetPagination) {
-      setCurrentPage(1);
       if (onPaginationReset) {
         onPaginationReset();
       }
@@ -177,7 +175,7 @@ const CardView: FC<CardViewProps> = ({
       >
         <div className="duration-300 delay-300">
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-            {data.map((file, index) => {
+            {files.map((file, index) => {
               const { fileFormat } = getFilePartsFromFileName(file.name);
               const fileType = getFileTypeFromExtension(fileFormat || null);
 

--- a/app/components/page-sections/files/ipfs/files-table/index.tsx
+++ b/app/components/page-sections/files/ipfs/files-table/index.tsx
@@ -28,7 +28,6 @@ import {
 import { decodeHexCid } from "@/lib/utils/decodeHexCid";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { usePagination } from "@/lib/hooks";
 import NameCell from "./NameCell";
 import SelectionActionBar from "../SelectionActionBar";
 import { SelectionColumn, SelectionHeaderColumn } from "../SelectionColumn";
@@ -62,6 +61,7 @@ interface Filter {
 interface FilesTableProps {
   showUnpinnedDialog?: boolean;
   files: FormattedUserIpfsFile[];
+  allFiles: FormattedUserIpfsFile[]; // Full list of files for header checkbox selection
   resetPagination?: boolean;
   onPaginationReset?: () => void;
   isRecentFiles?: boolean;
@@ -72,6 +72,9 @@ interface FilesTableProps {
     file: FormattedUserIpfsFile,
     polkadotAddress: string
   ) => void;
+  currentPage: number;
+  totalPages: number;
+  setCurrentPage: (page: number) => void;
 }
 
 // Create stable action functions outside component to prevent recreation
@@ -101,13 +104,17 @@ const copyToClipboard = (decodedCid: string) => {
 
 const FilesTable: FC<FilesTableProps> = memo(({
   files,
+  allFiles,
   resetPagination,
   onPaginationReset,
   isRecentFiles = false,
   searchTerm = "",
   activeFilters = [],
   sharedState,
-  handleFileDownload
+  handleFileDownload,
+  currentPage,
+  totalPages,
+  setCurrentPage
 }) => {
   const { polkadotAddress } = useWalletAuth();
   const { getParam } = useUrlParams();
@@ -163,16 +170,8 @@ const FilesTable: FC<FilesTableProps> = memo(({
     safeFiles.length === 0 &&
     (searchTerm || (activeFilters && activeFilters.length > 0));
 
-  const {
-    paginatedData,
-    setCurrentPage,
-    currentPage,
-    totalPages
-  } = usePagination(safeFiles, 10);
-
   useEffect(() => {
     if (resetPagination) {
-      setCurrentPage(1);
       if (onPaginationReset) {
         onPaginationReset();
       }
@@ -209,11 +208,10 @@ const FilesTable: FC<FilesTableProps> = memo(({
       onSuccess: () => {
         // Clear selection and exit selection mode
         clearSelection();
-        // Reset pagination to first page after deletion to ensure proper pagination state
-        setCurrentPage(1);
+        setCurrentPage(Math.max(1, totalPages));
       }
     });
-  }, [selectedFiles, deleteFiles, clearSelection, setCurrentPage]);
+  }, [selectedFiles, deleteFiles, clearSelection, setCurrentPage, totalPages]);
   const createTableItems = useCallback((file: FormattedUserIpfsFile, fileType: string | null, decodedCid: string) => {
     // Compute folderUrl if file is a folder
     let folderUrl: string | undefined = undefined;
@@ -288,7 +286,7 @@ const FilesTable: FC<FilesTableProps> = memo(({
         maxSize: 40,
         header: () => (
           <div className="flex justify-center items-center h-full">
-            <SelectionHeaderColumn files={safeFiles} />
+            <SelectionHeaderColumn files={allFiles} />
           </div>
         ),
         cell: ({ row }) => (
@@ -298,7 +296,7 @@ const FilesTable: FC<FilesTableProps> = memo(({
         ),
       }),
     ];
-  }, [isSelectionMode, safeFiles]);
+  }, [isSelectionMode, allFiles]);
 
   // Create a stable memo of columns that doesn't depend on every prop
   const columns = useMemo(
@@ -522,14 +520,14 @@ const FilesTable: FC<FilesTableProps> = memo(({
 
   const tableConfig = useMemo(() => ({
     columns,
-    data: paginatedData || [],
+    data: files || [],
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     defaultColumn: {
       minSize: 40,
       size: undefined
     }
-  }), [columns, paginatedData]);
+  }), [columns, files]);
 
   const table = useReactTable(tableConfig);
 
@@ -662,7 +660,7 @@ const FilesTable: FC<FilesTableProps> = memo(({
           isRecentFiles ? "min-h-[350px]" : "min-h-[700px]"
         )}
       >
-        <TableModule.TableWrapper className="duration-300 delay-300" key={`pagination-${currentPage}-${paginatedData?.length}`}>
+        <TableModule.TableWrapper className="duration-300 delay-300" key={`pagination-${currentPage}-${files?.length}`}>
           <TableModule.Table>
             <TableModule.THead>
               {headerRows}

--- a/app/components/page-sections/files/ipfs/index.tsx
+++ b/app/components/page-sections/files/ipfs/index.tsx
@@ -27,6 +27,7 @@ import {
   getViewModePreference,
   saveViewModePreference,
 } from "@/lib/utils/userPreferencesDb";
+import { usePagination } from "@/lib/hooks";
 import { useWalletAuth } from "@/app/lib/wallet-auth-context";
 import { triggerUnpinnedFilesRefetchAtom } from "@/app/lib/global-atoms/unpinAtoms";
 import { FileSelectionProvider } from "@/app/contexts/FileSelectionContext";
@@ -141,6 +142,14 @@ const Ipfs: FC<{ isRecentFiles?: boolean }> = ({ isRecentFiles = false }) => {
     selectedFileSize,
   ]);
 
+  // Shared pagination state between list and card views
+  const {
+    paginatedData,
+    setCurrentPage,
+    currentPage,
+    totalPages
+  } = usePagination(filteredData, 12);
+
   // Update active filters when filter settings change
   useEffect(() => {
     const newActiveFilters = generateActiveFilters(
@@ -155,6 +164,13 @@ const Ipfs: FC<{ isRecentFiles?: boolean }> = ({ isRecentFiles = false }) => {
   useEffect(() => {
     setShouldResetPagination(true);
   }, [searchTerm, selectedFileTypes, selectedDate, selectedFileSize]);
+
+  // Handle pagination reset
+  useEffect(() => {
+    if (shouldResetPagination) {
+      setCurrentPage(1);
+    }
+  }, [shouldResetPagination, setCurrentPage]);
 
   const handlePaginationReset = useCallback(() => {
     setShouldResetPagination(false);
@@ -502,7 +518,7 @@ const Ipfs: FC<{ isRecentFiles?: boolean }> = ({ isRecentFiles = false }) => {
             isFetching={isFetching}
             isPrivateView={isPrivateView}
             filteredData={filteredData}
-            displayedData={filteredData}
+            displayedData={paginatedData}
             searchTerm={searchTerm}
             activeFilters={activeFilters}
             viewMode={viewMode}
@@ -517,6 +533,9 @@ const Ipfs: FC<{ isRecentFiles?: boolean }> = ({ isRecentFiles = false }) => {
             handleApplyFilters={handleApplyFilters}
             handleResetFilters={handleResetFilters}
             error={error}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            setCurrentPage={setCurrentPage}
           />
         </div>
       </FileSelectionProvider>

--- a/app/components/page-sections/wallet/StakeWidget.tsx
+++ b/app/components/page-sections/wallet/StakeWidget.tsx
@@ -4,14 +4,14 @@ import { FC, useState } from "react";
 import { useRouter } from "next/navigation";
 import { AbstractIconWrapper, CardButton, Icons } from "@/components/ui";
 import { useStaking } from "@/app/lib/hooks/useStaking";
-import { formatStakingAmount, openInExplorer } from "@/app/lib/utils/staking";
-import { useWalletAuth } from "@/app/lib/wallet-auth-context";
+import { formatStakingAmount } from "@/app/lib/utils/staking";
+// import { useWalletAuth } from "@/app/lib/wallet-auth-context";
 import { toast } from "sonner";
 
 const StakeWidget: FC = () => {
     const router = useRouter();
     const { stakingInfo, operations } = useStaking();
-    const { polkadotAddress } = useWalletAuth();
+    // const { polkadotAddress } = useWalletAuth();
     const [isWithdrawing, setIsWithdrawing] = useState(false);
 
     const handleStakeNow = () => {
@@ -22,11 +22,11 @@ const StakeWidget: FC = () => {
         router.push("/unstake");
     };
 
-    const handleViewRewards = () => {
-        if (polkadotAddress) {
-            openInExplorer(polkadotAddress, 'account');
-        }
-    };
+    // const handleViewRewards = () => {
+    //     if (polkadotAddress) {
+    //         openInExplorer(polkadotAddress, 'account');
+    //     }
+    // };
 
     const handleWithdrawUnbonded = async () => {
         if (!operations.withdrawUnbonded) return;
@@ -116,13 +116,13 @@ const StakeWidget: FC = () => {
                                         Pending Rewards
                                     </div>
                                 </div>
-                                <button
+                                {/* <button
                                     onClick={handleViewRewards}
                                     className="ml-2 text-primary-50 hover:text-primary-40 transition-colors"
                                     title="View on Explorer"
                                 >
                                     <Icons.SendSquare2 className="size-3" />
-                                </button>
+                                </button> */}
                             </div>
                         )}
                     </div>

--- a/app/lib/utils/staking.ts
+++ b/app/lib/utils/staking.ts
@@ -28,18 +28,13 @@ export const fromPlancks = (amount: string): number => {
     return planckValue / 1e18;
 };
 
-export const getExplorerUrl = (address: string, type: 'account' | 'extrinsic' = 'account'): string => {
+export const getExplorerUrl = (address: string): string => {
     // Replace with your actual explorer URL
     const baseUrl = 'https://hipstats.com';
-
-    if (type === 'account') {
-        return `${baseUrl}/account/${address}`;
-    } else {
-        return `${baseUrl}/extrinsic/${address}`;
-    }
+    return `${baseUrl}/accounts/${address}`;
 };
 
-export const openInExplorer = (address: string, type: 'account' | 'extrinsic' = 'account'): void => {
-    const url = getExplorerUrl(address, type);
+export const openInExplorer = (address: string): void => {
+    const url = getExplorerUrl(address);
     window.open(url, '_blank', 'noopener,noreferrer');
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "hippius",
     "private": true,
-    "version": "0.1.28",
+    "version": "0.1.29",
     "type": "module",
     "scripts": {
         "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Hippius"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Hippius"
-version = "0.1.28"
+version = "0.1.29"
 description = "Hippius Desktop App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schema.tauri.app/config/2",
     "productName": "Hippius",
-    "version": "0.1.28",
+    "version": "0.1.29",
     "identifier": "hippius.com",
     "build": {
         "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
### Notable Changes
* Updated the app to version **0.1.29**.
* Pagination in the IPFS files section is now more consistent and reliable across views.
* Small cleanups in the staking widget and explorer links for a smoother experience.

### File Management
* Pagination state is now shared between card and table views, so switching views won’t reset your page.
* Pagination resets automatically when you search, filter, or delete files in bulk, keeping results valid.
* Only the right set of files is displayed per page, while selection and controls remain accurate.

### Staking & Explorer
* Wallet-related clutter has been cleaned from the staking widget, making it lighter.
* Explorer links now handle addresses more consistently, with simpler paths.

### Reliability & Safety
* Cleaner code behind the scenes for pagination and staking reduces the chance of errors.
* Version bump to **0.1.29** ensures your app stays up to date with the latest improvements.