### PR TITLE
Release 0.1.97

### DIFF
--- a/app/components/page-sections/home/storage-usage-trends/index.tsx
+++ b/app/components/page-sections/home/storage-usage-trends/index.tsx
@@ -4,9 +4,13 @@ import ChartTrends, { ChartTrendsConfig } from "@/components/ui/chart-trends";
 import StorageUsedTooltip from "./StorageUsedTooltip";
 import { formatBytes } from "@/app/lib/utils/formatBytes";
 
-// Drive-scoped: the chart and the "Total Storage Used" tile in
-// DetailList both feed off /user-credits-by-storage-history?storage_type=drive,
-// so the panel and the card can never report different totals.
+// Drive-scoped: the chart and the "Total Storage Used" tile both
+// feed off /user-extended-storage-metrics?storage=drive — the same
+// snapshot endpoint, just bucketed by day with carry-forward in
+// `get_drive_storage_chart`. Before 2026-05-08 the chart pulled
+// from /user-credits-by-storage-history (event-driven) and could
+// disagree with the tile by hundreds of MB after a deletion until
+// the next billing event landed; the move closes that drift.
 const config: ChartTrendsConfig = {
   invokeCommand: "get_drive_storage_chart",
   selfFetch: true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hippius",
   "private": true,
-  "version": "0.1.96",
+  "version": "0.1.97",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Hippius"
-version = "0.1.96"
+version = "0.1.97"
 dependencies = [
  "aes",
  "alloy-signer",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Hippius"
-version = "0.1.96"
+version = "0.1.97"
 description = "Hippius Desktop App"
 authors = ["you"]
 edition = "2024"

--- a/src-tauri/src/billing/drive_credits.rs
+++ b/src-tauri/src/billing/drive_credits.rs
@@ -1,13 +1,14 @@
-//! Drive-scoped credit history feeding the home page's storage trend
-//! chart, credit trend chart, and Total Credit Used card.
+//! Drive-scoped credit history feeding the home page's credit trend
+//! chart and Total Credit Used card.
 //!
-//! All three commands hit a single indexer endpoint
+//! Both commands hit a single indexer endpoint
 //! (`/user-credits-by-storage-history?storage_type=drive`) and project
-//! a different view onto the same response. Anchoring on one source
-//! guarantees the card and the chart never disagree about scope —
-//! commit `61fee2ee` (2026-05-05) created exactly that split by
-//! pointing the header at a drive-only endpoint while the chart kept
-//! reading the wallet-wide series.
+//! a different view onto the same response. The Storage Usage chart
+//! used to share this endpoint too, but moved to the snapshot-driven
+//! `/user-extended-storage-metrics` on 2026-05-08 — see
+//! [`crate::billing::drive_storage`] — because the credits-history
+//! endpoint only updates on a `CreditsConsumed` block, leaving the
+//! chart hours behind reality after a deletion.
 //!
 //! The indexer emits each charge as a paired `(CreditsConsumed,
 //! PointTransactionRecorded)` event at the same block; filtering to
@@ -15,10 +16,7 @@
 //! consumer and avoids double-counting.
 
 use crate::api::indexer::IndexerClient;
-use crate::billing::charts::{
-    ChartPoint, date_to_iso, dd_mon_label, format_balance, format_bytes, get_all_dates_in_range,
-    normalize_date, parse_timestamp_to_date, range_start, weekday_name,
-};
+use crate::billing::charts::{ChartPoint, date_to_iso, dd_mon_label, format_balance, get_all_dates_in_range, normalize_date, parse_timestamp_to_date, range_start, weekday_name};
 use crate::error::AppError;
 use chrono::NaiveDate;
 use serde::Deserialize;
@@ -51,9 +49,9 @@ const CACHE_TTL: Duration = Duration::from_secs(30);
 
 /// One row of `/user-credits-by-storage-history`.
 ///
-/// `credits_amount` and `drive_files_size` are planck/byte values, but
-/// the indexer applies `total_credits_amount * storage_percentage`
-/// server-side and emits the result as a string that may be fractional
+/// `credits_amount` is a planck value, but the indexer applies
+/// `total_credits_amount * storage_percentage` server-side and emits
+/// the result as a string that may be fractional
 /// (`"93189525824488.31"`). That makes `String → f64` the only correct
 /// parse path — `u128::from_str` rejects the dot. f64 has ~16 digits
 /// of mantissa, well above the 6-decimal-credit floor the chart
@@ -62,12 +60,13 @@ const CACHE_TTL: Duration = Duration::from_secs(30);
 /// Every field defaults for resilience: a header tile shouldn't fail
 /// to render because of a missing field, and `event_name == ""` is
 /// dropped naturally by the `CreditsConsumed` predicate downstream.
+/// `drive_files_size` is also present on the wire but unused here —
+/// the storage chart now reads it from `/user-extended-storage-metrics`
+/// instead. Serde tolerates the extra field by default.
 #[derive(Deserialize, Default, Clone, Debug)]
 struct DriveCreditEvent {
     #[serde(default)]
     credits_amount: String,
-    #[serde(default)]
-    drive_files_size: String,
     #[serde(default)]
     event_name: String,
     #[serde(default)]
@@ -162,10 +161,6 @@ fn planck_str_to_credits(raw: &str) -> f64 {
     raw.parse::<f64>().unwrap_or(0.0) / 1e18
 }
 
-fn bytes_str_to_f64(raw: &str) -> f64 {
-    raw.parse::<f64>().unwrap_or(0.0)
-}
-
 /// Filter to `CreditsConsumed` rows, parse timestamps, sort ascending.
 /// Rows with malformed timestamps drop out — they can't contribute to
 /// a dated chart without a date.
@@ -177,39 +172,6 @@ fn consumed_events_by_date(events: &[DriveCreditEvent]) -> Vec<(NaiveDate, &Driv
         .collect();
     typed.sort_by_key(|(d, _)| *d);
     typed
-}
-
-/// Snapshot of `drive_files_size` per day, carry-forward across the
-/// requested range. Multiple events on the same day collapse to the
-/// latest reading — closest to an end-of-day snapshot.
-fn build_storage_chart(events: &[DriveCreditEvent], range: &str) -> Vec<ChartPoint> {
-    let consumed = consumed_events_by_date(events);
-    if consumed.is_empty() {
-        return Vec::new();
-    }
-
-    let mut by_day: BTreeMap<NaiveDate, f64> = BTreeMap::new();
-    for (date, event) in &consumed {
-        by_day.insert(*date, bytes_str_to_f64(&event.drive_files_size));
-    }
-
-    let today = chrono::Utc::now().date_naive();
-    let Some(start) = range_start(range, today) else {
-        return Vec::new();
-    };
-    let dates = get_all_dates_in_range(start, today);
-
-    // Seed carry-forward with the last snapshot strictly before the
-    // window. Otherwise a range that opens on a quiet day would show
-    // 0 bytes until the next event, which misrepresents storage that
-    // was already in place.
-    let pre_range_seed = consumed
-        .iter()
-        .take_while(|(d, _)| *d < start)
-        .last()
-        .map_or(0.0, |(_, e)| bytes_str_to_f64(&e.drive_files_size));
-
-    render_storage_points(&dates, &by_day, range, pre_range_seed)
 }
 
 /// Cumulative drive credit usage per day.
@@ -251,33 +213,6 @@ fn build_credits_chart(events: &[DriveCreditEvent], range: &str) -> Vec<ChartPoi
     render_credit_points(&dates, &cumulative, range, pre_range_total)
 }
 
-fn render_storage_points(dates: &[NaiveDate], by_day: &BTreeMap<NaiveDate, f64>, range: &str, seed: f64) -> Vec<ChartPoint> {
-    let is_last7 = range == "last7days";
-    let mut last_balance = seed;
-    dates
-        .iter()
-        .map(|&date| {
-            let entry = by_day.get(&date).copied();
-            let has_data = entry.is_some();
-            if let Some(v) = entry {
-                last_balance = v;
-            }
-            let day_label = if is_last7 { weekday_name(date).to_string() } else { dd_mon_label(date) };
-            let band_label = if is_last7 { Some(weekday_name(date).to_string()) } else { None };
-            ChartPoint {
-                x: date_to_iso(date),
-                balance: last_balance,
-                formatted_balance: format_bytes(last_balance),
-                timestamp: if has_data { normalize_date(date) } else { String::new() },
-                day_label,
-                band_label,
-                credit: None,
-                formatted_credit: None,
-            }
-        })
-        .collect()
-}
-
 fn render_credit_points(dates: &[NaiveDate], cumulative: &BTreeMap<NaiveDate, f64>, range: &str, seed: f64) -> Vec<ChartPoint> {
     let is_last7 = range == "last7days";
     dates
@@ -308,20 +243,6 @@ fn render_credit_points(dates: &[NaiveDate], cumulative: &BTreeMap<NaiveDate, f6
 }
 
 // --- Tauri commands -------------------------------------------------------
-
-/// Drive storage time series for the home page's storage trend chart.
-///
-/// # Errors
-/// Propagates [`AppError::Api`] from the underlying indexer request.
-#[tauri::command]
-pub async fn get_drive_storage_chart(
-    state: tauri::State<'_, crate::app_state::AppState>,
-    account_id: String,
-    range: String,
-) -> Result<Vec<ChartPoint>, AppError> {
-    let events = cached_drive_events(&state, &account_id).await?;
-    Ok(build_storage_chart(&events, &range))
-}
 
 /// Cumulative drive credit usage time series.
 ///
@@ -356,10 +277,9 @@ pub async fn get_drive_credits_total(state: tauri::State<'_, crate::app_state::A
 mod tests {
     use super::*;
 
-    fn evt(event_name: &str, credits: &str, drive_size: &str, ts: &str) -> DriveCreditEvent {
+    fn evt(event_name: &str, credits: &str, ts: &str) -> DriveCreditEvent {
         DriveCreditEvent {
             credits_amount: credits.to_string(),
-            drive_files_size: drive_size.to_string(),
             event_name: event_name.to_string(),
             processed_timestamp: ts.to_string(),
         }
@@ -395,8 +315,8 @@ mod tests {
         // once as `PointTransactionRecorded` at the same block. Without
         // the filter every total in the UI would double.
         let events = vec![
-            evt("CreditsConsumed", "100", "10", "2026-05-01T00:00:00Z"),
-            evt("PointTransactionRecorded", "100", "10", "2026-05-01T00:00:00Z"),
+            evt("CreditsConsumed", "100", "2026-05-01T00:00:00Z"),
+            evt("PointTransactionRecorded", "100", "2026-05-01T00:00:00Z"),
         ];
         let kept = consumed_events_by_date(&events);
         assert_eq!(kept.len(), 1);
@@ -406,8 +326,8 @@ mod tests {
     #[test]
     fn malformed_timestamp_drops_event() {
         let events = vec![
-            evt("CreditsConsumed", "100", "10", "not-a-date"),
-            evt("CreditsConsumed", "200", "20", "2026-05-01T00:00:00Z"),
+            evt("CreditsConsumed", "100", "not-a-date"),
+            evt("CreditsConsumed", "200", "2026-05-01T00:00:00Z"),
         ];
         let kept = consumed_events_by_date(&events);
         assert_eq!(kept.len(), 1);
@@ -419,9 +339,9 @@ mod tests {
         // Indexer returns newest-first; charts need oldest-first to
         // run carry-forward correctly.
         let events = vec![
-            evt("CreditsConsumed", "0", "30", "2026-05-03T00:00:00Z"),
-            evt("CreditsConsumed", "0", "10", "2026-05-01T00:00:00Z"),
-            evt("CreditsConsumed", "0", "20", "2026-05-02T00:00:00Z"),
+            evt("CreditsConsumed", "0", "2026-05-03T00:00:00Z"),
+            evt("CreditsConsumed", "0", "2026-05-01T00:00:00Z"),
+            evt("CreditsConsumed", "0", "2026-05-02T00:00:00Z"),
         ];
         let kept = consumed_events_by_date(&events);
         let dates: Vec<NaiveDate> = kept.iter().map(|(d, _)| *d).collect();
@@ -434,9 +354,9 @@ mod tests {
         // double-count guard is pinned even if the IPC plumbing
         // changes.
         let events = [
-            evt("CreditsConsumed", "1000000000000000000", "0", "2026-05-01T00:00:00Z"),
-            evt("PointTransactionRecorded", "1000000000000000000", "0", "2026-05-01T00:00:00Z"),
-            evt("CreditsConsumed", "2000000000000000000", "0", "2026-05-02T00:00:00Z"),
+            evt("CreditsConsumed", "1000000000000000000", "2026-05-01T00:00:00Z"),
+            evt("PointTransactionRecorded", "1000000000000000000", "2026-05-01T00:00:00Z"),
+            evt("CreditsConsumed", "2000000000000000000", "2026-05-02T00:00:00Z"),
         ];
         let total: f64 = events
             .iter()
@@ -460,7 +380,9 @@ mod tests {
     fn history_page_deserializes_real_indexer_shape() {
         // Trimmed-down copy of one row from the live response (account
         // 5Ft4…6Q on 2026-05-06). Pins both the field set and the
-        // fractional-planck handling end-to-end.
+        // fractional-planck handling end-to-end. `drive_files_size`
+        // remains in the wire payload — Serde silently ignores it
+        // since DriveCreditEvent stopped reading it.
         let json = r#"{
             "data":[{
                 "credits_amount":"93189525824488.31",

--- a/src-tauri/src/billing/drive_storage.rs
+++ b/src-tauri/src/billing/drive_storage.rs
@@ -1,0 +1,375 @@
+//! Drive-storage time series for the home page's Storage Usage chart.
+//!
+//! Backed by `/user-extended-storage-metrics?storage=drive` — the same
+//! endpoint that powers the "Total Storage Used" tile via
+//! [`crate::billing::queries::get_drive_storage_stats`]. Tile and chart
+//! now read the same source, so the drift that existed up to
+//! 2026-05-08 — chart pulled from `/user-credits-by-storage-history`
+//! (event-driven, only updates on a `CreditsConsumed` block) while the
+//! tile pulled from `/user-extended-storage-metrics` (snapshot-driven,
+//! ~30 s freshness) — cannot recur. A deletion that drops the tile
+//! to 21 MB will land on the chart's "today" point at the next
+//! snapshot poll instead of waiting for the next billing event hours
+//! later.
+//!
+//! The endpoint emits one row per indexer snapshot. The chart
+//! collapses to one point per day using the **latest** snapshot of
+//! that day, then carry-forwards to fill quiet days, mirroring the
+//! prior credits-event-based logic so the visible chart shape is
+//! unchanged.
+
+use crate::api::indexer::IndexerClient;
+use crate::billing::charts::{ChartPoint, date_to_iso, dd_mon_label, format_bytes, get_all_dates_in_range, normalize_date, range_start, weekday_name};
+use crate::error::AppError;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+const ENDPOINT: &str = "/user-extended-storage-metrics";
+const DRIVE_STORAGE_FILTER: &str = "drive";
+const PAGE_LIMIT: u32 = 100;
+
+/// Defensive page cap. At 100 snapshots/page that's 50_000 rows — far
+/// beyond what an account produces in a year of ~30 s snapshots
+/// (~1M/yr theoretical, but the indexer aggregates so observed volume
+/// is well under 10k for active accounts). Plays the same safety-net
+/// role as `MAX_PAGES` in `drive_credits.rs`; tuned higher because
+/// snapshot frequency is much higher than billing-event frequency.
+const MAX_PAGES: u32 = 500;
+
+/// Cache window. Aligns with `useDriveStorageStats`'s 30 s
+/// `refetchInterval` so the home page's tile and chart fetch on mount
+/// in lockstep and the second-arriving call hits cache.
+const CACHE_TTL: Duration = Duration::from_secs(30);
+
+/// One snapshot row from `/user-extended-storage-metrics?storage=drive`.
+///
+/// `drive_files_size` arrives as a numeric string for the same reason
+/// `DriveCreditEvent.drive_files_size` did: total bytes can exceed
+/// JSON's 53-bit safe-integer ceiling. `processed_timestamp` is the
+/// only non-size field we need here — bucketing happens by date and
+/// we share `parse_timestamp_to_date` with the credits chart.
+#[derive(Deserialize, Default, Clone, Debug)]
+struct DriveStorageSnapshot {
+    #[serde(default)]
+    drive_files_size: String,
+    #[serde(default)]
+    processed_timestamp: String,
+}
+
+#[derive(Deserialize, Default)]
+struct Pagination {
+    #[serde(default)]
+    total_pages: u32,
+}
+
+#[derive(Deserialize, Default)]
+struct MetricsPage {
+    #[serde(default)]
+    data: Vec<DriveStorageSnapshot>,
+    #[serde(default)]
+    pagination: Pagination,
+}
+
+struct CacheEntry {
+    fetched_at: Instant,
+    snapshots: Vec<DriveStorageSnapshot>,
+}
+
+/// Process-wide cache. The `tokio::sync::Mutex` is held across the
+/// indexer fetch deliberately — it acts as a single-flight gate so
+/// the home page's near-simultaneous tile + chart mounts do one
+/// round-trip instead of two.
+fn cache() -> &'static Mutex<HashMap<String, CacheEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, CacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+async fn cached_drive_snapshots(state: &crate::app_state::AppState, account_id: &str) -> Result<Vec<DriveStorageSnapshot>, AppError> {
+    let mut guard = cache().lock().await;
+    if let Some(entry) = guard.get(account_id)
+        && entry.fetched_at.elapsed() < CACHE_TTL
+    {
+        return Ok(entry.snapshots.clone());
+    }
+    let snapshots = fetch_all_drive_snapshots(state, account_id).await?;
+    guard.insert(
+        account_id.to_string(),
+        CacheEntry {
+            fetched_at: Instant::now(),
+            snapshots: snapshots.clone(),
+        },
+    );
+    Ok(snapshots)
+}
+
+/// Walk the indexer's pages and collect every drive-scoped snapshot
+/// for the account. Stops as soon as `page >= total_pages`; bails at
+/// [`MAX_PAGES`] with a warning rather than looping forever if the
+/// indexer ever returns a runaway count.
+async fn fetch_all_drive_snapshots(state: &crate::app_state::AppState, account_id: &str) -> Result<Vec<DriveStorageSnapshot>, AppError> {
+    let indexer = IndexerClient::from_env(state.api_client.clone())?;
+    let limit_str = PAGE_LIMIT.to_string();
+    let mut all = Vec::new();
+
+    for page in 1..=MAX_PAGES {
+        let page_str = page.to_string();
+        let params = [
+            ("account_id", account_id),
+            ("storage", DRIVE_STORAGE_FILTER),
+            ("page", page_str.as_str()),
+            ("limit", limit_str.as_str()),
+        ];
+        let response: MetricsPage = indexer.get(ENDPOINT, &params).await?;
+        let total_pages = response.pagination.total_pages.max(1);
+        all.extend(response.data);
+        if page >= total_pages {
+            return Ok(all);
+        }
+    }
+
+    tracing::warn!(account_id, max_pages = MAX_PAGES, "drive storage history exceeded page cap; truncating");
+    Ok(all)
+}
+
+fn bytes_str_to_f64(raw: &str) -> f64 {
+    raw.parse::<f64>().unwrap_or(0.0)
+}
+
+/// Parse an ISO-8601 timestamp into a UTC `DateTime` for ordering.
+///
+/// Sister of `charts::parse_timestamp_to_date`, but returns the full
+/// instant — required because the storage chart collapses several
+/// same-day snapshots to the latest one, which needs second/sub-second
+/// resolution that `NaiveDate` discards. Tries the same format menu so
+/// any timestamp the credits chart accepts is also accepted here.
+fn parse_timestamp(ts: &str) -> Option<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(ts) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    for fmt in ["%Y-%m-%dT%H:%M:%S%.fZ", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%.f"] {
+        if let Ok(naive) = NaiveDateTime::parse_from_str(ts, fmt) {
+            return Some(naive.and_utc());
+        }
+    }
+    None
+}
+
+/// Parse, sort by full timestamp ascending, drop malformed rows.
+///
+/// Sorting by date alone is **not** sufficient: the indexer emits many
+/// snapshots per day and `Vec::sort_by_key` is stable, so equal-date
+/// rows would retain the indexer's newest-first input order and the
+/// downstream `BTreeMap::insert` collapse would end up keeping the
+/// **oldest** same-day reading instead of the latest. Sorting by the
+/// full datetime fixes this — last-insert-wins on a chronologically
+/// ascending stream collapses each day to its latest snapshot.
+fn snapshots_sorted(snapshots: &[DriveStorageSnapshot]) -> Vec<(DateTime<Utc>, &DriveStorageSnapshot)> {
+    let mut typed: Vec<(DateTime<Utc>, &DriveStorageSnapshot)> = snapshots.iter().filter_map(|s| parse_timestamp(&s.processed_timestamp).map(|dt| (dt, s))).collect();
+    typed.sort_by_key(|(dt, _)| *dt);
+    typed
+}
+
+/// Daily snapshot of drive storage, carry-forward across the
+/// requested range. Multiple snapshots on the same day collapse to
+/// the latest reading — closest to an end-of-day total.
+fn build_storage_chart(snapshots: &[DriveStorageSnapshot], range: &str) -> Vec<ChartPoint> {
+    let typed = snapshots_sorted(snapshots);
+    if typed.is_empty() {
+        return Vec::new();
+    }
+
+    // `typed` is sorted ascending by full timestamp; successive
+    // `BTreeMap::insert` overwrites older same-day entries with newer
+    // ones, so `by_day` ends up holding the latest reading for each
+    // date.
+    let mut by_day: BTreeMap<NaiveDate, f64> = BTreeMap::new();
+    for (dt, snap) in &typed {
+        by_day.insert(dt.date_naive(), bytes_str_to_f64(&snap.drive_files_size));
+    }
+
+    let today = chrono::Utc::now().date_naive();
+    let Some(start) = range_start(range, today) else {
+        return Vec::new();
+    };
+    let dates = get_all_dates_in_range(start, today);
+
+    // Pre-range seed: latest snapshot strictly before the window.
+    // Otherwise a window that opens on a quiet day would draw 0 B
+    // until the next snapshot, which misrepresents storage that was
+    // already in place.
+    let pre_range_seed = typed
+        .iter()
+        .take_while(|(dt, _)| dt.date_naive() < start)
+        .last()
+        .map_or(0.0, |(_, s)| bytes_str_to_f64(&s.drive_files_size));
+
+    render_storage_points(&dates, &by_day, range, pre_range_seed)
+}
+
+fn render_storage_points(dates: &[NaiveDate], by_day: &BTreeMap<NaiveDate, f64>, range: &str, seed: f64) -> Vec<ChartPoint> {
+    let is_last7 = range == "last7days";
+    let mut last_balance = seed;
+    dates
+        .iter()
+        .map(|&date| {
+            let entry = by_day.get(&date).copied();
+            let has_data = entry.is_some();
+            if let Some(v) = entry {
+                last_balance = v;
+            }
+            let day_label = if is_last7 { weekday_name(date).to_string() } else { dd_mon_label(date) };
+            let band_label = if is_last7 { Some(weekday_name(date).to_string()) } else { None };
+            ChartPoint {
+                x: date_to_iso(date),
+                balance: last_balance,
+                formatted_balance: format_bytes(last_balance),
+                timestamp: if has_data { normalize_date(date) } else { String::new() },
+                day_label,
+                band_label,
+                credit: None,
+                formatted_credit: None,
+            }
+        })
+        .collect()
+}
+
+// --- Tauri commands -------------------------------------------------------
+
+/// Drive storage time series for the home page's Storage Usage chart.
+///
+/// # Errors
+/// Propagates [`AppError::Api`] from the underlying indexer request.
+#[tauri::command]
+pub async fn get_drive_storage_chart(
+    state: tauri::State<'_, crate::app_state::AppState>,
+    account_id: String,
+    range: String,
+) -> Result<Vec<ChartPoint>, AppError> {
+    let snapshots = cached_drive_snapshots(&state, &account_id).await?;
+    Ok(build_storage_chart(&snapshots, &range))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(size: &str, ts: &str) -> DriveStorageSnapshot {
+        DriveStorageSnapshot {
+            drive_files_size: size.to_string(),
+            processed_timestamp: ts.to_string(),
+        }
+    }
+
+    #[test]
+    fn malformed_timestamp_drops_snapshot() {
+        let snaps = vec![snap("100", "not-a-date"), snap("200", "2026-05-01T00:00:00Z")];
+        let kept = snapshots_sorted(&snaps);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].1.drive_files_size, "200");
+    }
+
+    #[test]
+    fn snapshots_returned_in_chronological_order() {
+        // Indexer returns newest-first; carry-forward needs oldest-first.
+        let snaps = vec![
+            snap("30", "2026-05-03T00:00:00Z"),
+            snap("10", "2026-05-01T00:00:00Z"),
+            snap("20", "2026-05-02T00:00:00Z"),
+        ];
+        let kept = snapshots_sorted(&snaps);
+        let dates: Vec<NaiveDate> = kept.iter().map(|(dt, _)| dt.date_naive()).collect();
+        assert!(dates.windows(2).all(|w| w[0] <= w[1]), "not sorted: {dates:?}");
+    }
+
+    #[test]
+    fn last_snapshot_of_day_wins_in_by_day_map() {
+        // Three same-day snapshots fed in random input order. The
+        // sort-by-full-timestamp + overwriting-insert pipeline must
+        // end with the latest (18:00) reading in by_day, not the
+        // first (08:00). Sorting by date alone would silently fail
+        // this test because `Vec::sort_by_key` is stable — see the
+        // comment on `snapshots_sorted`.
+        let snaps = vec![
+            snap("100", "2026-05-01T08:00:00Z"),
+            snap("300", "2026-05-01T18:00:00Z"),
+            snap("200", "2026-05-01T12:00:00Z"),
+        ];
+        let typed = snapshots_sorted(&snaps);
+        let mut by_day: BTreeMap<NaiveDate, f64> = BTreeMap::new();
+        for (dt, snap) in &typed {
+            by_day.insert(dt.date_naive(), bytes_str_to_f64(&snap.drive_files_size));
+        }
+        let date = NaiveDate::from_ymd_opt(2026, 5, 1).expect("valid date");
+        assert!((by_day[&date] - 300.0).abs() < f64::EPSILON, "got {}", by_day[&date]);
+    }
+
+    #[test]
+    fn sub_second_timestamps_order_correctly() {
+        // Real indexer payloads include `.001Z`-suffixed timestamps
+        // alongside `Z` ones in the same minute. Verify the parser
+        // orders them chronologically — naive lexicographic sort on
+        // the raw string would put `.001Z` before `Z` because `.` <
+        // `Z` in ASCII, reversing the actual order.
+        let snaps = vec![snap("100", "2026-05-08T07:50:18.001Z"), snap("200", "2026-05-08T07:50:18Z")];
+        let typed = snapshots_sorted(&snaps);
+        // After sort: 07:50:18Z (no fraction) then 07:50:18.001Z.
+        assert_eq!(typed[0].1.drive_files_size, "200");
+        assert_eq!(typed[1].1.drive_files_size, "100");
+    }
+
+    #[test]
+    fn metrics_page_deserializes_real_indexer_shape() {
+        // Real row trimmed from account 5E4Z…ah on 2026-05-08. Pins
+        // the field names and the string-typed bytes parse so a
+        // future indexer schema change fails this test loudly.
+        let json = r#"{
+            "data":[{
+                "drive_files_size":"21339640",
+                "processed_timestamp":"2026-05-08T07:50:18.001Z"
+            }],
+            "pagination":{"page":1,"limit":1,"total":248,"total_pages":248}
+        }"#;
+        let page: MetricsPage = serde_json::from_str(json).expect("parse");
+        assert_eq!(page.data.len(), 1);
+        assert_eq!(page.pagination.total_pages, 248);
+        assert_eq!(page.data[0].drive_files_size, "21339640");
+    }
+
+    #[test]
+    fn metrics_page_tolerates_missing_pagination() {
+        // The pagination block uses `#[serde(default)]` so an indexer
+        // that ever omits the wrapper still parses to "page 1 of 1".
+        let json = r#"{"data":[]}"#;
+        let page: MetricsPage = serde_json::from_str(json).expect("parse");
+        assert_eq!(page.pagination.total_pages, 0);
+        assert!(page.data.is_empty());
+    }
+
+    #[test]
+    fn empty_snapshots_yield_empty_chart() {
+        let out = build_storage_chart(&[], "last7days");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn pre_window_seed_carries_into_first_day() {
+        // Only one snapshot, dated *before* a 7-day window opens on
+        // today. Every chart point should carry that pre-window
+        // value, not 0 — that was the original bug fix the credits
+        // chart shipped with and the new storage path must preserve.
+        let today = chrono::Utc::now().date_naive();
+        let pre = today
+            .checked_sub_signed(chrono::Duration::days(30))
+            .expect("subtract 30 days from today");
+        let ts = format!("{pre}T00:00:00Z");
+        let snaps = vec![snap("12345", &ts)];
+
+        let out = build_storage_chart(&snaps, "last7days");
+        assert!(!out.is_empty());
+        assert!(out.iter().all(|p| (p.balance - 12345.0).abs() < f64::EPSILON), "expected all points to seed from pre-window snapshot, got {out:?}");
+    }
+}

--- a/src-tauri/src/billing/mod.rs
+++ b/src-tauri/src/billing/mod.rs
@@ -3,6 +3,7 @@
 pub mod charts;
 pub mod credits;
 pub mod drive_credits;
+pub mod drive_storage;
 pub mod eligibility;
 pub mod queries;
 pub mod subscriptions;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -38,7 +38,8 @@ use crate::billing::charts::{
     calculate_storage_capacity, calculate_storage_cost, format_balance_chart, format_credits_chart, transform_marketplace_credits,
 };
 use crate::billing::credits::{check_sync_eligibility, get_user_credits};
-use crate::billing::drive_credits::{get_drive_credits_chart, get_drive_credits_total, get_drive_storage_chart};
+use crate::billing::drive_credits::{get_drive_credits_chart, get_drive_credits_total};
+use crate::billing::drive_storage::get_drive_storage_chart;
 use crate::billing::eligibility::check_action_eligibility;
 use crate::billing::queries::{
     get_add_credit_events, get_balance_transfers, get_billing_transactions, get_credits, get_deposit_address, get_drive_storage_stats,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hippius",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "identifier": "hippius.com",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tests/local_db_commands.rs
+++ b/src-tauri/tests/local_db_commands.rs
@@ -272,7 +272,7 @@ async fn soft_delete_all_includes_system_rows() {
     let bob = "bob";
 
     insert_notification(&pool, alice, None, None, "a1").await;
-    insert_notification(&pool, "system", Some("Hippius"), Some("0.1.96"), "Update Available").await;
+    insert_notification(&pool, "system", Some("Hippius"), Some("0.1.97"), "Update Available").await;
     insert_notification(&pool, bob, None, None, "b1").await;
 
     // Same SQL the production command runs.


### PR DESCRIPTION
## What's Changed

### Bug Fixes

- **Storage Usage chart now reflects accurate values after file deletions** The Storage Usage chart on the home screen could show outdated storage figures after deleting files, taking several minutes to catch up with your actual usage. This has been fixed — the chart now always reflects your current storage usage accurately.