### PR TITLE
fix(recovery): don't break OAuth when recovery probe fails

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -163,11 +163,23 @@ export default function OAuthCallbackPage() {
                 router.replace(redirectPath);
             } catch (err) {
                 console.error("[OAuthCallback] Failed to process callback:", err);
-                setError(
-                    err instanceof Error
-                        ? err.message
-                        : "Failed to complete authentication. Please try again."
-                );
+                // Tauri invoke rejects with the serialized Rust error
+                // (plain object shaped like {kind, message}), not an
+                // Error instance — so `err instanceof Error` is false
+                // for backend failures. Coerce every shape we might
+                // see into a renderable string so the user sees the
+                // actual failure rather than a generic fallback.
+                let message: string;
+                if (err instanceof Error) {
+                    message = err.message;
+                } else if (typeof err === "object" && err !== null && "message" in err) {
+                    message = String((err as { message: unknown }).message);
+                } else if (typeof err === "string") {
+                    message = err;
+                } else {
+                    message = "Failed to complete authentication. Please try again.";
+                }
+                setError(message);
             }
         };
 

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -53,15 +53,33 @@ export default function OAuthCallbackPage() {
                     }
                 }
 
-                // Fix malformed URL with multiple question marks (backend issue workaround)
-                // Example: ?source=desktop?code=xxx should be ?source=desktop&code=xxx
+                // Fix malformed URL with multiple `?` characters (backend
+                // workaround). The OAuth provider sometimes returns
+                // `?source=desktop&state=...?code=...` instead of
+                // `&code=...`, which makes `URLSearchParams` parse as if
+                // `state` only contains the first segment and drops `code`,
+                // `username`, etc. — or, depending on the URL shape, drops
+                // `state` entirely.
+                //
+                // We swap the leading `?` for a sentinel that contains no
+                // `?` characters, normalise every remaining `?` to `&`,
+                // then restore the leading `?`. The previous version used
+                // `?FIRST?` as the sentinel — its own `?` characters got
+                // converted to `&` in step 2, so the restore step found
+                // nothing and the URL was returned with no `?` at all,
+                // which is what produced the "Missing state parameter"
+                // error users were hitting.
                 let fixedSearchParams: URLSearchParams | null = null;
                 if (typeof window !== "undefined") {
                     const currentUrl = window.location.href;
                     const questionMarkCount = (currentUrl.match(/\?/g) || []).length;
 
                     if (questionMarkCount > 1) {
-                        const fixedUrl = currentUrl.replace(/\?/, "?FIRST?").replace(/\?/g, "&").replace(/\?FIRST\?/, "?");
+                        const SENTINEL = "__OAUTH_FIRST_Q__";
+                        const fixedUrl = currentUrl
+                            .replace("?", SENTINEL)
+                            .replace(/\?/g, "&")
+                            .replace(SENTINEL, "?");
                         const url = new URL(fixedUrl);
                         fixedSearchParams = url.searchParams;
                     }

--- a/src-tauri/src/auth/oauth.rs
+++ b/src-tauri/src/auth/oauth.rs
@@ -482,23 +482,30 @@ pub async fn complete_oauth_flow(
         // login paths never block). We need to flip it to `Pending`
         // whenever the dialog is required so `ensure_sync_mnemonic`
         // parks until the user has entered their recovery password or
-        // completed the signup wizard. The decision is based on the
-        // `RecoveryCheck` we get from probing the server for a sealed
-        // blob and checking local mnemonic presence.
-        let recovery_check = crate::recovery::check_recovery_state_inner(&state).await?;
-        let gate_target = match recovery_check.recommended_flow {
-            // Local mnemonic exists — sync can proceed without the dialog.
-            crate::recovery::RecoveryFlow::Proceed => crate::recovery::RecoveryGateState::Skipped,
-            // Dialog required: signup, unlock, or retry after Unknown.
-            _ => crate::recovery::RecoveryGateState::Pending,
-        };
-        state.set_recovery_state(gate_target);
-
-        // Tell the FE which dialog to show, if any. Emit before
-        // `auth_ready` so the recovery dialog is mounted before sync
-        // init fires — though the gate also prevents the race.
-        if let Err(e) = app.emit("oauth_recovery_check_needed", &recovery_check) {
-            warn!(error = %e, "Failed to emit oauth_recovery_check_needed");
+        // completed the signup wizard.
+        //
+        // A failure here must NOT break OAuth itself. If the probe
+        // errors (transient SQL, hcfs-server down, config missing),
+        // we log and leave the gate at its `Skipped` default — the
+        // user lands in the app, and `ExistingUserRecoveryPrompt` or
+        // a subsequent `check_recovery_state` invoke from the FE
+        // surfaces the prompt on the next cycle. The earlier code
+        // propagated this via `?` and killed OAuth with a generic
+        // "Authentication failed" toast.
+        match crate::recovery::check_recovery_state_inner(&state).await {
+            Ok(recovery_check) => {
+                let gate_target = match recovery_check.recommended_flow {
+                    crate::recovery::RecoveryFlow::Proceed => crate::recovery::RecoveryGateState::Skipped,
+                    _ => crate::recovery::RecoveryGateState::Pending,
+                };
+                state.set_recovery_state(gate_target);
+                if let Err(e) = app.emit("oauth_recovery_check_needed", &recovery_check) {
+                    warn!(error = %e, "Failed to emit oauth_recovery_check_needed");
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "Recovery probe failed during OAuth callback; gate stays Skipped");
+            }
         }
 
         // Signal the FE that auth is ready so `tryAutoInitSync` can


### PR DESCRIPTION
## Summary
Follow-up to #305. A transient failure in `check_recovery_state_inner` (SQL error, hcfs-server unreachable, schema drift) was propagating up via `?` inside `complete_oauth_flow` and killing the entire OAuth callback with a generic "Authentication failed" toast — a user hit this on a build of #305.

Swap the `?` for a `match`:
- On success: set the gate and emit `oauth_recovery_check_needed` as before.
- On failure: log and leave the gate at its `Skipped` default. Sync unblocks, OAuth completes, and the FE's explicit `check_recovery_state` invoke from OAuthCallbackPage (or the next launch's `ExistingUserRecoveryPrompt` probe) surfaces the dialog once the underlying issue clears.

OAuth must never break because recovery is sick.

## Test plan
- [x] `cargo build --all-targets` clean
- [ ] Reproduce the original failure (e.g. by dropping the `hcfs_config` table) and confirm OAuth still completes
- [ ] Verify normal-case recovery dialog still appears on a fresh OAuth signup