### PR TITLE
feat(desktop): macOS close-to-tray — hide window instead of quit

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -20,7 +20,7 @@ use hcfs_client::engine::runner::SyncRunner;
 
 use sqlx::sqlite::SqlitePool;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock, atomic::AtomicBool};
 
 /// The single top-level state container for the entire Tauri backend.
 ///
@@ -69,6 +69,12 @@ pub struct AppState {
     /// recovery flow has had a chance to install the unsealed one.
     /// See `docs/plans/2026-04-14-oauth-account-recovery.md`.
     recovery_gate: tokio::sync::watch::Sender<RecoveryGateState>,
+    /// Set to `true` after `stop_nebula` has run during shutdown. The
+    /// `RunEvent::ExitRequested` handler uses this to distinguish the
+    /// initial exit request (Cmd+Q, tray Quit, etc. — defer and stop
+    /// Nebula first) from the re-entrant one triggered by the post-
+    /// cleanup `app.exit(0)` (allow the exit to proceed).
+    pub nebula_stopped: AtomicBool,
 }
 
 impl Default for AppState {
@@ -124,6 +130,7 @@ impl AppState {
             // `complete_oauth_flow` flips this to `Pending` at its start so
             // the dialog gets a chance to run before any sync init races in.
             recovery_gate: tokio::sync::watch::channel(RecoveryGateState::Skipped).0,
+            nebula_stopped: AtomicBool::new(false),
         }
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -93,6 +93,7 @@ use crate::utils::support::{
     create_support_ticket, get_support_ticket_messages, list_support_tickets, post_ticket_message, update_support_ticket, upload_ticket_attachment,
 };
 use crate::utils::tray_menu::get_tray_menu_data;
+use futures_util::FutureExt;
 use sqlx::Row;
 use sqlx::sqlite::SqlitePool;
 use tauri::{Builder, Emitter, Manager, Wry, path::BaseDirectory};
@@ -389,7 +390,76 @@ fn main() {
     let builder = on_window_event(builder);
 
     info!("Running Tauri application...");
-    builder.run(tauri::generate_context!()).expect("error while running tauri application");
+    let app = builder.build(tauri::generate_context!()).expect("error while building tauri application");
+
+    app.run(|app_handle, event| {
+        match event {
+            // Single gate for every app-exit path (Cmd+Q, app menu Quit,
+            // tray Quit, `app.exit(n)`). On the first pass we defer the
+            // exit, stop Nebula, and re-request exit; the second pass
+            // sees `nebula_stopped=true` and lets Tauri proceed.
+            tauri::RunEvent::ExitRequested { api, .. } => {
+                let state = app_handle.state::<crate::app_state::AppState>();
+                let already_stopped = state.nebula_stopped.load(std::sync::atomic::Ordering::SeqCst);
+
+                if already_stopped {
+                    // Second pass — allow the exit.
+                    info!("Exit requested; Nebula already stopped, exiting");
+                    return;
+                }
+
+                info!("Exit requested; stopping Nebula before exit");
+                api.prevent_exit();
+
+                // A rapid second Cmd+Q before this task finishes spawns a second cleanup
+                // task. That's fine: `stop_nebula` is idempotent (pkill / taskkill are
+                // no-ops on the second call) and Tauri ignores `exit(0)` after the event
+                // loop has shut down. No extra guard needed.
+                let handle_clone = app_handle.clone();
+                tauri::async_runtime::spawn(async move {
+                    let app_state = handle_clone.state::<crate::app_state::AppState>();
+                    // If stop_nebula panics we still want to flip the flag and re-request
+                    // exit — a hung app with a hidden window is worse than an unclean
+                    // Nebula shutdown. AssertUnwindSafe is fine here: NebulaState is self-
+                    // contained behind its own mutexes, so a partial stop can't corrupt
+                    // any shared state we read later.
+                    let result = std::panic::AssertUnwindSafe(crate::nebula::manager::stop_nebula(&app_state.nebula))
+                        .catch_unwind()
+                        .await;
+                    match result {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => warn!("Failed to stop Nebula during shutdown: {e}"),
+                        Err(_) => error!("stop_nebula panicked during shutdown — exiting anyway"),
+                    }
+                    app_state.nebula_stopped.store(true, std::sync::atomic::Ordering::SeqCst);
+                    info!("Nebula stopped; re-requesting exit");
+                    handle_clone.exit(0);
+                });
+            }
+
+            // macOS dock icon click with no visible windows. Mirrors the
+            // tray's "Open Hippius" action.
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Reopen { has_visible_windows, .. } => {
+                if has_visible_windows {
+                    return;
+                }
+                if let Some(window) = app_handle.get_webview_window("main") {
+                    if let Err(e) = window.unminimize() {
+                        debug!("Failed to unminimize window on reopen: {e}");
+                    }
+                    if let Err(e) = window.show() {
+                        debug!("Failed to show window on reopen: {e}");
+                    }
+                    if let Err(e) = window.set_focus() {
+                        debug!("Failed to focus window on reopen: {e}");
+                    }
+                }
+            }
+
+            _ => {}
+        }
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -396,27 +396,34 @@ fn main() {
 // App setup (was setup.rs)
 // ---------------------------------------------------------------------------
 
-/// Register the window close handler on the Tauri builder.
+/// Window-close dispatcher.
 ///
-/// Prevents the default close, stops Nebula, then exits cleanly.
+/// On macOS, closing the main window (red-X / Cmd+W) hides the window so
+/// the app keeps running in the tray. All genuine quit paths on macOS —
+/// Cmd+Q, the app menu's Quit Hippius, the tray's Quit Hippius — fire
+/// `RunEvent::ExitRequested` instead, where Nebula cleanup happens.
+///
+/// On Windows/Linux, closing the window exits the app (current behavior).
+/// We call `app.exit(0)` rather than letting Tauri's default close fire
+/// so that `RunEvent::ExitRequested` runs and Nebula is stopped there.
 pub fn on_window_event(builder: Builder<Wry>) -> Builder<Wry> {
     builder.on_window_event(|window, event| {
         if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-            info!("Close requested");
             api.prevent_close();
-            let app_handle = window.app_handle().clone();
 
-            tauri::async_runtime::spawn(async move {
-                debug!("Stopping Nebula VPN...");
-                // Stop Nebula before exiting
-                let nebula_st = &app_handle.state::<crate::app_state::AppState>().nebula;
-                if let Err(e) = crate::nebula::manager::stop_nebula(nebula_st).await {
-                    warn!("Failed to stop Nebula: {}", e);
+            #[cfg(target_os = "macos")]
+            {
+                info!("Window close requested on macOS — hiding to tray");
+                if let Err(e) = window.hide() {
+                    warn!("Failed to hide window: {e}");
                 }
+            }
 
-                info!("Exiting application...");
-                app_handle.exit(0);
-            });
+            #[cfg(not(target_os = "macos"))]
+            {
+                info!("Window close requested — exiting app");
+                window.app_handle().exit(0);
+            }
         }
     })
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -479,6 +479,13 @@ fn main() {
 pub fn on_window_event(builder: Builder<Wry>) -> Builder<Wry> {
     builder.on_window_event(|window, event| {
         if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+            // Only intercept the main window. If a future refactor adds a
+            // secondary window (e.g. a settings popup), its close button
+            // should behave normally and not hide-to-tray the whole app.
+            if window.label() != "main" {
+                return;
+            }
+
             api.prevent_close();
 
             #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

- On macOS, clicking the red-X (or Cmd+W) now hides the main window instead of quitting. Tray, sync, and Nebula keep running.
- Cmd+Q, the macOS app menu's "Quit Hippius", and the tray's "Quit Hippius" still fully quit (Nebula stops cleanly first).
- Clicking the dock icon while the window is hidden brings it back (parity with the tray's "Open Hippius" action).
- Windows/Linux behavior is unchanged.

## Design

Single-gate architecture: every quit path funnels through `RunEvent::ExitRequested`. An `AtomicBool` latch (`AppState::nebula_stopped`) breaks the re-entrant `app.exit(0)` that happens after async Nebula cleanup completes. First pass → ``api.prevent_exit()`` + spawn cleanup; second pass (flag set) → bare return → Tauri exits. ``AssertUnwindSafe + catch_unwind`` around ``stop_nebula`` guarantees the flag-flip + re-exit run even if cleanup panics, so the app can never hang with a hidden window.

Design doc: ``docs/plans/2026-04-20-macos-close-to-tray-design.md``
Plan doc:   ``docs/plans/2026-04-20-macos-close-to-tray.md``

## Changes

- ``src-tauri/src/app_state.rs`` — add ``pub nebula_stopped: AtomicBool``.
- ``src-tauri/src/main.rs`` —
  - ``on_window_event`` rewritten: macOS ``window.hide()``, Windows/Linux ``app.exit(0)``. Inline async Nebula-stop removed.
  - ``main()`` tail switches from ``builder.run(ctx)`` → ``builder.build(ctx).expect(...).run(|app, event| ...)``.
  - New ``RunEvent::ExitRequested`` handler: the single Nebula-cleanup gate for all platforms.
  - New ``RunEvent::Reopen`` handler (macOS cfg-gated): restores the main window when ``has_visible_windows == false``.
  - One new import: ``use futures_util::FutureExt;`` (for ``catch_unwind``).

No frontend changes. No new IPC commands. No schema or migration changes.

## Test plan

Automated:
- [x] ``SQLX_OFFLINE=true cargo check`` — clean
- [x] ``cargo fmt --check -- src/main.rs`` — clean
- [x] ``SQLX_OFFLINE=true cargo test --lib`` — 343 passing, 0 failing

Manual (on macOS, run ``pnpm tauri:dev`` in the worktree):
- [ ] Red-X hides window; tray + dock stay alive
- [ ] Tray "Open Hippius" reopens the window
- [ ] Dock icon click reopens the window
- [ ] Cmd+W hides (same as red-X)
- [ ] Cmd+Q fully quits; ``ps aux | grep nebula`` shows nothing
- [ ] App menu → Quit Hippius — same as Cmd+Q
- [ ] Tray → Quit Hippius — same as Cmd+Q
- [ ] Sync keeps running while window hidden (touch a file, reopen, confirm sync)
- [ ] Nebula keeps running while window hidden (enable VPN, close, ``ps aux | grep nebula`` still lists it)