### PR TITLE
fix(files/sync): macOS Finder name ordering + filter dropdown positioning

### DIFF
--- a/app/components/page-sections/files/files-table/index.tsx
+++ b/app/components/page-sections/files/files-table/index.tsx
@@ -56,6 +56,7 @@ import { useFileSelection } from "@/app/contexts/FileSelectionContext";
 import useDeleteFile from "@/app/lib/hooks/use-delete-file";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { revealFile } from "@/lib/utils/revealFile";
+import { macosNameCmp } from "@/lib/utils/fileSort";
 
 import { toast } from "sonner";
 
@@ -517,6 +518,11 @@ const FilesTable: FC<FilesTableProps> = memo(
             header: "NAME",
             enableSorting: true,
             id: "name",
+            sortingFn: (rowA, rowB, columnId) =>
+              macosNameCmp(
+                rowA.getValue<string>(columnId) ?? "",
+                rowB.getValue<string>(columnId) ?? "",
+              ),
             minSize: 200,
             maxSize: 1000,
             cell: (info) => {

--- a/app/components/page-sections/files/filter-dialog-content/DateSelector.tsx
+++ b/app/components/page-sections/files/filter-dialog-content/DateSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import * as Menubar from "@radix-ui/react-menubar";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Icons } from "@/components/ui";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -142,17 +142,17 @@ const DateSelector: React.FC<DateSelectorProps> = ({
   const today = new Date();
 
   return (
-    <Menubar.Root>
-      <Menubar.Menu>
-        <Menubar.Trigger asChild>
-          <button className="flex justify-center group px-3 py-2 bg-grey-100 min-w-[7rem] rounded border border-grey-80 hover:bg-grey-80 transition-colors">
-            <div className="text-sm font-medium text-grey-10 leading-5">
-              {getDisplayText()}
-            </div>
-            <Icons.CalendarNew className="ml-2 mt-0.5 size-4 text-primary-10" />
-          </button>
-        </Menubar.Trigger>
-        <Menubar.Content className="mt-1 bg-white border border-grey-80 rounded-lg p-4 shadow-menu min-w-[20rem] max-w-[22.5rem] z-50" align="start" sideOffset={4}>
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button className="flex justify-center group px-3 py-2 bg-grey-100 min-w-[7rem] rounded border border-grey-80 hover:bg-grey-80 transition-colors">
+          <div className="text-sm font-medium text-grey-10 leading-5">
+            {getDisplayText()}
+          </div>
+          <Icons.CalendarNew className="ml-2 mt-0.5 size-4 text-primary-10" />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className="mt-1 bg-white border border-grey-80 rounded-lg p-4 shadow-menu min-w-[20rem] max-w-[22.5rem] z-50" align="start" sideOffset={4}>
           {/* Calendar Header */}
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">
@@ -292,9 +292,9 @@ const DateSelector: React.FC<DateSelectorProps> = ({
               </>
             )}
           </div>
-        </Menubar.Content>
-      </Menubar.Menu>
-    </Menubar.Root>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
   );
 };
 

--- a/app/components/page-sections/files/filter-dialog-content/EnhancedFileSizeSelector.tsx
+++ b/app/components/page-sections/files/filter-dialog-content/EnhancedFileSizeSelector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import * as Menubar from "@radix-ui/react-menubar";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as Checkbox from "@radix-ui/react-checkbox";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Icons } from "@/components/ui";
@@ -102,20 +102,24 @@ const EnhancedFileSizeSelector: React.FC<EnhancedFileSizeSelectorProps> = ({
 
     return (
         <>
-            <Menubar.Root>
-                <Menubar.Menu>
-                    <Menubar.Trigger asChild>
-                        <button className="flex justify-center group px-3 py-2 bg-grey-100 min-w-[7rem] rounded border border-grey-80 hover:bg-grey-80 transition-colors">
-                            <div className="text-sm font-medium text-grey-40 leading-5">
-                                {getDisplayText()}
-                            </div>
-                            <Icons.ChevronDown className="ml-2 mt-0.5 size-4 text-grey-40 transition-transform duration-200 group-data-[state=open]:rotate-180" />
-                        </button>
-                    </Menubar.Trigger>
-                    <Menubar.Content className="mt-1 bg-white border border-grey-80 rounded-lg px-2 py-1 shadow-menu min-w-[13.75rem] z-50">
+            <DropdownMenu.Root>
+                <DropdownMenu.Trigger asChild>
+                    <button className="flex justify-center group px-3 py-2 bg-grey-100 min-w-[7rem] rounded border border-grey-80 hover:bg-grey-80 transition-colors">
+                        <div className="text-sm font-medium text-grey-40 leading-5">
+                            {getDisplayText()}
+                        </div>
+                        <Icons.ChevronDown className="ml-2 mt-0.5 size-4 text-grey-40 transition-transform duration-200 group-data-[state=open]:rotate-180" />
+                    </button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Portal>
+                    <DropdownMenu.Content
+                        sideOffset={4}
+                        align="start"
+                        className="mt-1 bg-white border border-grey-80 rounded-lg px-2 py-1 shadow-menu min-w-[13.75rem] z-50"
+                    >
                         {selectedSizes.length > 0 && (
                             <>
-                                <Menubar.Item
+                                <DropdownMenu.Item
                                     className="flex items-center gap-2 p-2 hover:bg-grey-80 cursor-pointer rounded text-grey-40 text-xs font-medium outline-none w-full"
                                     onSelect={(e) => {
                                         e.preventDefault();
@@ -128,12 +132,12 @@ const EnhancedFileSizeSelector: React.FC<EnhancedFileSizeSelectorProps> = ({
                                     <span className="font-medium text-xs text-red-600">
                                         Clear All Sizes
                                     </span>
-                                </Menubar.Item>
+                                </DropdownMenu.Item>
                                 <div className="border-t border-grey-90 my-1" />
                             </>
                         )}
                         {fileSizeOptions.map((option) => (
-                            <Menubar.Item
+                            <DropdownMenu.Item
                                 key={option.value}
                                 className="flex items-center gap-2 p-2 hover:bg-grey-80 cursor-pointer rounded text-grey-40 text-xs font-medium outline-none w-full"
                                 onSelect={(e) => {
@@ -145,13 +149,7 @@ const EnhancedFileSizeSelector: React.FC<EnhancedFileSizeSelectorProps> = ({
                                     <Checkbox.Root
                                         className="h-4 w-4 rounded border border-grey-70 flex items-center justify-center bg-grey-90 data-[state=checked]:bg-primary-50 data-[state=checked]:border-primary-50 transition-colors"
                                         checked={selectedSizes.includes(option.value)}
-                                        onCheckedChange={(checked) => {
-                                            if (checked) {
-                                                handleSizeToggle(option.value);
-                                            } else {
-                                                handleSizeToggle(option.value);
-                                            }
-                                        }}
+                                        onCheckedChange={() => handleSizeToggle(option.value)}
                                     >
                                         <Checkbox.Indicator>
                                             <Check className="size-4 text-white" />
@@ -170,11 +168,11 @@ const EnhancedFileSizeSelector: React.FC<EnhancedFileSizeSelectorProps> = ({
                                         {option.description}
                                     </span>
                                 </div>
-                            </Menubar.Item>
+                            </DropdownMenu.Item>
                         ))}
-                    </Menubar.Content>
-                </Menubar.Menu>
-            </Menubar.Root>
+                    </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+            </DropdownMenu.Root>
 
             {/* Custom Size Dialog */}
             <Dialog.Root open={isCustomDialogOpen} onOpenChange={setIsCustomDialogOpen}>

--- a/app/components/page-sections/files/filter-dialog-content/FileTypeSelector.tsx
+++ b/app/components/page-sections/files/filter-dialog-content/FileTypeSelector.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import * as Menubar from "@radix-ui/react-menubar";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as Checkbox from "@radix-ui/react-checkbox";
 import { Icons } from "@/components/ui";
 import { cn } from "@/lib/utils";
@@ -28,27 +28,22 @@ const fileTypes: Array<{
   icon: React.FC<Record<string, unknown>>;
   color: string;
 }> = [
-    { type: "folder", label: "Folder", icon: Folder2, color: "text-primary-40" },
-    { type: "image", label: "Image", icon: Image, color: "text-[#ea4335]" },
-    { type: "video", label: "Video", icon: Video, color: "text-[#ea4335]" },
-    { type: "audio", label: "Audio", icon: Note, color: "text-[#9b59b6]" },
-    { type: "PDF", label: "PDF", icon: PDF, color: "text-[#ea4335]" },
-    { type: "doc", label: "Document", icon: Document, color: "text-[#4285F4]" },
-    { type: "XLS", label: "Spreadsheet", icon: Sheet, color: "text-[#34a853]" },
-    { type: "PPT", label: "Presentation", icon: Presentation, color: "text-[#fbbc04]" },
-    { type: "archive", label: "Archive", icon: Zip, color: "text-[#f39c12]" },
-    { type: "disk_image", label: "Disk Image", icon: File, color: "text-primary-70 fill-primary-60" },
-    { type: "code", label: "Code", icon: Terminal, color: "text-[#4285F4]" },
-    { type: "markdown", label: "Markdown", icon: DocumentText, color: "text-[#4285F4]" },
-    { type: "sql", label: "Database", icon: CentralizedDataBase, color: "text-[#4285F4]" },
-    { type: "svg", label: "SVG", icon: SVG, color: "text-black" },
-    {
-      type: "document",
-      label: "Other",
-      icon: File,
-      color: "text-primary-70 fill-primary-60",
-    },
-  ];
+  { type: "folder", label: "Folder", icon: Folder2, color: "text-primary-40" },
+  { type: "image", label: "Image", icon: Image, color: "text-[#ea4335]" },
+  { type: "video", label: "Video", icon: Video, color: "text-[#ea4335]" },
+  { type: "audio", label: "Audio", icon: Note, color: "text-[#9b59b6]" },
+  { type: "PDF", label: "PDF", icon: PDF, color: "text-[#ea4335]" },
+  { type: "doc", label: "Document", icon: Document, color: "text-[#4285F4]" },
+  { type: "XLS", label: "Spreadsheet", icon: Sheet, color: "text-[#34a853]" },
+  { type: "PPT", label: "Presentation", icon: Presentation, color: "text-[#fbbc04]" },
+  { type: "archive", label: "Archive", icon: Zip, color: "text-[#f39c12]" },
+  { type: "disk_image", label: "Disk Image", icon: File, color: "text-primary-70 fill-primary-60" },
+  { type: "code", label: "Code", icon: Terminal, color: "text-[#4285F4]" },
+  { type: "markdown", label: "Markdown", icon: DocumentText, color: "text-[#4285F4]" },
+  { type: "sql", label: "Database", icon: CentralizedDataBase, color: "text-[#4285F4]" },
+  { type: "svg", label: "SVG", icon: SVG, color: "text-black" },
+  { type: "document", label: "Other", icon: File, color: "text-primary-70 fill-primary-60" },
+];
 
 interface FileTypeSelectorProps {
   selectedTypes?: FileTypes[];
@@ -76,19 +71,23 @@ const FileTypeSelector: React.FC<FileTypeSelectorProps> = ({
   };
 
   return (
-    <Menubar.Root>
-      <Menubar.Menu>
-        <Menubar.Trigger asChild>
-          <button className="flex justify-center group px-3 py-2 bg-grey-100 w-full rounded border border-grey-80 hover:bg-grey-80 min-w-[7rem] transition-colors">
-            <div className="text-sm font-medium text-grey-40 leading-5">
-              {getDisplayText()}
-            </div>
-            <Icons.ChevronDown className="ml-2 mt-0.5 size-4 text-grey-10 transition-transform duration-200 group-data-[state=open]:rotate-180" />
-          </button>
-        </Menubar.Trigger>
-        <Menubar.Content className="mt-1 bg-white border border-grey-80 rounded-lg px-2 py-1 shadow-menu min-w-[9.5625rem] z-50">
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button className="flex justify-center group px-3 py-2 bg-grey-100 w-full rounded border border-grey-80 hover:bg-grey-80 min-w-[7rem] transition-colors">
+          <div className="text-sm font-medium text-grey-40 leading-5">
+            {getDisplayText()}
+          </div>
+          <Icons.ChevronDown className="ml-2 mt-0.5 size-4 text-grey-10 transition-transform duration-200 group-data-[state=open]:rotate-180" />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          sideOffset={4}
+          align="start"
+          className="mt-1 bg-white border border-grey-80 rounded-lg px-2 py-1 shadow-menu min-w-[9.5625rem] z-50"
+        >
           {fileTypes.map((fileType) => (
-            <Menubar.Item
+            <DropdownMenu.Item
               key={fileType.type}
               className="flex items-center gap-2 p-2 hover:bg-grey-80 cursor-pointer rounded text-grey-40 text-xs font-medium outline-none w-full"
               onSelect={(e) => {
@@ -113,11 +112,11 @@ const FileTypeSelector: React.FC<FileTypeSelectorProps> = ({
                   {fileType.label}
                 </span>
               </div>
-            </Menubar.Item>
+            </DropdownMenu.Item>
           ))}
-        </Menubar.Content>
-      </Menubar.Menu>
-    </Menubar.Root>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
   );
 };
 

--- a/app/components/page-sections/files/filter-dialog-content/FileTypeSelector.tsx
+++ b/app/components/page-sections/files/filter-dialog-content/FileTypeSelector.tsx
@@ -73,7 +73,7 @@ const FileTypeSelector: React.FC<FileTypeSelectorProps> = ({
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
-        <button className="flex justify-center group px-3 py-2 bg-grey-100 w-full rounded border border-grey-80 hover:bg-grey-80 min-w-[7rem] transition-colors">
+        <button className="flex justify-center group px-3 py-2 bg-grey-100 rounded border border-grey-80 hover:bg-grey-80 min-w-[7rem] transition-colors">
           <div className="text-sm font-medium text-grey-40 leading-5">
             {getDisplayText()}
           </div>

--- a/app/lib/utils/fileSort.ts
+++ b/app/lib/utils/fileSort.ts
@@ -1,0 +1,48 @@
+/**
+ * Compare two file/folder names using macOS Finder ordering rules
+ * (equivalent to NSString.localizedStandardCompare):
+ *   1. Case-insensitive
+ *   2. Natural number ordering  ("9" < "10", "2025" < "2026")
+ *   3. Category order: punctuation/symbols < digits < letters
+ *
+ * Mirrors the `macos_name_cmp` Rust function in sync/files.rs so that
+ * clicking the NAME column header gives the same order as the default load.
+ */
+export function macosNameCmp(a: string, b: string): number {
+  const norm = (s: string): string =>
+    s
+      .split("")
+      .map((c) => {
+        if (/\d/.test(c)) return c;
+        const lo = c.toLowerCase();
+        return /[a-z]/.test(lo) ? lo : "\x01";
+      })
+      .join("");
+
+  const na = norm(a);
+  const nb = norm(b);
+
+  let i = 0;
+  let j = 0;
+
+  while (i < na.length && j < nb.length) {
+    const ca = na[i];
+    const cb = nb[j];
+
+    if (/\d/.test(ca) && /\d/.test(cb)) {
+      let numA = "";
+      let numB = "";
+      while (i < na.length && /\d/.test(na[i])) numA += na[i++];
+      while (j < nb.length && /\d/.test(nb[j])) numB += nb[j++];
+      const diff = parseInt(numA, 10) - parseInt(numB, 10);
+      if (diff !== 0) return diff;
+    } else {
+      if (ca < cb) return -1;
+      if (ca > cb) return 1;
+      i++;
+      j++;
+    }
+  }
+
+  return na.length - nb.length;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hippius",
   "private": true,
-  "version": "0.1.98",
+  "version": "0.1.99",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Hippius"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "aes",
  "alloy-signer",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Hippius"
-version = "0.1.98"
+version = "0.1.99"
 description = "Hippius Desktop App"
 authors = ["you"]
 edition = "2024"

--- a/src-tauri/src/sync/files.rs
+++ b/src-tauri/src/sync/files.rs
@@ -1262,6 +1262,68 @@ pub async fn list_sync_folder_grouped(
     list_sync_folder_grouped_inner(&state, account_id, sync_path, subfolder, label).await
 }
 
+/// Compare two file/folder names using macOS Finder ordering rules, which
+/// match `NSString.localizedStandardCompare`:
+///   1. Case-insensitive
+///   2. Natural number ordering ("9" < "10", "2025" < "2026")
+///   3. Primary category order: punctuation/symbols < digits < letters
+///
+/// This keeps `_backup` before `2025_rennsport` before `InstantUpload`,
+/// matching what the user sees in Finder when sorted by name.
+///
+/// Implementation: normalize each name so that every non-alphanumeric char
+/// becomes `'\x01'` (which sorts before all digits and letters), and
+/// lowercase all letters, then compare the resulting strings with natural
+/// number ordering (digit runs compared numerically, not lexicographically).
+fn macos_name_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    fn normalize_char(c: char) -> char {
+        if c.is_ascii_digit() {
+            c
+        } else if let Some(lower) = c.to_lowercase().next() {
+            if lower.is_alphabetic() { lower } else { '\x01' }
+        } else {
+            '\x01'
+        }
+    }
+
+    // Walk both normalized strings simultaneously, comparing digit runs
+    // numerically and all other characters by value.
+    let mut ai = a.chars().map(normalize_char).peekable();
+    let mut bi = b.chars().map(normalize_char).peekable();
+
+    loop {
+        match (ai.peek().copied(), bi.peek().copied()) {
+            (None, None) => return std::cmp::Ordering::Equal,
+            (None, Some(_)) => return std::cmp::Ordering::Less,
+            (Some(_), None) => return std::cmp::Ordering::Greater,
+            (Some(ac), Some(bc)) => {
+                if ac.is_ascii_digit() && bc.is_ascii_digit() {
+                    // Compare digit runs as integers (natural sort).
+                    let mut an: u64 = 0;
+                    let mut bn: u64 = 0;
+                    while ai.peek().map_or(false, |c| c.is_ascii_digit()) {
+                        an = an * 10 + ai.next().unwrap().to_digit(10).unwrap() as u64;
+                    }
+                    while bi.peek().map_or(false, |c| c.is_ascii_digit()) {
+                        bn = bn * 10 + bi.next().unwrap().to_digit(10).unwrap() as u64;
+                    }
+                    match an.cmp(&bn) {
+                        std::cmp::Ordering::Equal => continue,
+                        ord => return ord,
+                    }
+                } else {
+                    ai.next();
+                    bi.next();
+                    match ac.cmp(&bc) {
+                        std::cmp::Ordering::Equal => continue,
+                        ord => return ord,
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Pure helper for [`list_sync_folder_grouped`], exposed for integration tests
 /// so they can drive it against a hand-assembled [`AppState`] without going
 /// through the Tauri command layer.
@@ -1368,6 +1430,12 @@ pub async fn list_sync_folder_grouped_inner(
         });
     }
     files.extend(server_only_files);
+
+    // Sort both lists to match macOS Finder name ordering:
+    // punctuation/symbols first, then digits, then letters, with natural
+    // number ordering within digit runs.
+    folders.sort_by(|a, b| macos_name_cmp(&a.name, &b.name));
+    files.sort_by(|a, b| macos_name_cmp(&a.name, &b.name));
 
     // 5. Backfill flag. NULL on `relative_paths_backfilled_at` ⇒ pending.
     // Any DB error — missing row, pool not ready — surfaces as
@@ -1962,6 +2030,60 @@ async fn copy_dir_recursive(src: &Path, dst: &Path, depth: u32) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- macos_name_cmp ---
+
+    /// Verifies that `macos_name_cmp` produces the same ordering as macOS
+    /// Finder when sorting by name: symbols/punctuation < digits < letters,
+    /// with natural (not lexicographic) number ordering.
+    #[test]
+    fn macos_name_cmp_matches_finder_order() {
+        let mut names = vec![
+            "wordpress",
+            "2025_rennsport",
+            "_notes",
+            "InstantUpload",
+            "_backup",
+            "Photos",
+            "2026_rennsport",
+            "__bittensor",
+            "mogmachine.memory",
+            "portugal",
+        ];
+        names.sort_by(|a, b| macos_name_cmp(a, b));
+
+        // Expected order matches macOS Finder:
+        // underscore-prefixed → digits → letters (case-insensitive)
+        assert_eq!(
+            names,
+            vec![
+                "__bittensor",
+                "_backup",
+                "_notes",
+                "2025_rennsport",
+                "2026_rennsport",
+                "InstantUpload",
+                "mogmachine.memory",
+                "Photos",
+                "portugal",
+                "wordpress",
+            ]
+        );
+    }
+
+    #[test]
+    fn macos_name_cmp_natural_number_ordering() {
+        let mut names = vec!["file10", "file2", "file1", "file20", "file9"];
+        names.sort_by(|a, b| macos_name_cmp(a, b));
+        assert_eq!(names, vec!["file1", "file2", "file9", "file10", "file20"]);
+    }
+
+    #[test]
+    fn macos_name_cmp_case_insensitive() {
+        let mut names = vec!["Zebra", "apple", "Mango", "banana"];
+        names.sort_by(|a, b| macos_name_cmp(a, b));
+        assert_eq!(names, vec!["apple", "banana", "Mango", "Zebra"]);
+    }
 
     // --- derive_relative_name ---
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hippius",
-  "version": "0.1.98",
+  "version": "0.1.99",
   "identifier": "hippius.com",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tests/local_db_commands.rs
+++ b/src-tauri/tests/local_db_commands.rs
@@ -272,7 +272,7 @@ async fn soft_delete_all_includes_system_rows() {
     let bob = "bob";
 
     insert_notification(&pool, alice, None, None, "a1").await;
-    insert_notification(&pool, "system", Some("Hippius"), Some("0.1.98"), "Update Available").await;
+    insert_notification(&pool, "system", Some("Hippius"), Some("0.1.99"), "Update Available").await;
     insert_notification(&pool, bob, None, None, "b1").await;
 
     // Same SQL the production command runs.


### PR DESCRIPTION
## Summary

- **macOS Finder name ordering** — File and folder listings now sort identically to macOS Finder (`NSString.localizedStandardCompare`): symbols/punctuation first, then natural-number digit runs, then letters case-insensitively. Implemented in Rust (`sync/files.rs`) for the default load order, and mirrored in TypeScript (`lib/utils/fileSort.ts`) as a TanStack Table `sortingFn` so clicking the NAME column header also uses Finder ordering.
- **Filter dropdown positioning** — The File Type, Size, and Date filter pills were built with `@radix-ui/react-menubar` which does not portal to `document.body`, causing dropdowns to appear at incorrect positions. Replaced with `@radix-ui/react-dropdown-menu` (`DropdownMenu.Portal` + `DropdownMenu.Content`) across all three components so they render relative to the viewport correctly.
- **Version bump** — 0.1.98 → 0.1.99