### PR TITLE
Release 0.1.100

### DIFF
--- a/app/(pages)/ResponsiveContent.tsx
+++ b/app/(pages)/ResponsiveContent.tsx
@@ -7,6 +7,7 @@ import ProfileCard from "@/components/dashboard-title-wrapper/ProfileCard";
 import BlockChainStats from "@/components/dashboard-title-wrapper/BlockChainStats";
 import ConflictsBanner from "@/components/ui/ConflictsBanner";
 import MigrationBanner from "@/components/ui/MigrationBanner";
+import CreditsExhaustedBanner from "@/components/billing/CreditsExhaustedBanner";
 import { SyncReauthRequiredAlert } from "@/components/ui/SyncReauthRequiredAlert";
 
 export default function ResponsiveContent({
@@ -35,6 +36,7 @@ export default function ResponsiveContent({
           </div>
           <ConflictsBanner />
           <MigrationBanner />
+          <CreditsExhaustedBanner />
           {/* `SyncReauthRequiredAlert` auto-renders null unless Rust's
               `restore_session` flagged `sync_requires_reauth = true`
               (keychain-miss for a mnemonic user). Mounting it here in

--- a/app/(pages)/SyncEventLogger.tsx
+++ b/app/(pages)/SyncEventLogger.tsx
@@ -5,6 +5,7 @@ import { useSyncSnapshotListener } from "@/lib/hooks/useSyncSnapshot";
 import { useDriveStatuses } from "@/lib/hooks/useDriveStatuses";
 import { useServerCapabilities } from "@/lib/hooks/useServerCapabilities";
 import { useUploadProcessing } from "@/lib/hooks/useUploadProcessing";
+import { useCreditsExhausted } from "@/lib/hooks/useCreditsExhausted";
 
 /**
  * Invisible component that mounts the cross-cutting sync hooks:
@@ -13,6 +14,8 @@ import { useUploadProcessing } from "@/lib/hooks/useUploadProcessing";
  * - `useDriveStatuses()` — single producer for `driveStatusesAtom`,
  *   subscribed to the per-drive Rust events. Replaces the old global
  *   per-drive status hook (replaces the deleted global engine-status hook).
+ * - `useCreditsExhausted()` — writes the credits-exhausted atom on
+ *   `hcfs_credits_exhausted` events; the banner reads it.
  *
  * Must be rendered within an authenticated layout.
  */
@@ -21,6 +24,7 @@ export default function SyncEventLogger() {
   useUploadProcessing();
   useSyncSnapshotListener();
   useDriveStatuses();
+  useCreditsExhausted();
   // Caches `serverCapabilitiesAtom` once per session so share UI surfaces
   // can gate themselves on `shares: true` without each surface fetching
   // separately. Cleared automatically on logout.

--- a/app/(pages)/SyncEventLogger.tsx
+++ b/app/(pages)/SyncEventLogger.tsx
@@ -6,6 +6,7 @@ import { useDriveStatuses } from "@/lib/hooks/useDriveStatuses";
 import { useServerCapabilities } from "@/lib/hooks/useServerCapabilities";
 import { useUploadProcessing } from "@/lib/hooks/useUploadProcessing";
 import { useCreditsExhausted } from "@/lib/hooks/useCreditsExhausted";
+import { useMetadataStale } from "@/lib/hooks/useMetadataStale";
 
 /**
  * Invisible component that mounts the cross-cutting sync hooks:
@@ -16,6 +17,10 @@ import { useCreditsExhausted } from "@/lib/hooks/useCreditsExhausted";
  *   per-drive status hook (replaces the deleted global engine-status hook).
  * - `useCreditsExhausted()` — writes the credits-exhausted atom on
  *   `hcfs_credits_exhausted` events; the banner reads it.
+ * - `useMetadataStale()` — writes `metadataStaleLabelsAtom` on
+ *   `hcfs_metadata_stale` events and clears it on `hcfs_activity_updated`,
+ *   so the Files page can surface a per-drive "couldn't refresh upload
+ *   dates" banner when the bounded-retry reconcile exhausts its budget.
  *
  * Must be rendered within an authenticated layout.
  */
@@ -25,6 +30,7 @@ export default function SyncEventLogger() {
   useSyncSnapshotListener();
   useDriveStatuses();
   useCreditsExhausted();
+  useMetadataStale();
   // Caches `serverCapabilitiesAtom` once per session so share UI surfaces
   // can gate themselves on `shares: true` without each surface fetching
   // separately. Cleared automatically on logout.

--- a/app/(pages)/SyncStatusDialog.tsx
+++ b/app/(pages)/SyncStatusDialog.tsx
@@ -239,6 +239,13 @@ const SyncStatusDialog: React.FC<SyncStatusDialogProps> = ({
   const isSingleFile = totalFiles === 1;
   const effectiveInProgress = snapshot.effectiveInProgress;
   const effectiveCompleted = snapshot.effectiveCompleted;
+  // Rust marks `widgetState="preparing"` between SyncStarted and the
+  // first session-populated snapshot for file-watcher-initiated
+  // cycles. The title, tooltip, collapsed-header status and badge all
+  // branch on this flag — without it the three surfaces would
+  // disagree (collapsed: "Syncing 0%", title: "File Sync", badge:
+  // "Preparing sync...") because each has its own derived condition.
+  const isPreparing = snapshot.widgetState === "preparing";
 
   // ── Smoothed progress ──────────────────────────────────────────
   // Interpolate between snapshot.overallPercent values so the bar
@@ -523,7 +530,9 @@ const SyncStatusDialog: React.FC<SyncStatusDialogProps> = ({
                       ? "Sync Failed"
                       : effectiveCompleted
                         ? "Sync Complete"
-                        : "File Sync"}
+                        : isPreparing
+                          ? "Preparing Sync"
+                          : "File Sync"}
               </span>
               <InfoTooltip className="ml-2">
                 {isRetrying
@@ -532,7 +541,9 @@ const SyncStatusDialog: React.FC<SyncStatusDialogProps> = ({
                     ? "Some files failed to sync. Please try again."
                     : effectiveCompleted
                       ? "All files have been successfully synced to the network."
-                      : "Your files are being synced to the Hippius network. This process may take a few minutes."}
+                      : isPreparing
+                        ? "Scanning your sync folder for changes. The transfer will start shortly."
+                        : "Your files are being synced to the Hippius network. This process may take a few minutes."}
               </InfoTooltip>
             </h2>
           </div>
@@ -554,9 +565,11 @@ const SyncStatusDialog: React.FC<SyncStatusDialogProps> = ({
                       ? "Failed"
                       : effectiveCompleted || isCompleted
                         ? "Complete"
-                        : percentage !== null && percentage < 100
-                          ? `Syncing ${percentage}%`
-                          : "Syncing..."
+                        : isPreparing
+                          ? "Preparing..."
+                          : percentage !== null && percentage < 100
+                            ? `Syncing ${percentage}%`
+                            : "Syncing..."
                 }
               </span>
             )}
@@ -630,7 +643,15 @@ const SyncStatusDialog: React.FC<SyncStatusDialogProps> = ({
                 const { syncedCount, deletedCount, actualTotal, failedFiles, syncDirection, effectiveCompleted, effectiveInProgress } = snapshot;
                 const completedTotal = syncedCount + deletedCount;
                 let badgeText: string;
-                if (snapshot.statusVariant === "error") {
+                // Short-circuit on the preparing flag computed above. The
+                // trailing else of this chain ALSO writes "Preparing sync..."
+                // (a generic empty-state fallback) — both code paths
+                // converge on the same copy so the badge stays consistent
+                // with the title/tooltip/collapsed-status branches that
+                // gate on `isPreparing` only.
+                if (isPreparing) {
+                  badgeText = "Preparing sync...";
+                } else if (snapshot.statusVariant === "error") {
                   const verb = syncDirection === "download" ? "download" : syncDirection === "upload" ? "upload" : "sync";
                   badgeText = `${failedFiles} of ${actualTotal} files failed to ${verb}`;
                 } else if (effectiveCompleted) {

--- a/app/(pages)/SyncStatusDialog.tsx
+++ b/app/(pages)/SyncStatusDialog.tsx
@@ -718,11 +718,22 @@ const SyncStatusDialog: React.FC<SyncStatusDialogProps> = ({
               </div>
               <div className="flex items-center justify-between mt-1">
                 <div className="flex items-center gap-2">
-                  {snapshot.bytesExpected > 0 && (
+                  {/* When the intent manifest is active, show user-truthful
+                      "X of Y" totals (what the user dragged in, vs. what
+                      has finished). Use `??` (not `||`) so an explicit
+                      `intentTotalBytes: 0` is not misread as "fall back" —
+                      0-totals correctly fail the `> 0` guard. Fall back to
+                      the per-cycle line on legacy / pre-login snapshots
+                      where intent fields are `undefined`. */}
+                  {(snapshot.intentActive ?? false) && (snapshot.intentTotalBytes ?? 0) > 0 ? (
+                    <span className="text-[0.625rem] text-grey-50">
+                      {formatBytes(snapshot.intentCompletedBytes ?? 0)} of {formatBytes(snapshot.intentTotalBytes ?? 0)}
+                    </span>
+                  ) : snapshot.bytesExpected > 0 ? (
                     <span className="text-[0.625rem] text-grey-50">
                       {formatBytes(snapshot.progressBytes)} / {formatBytes(snapshot.bytesExpected)}
                     </span>
-                  )}
+                  ) : null}
                   {effectiveInProgress && speedBytesPerSec !== null && speedBytesPerSec > 0 && (
                     <span className="text-[0.625rem] text-grey-50">
                       · {formatBytes(Math.round(speedBytesPerSec))}/s

--- a/app/(pages)/__tests__/SyncStatusDialog.test.tsx
+++ b/app/(pages)/__tests__/SyncStatusDialog.test.tsx
@@ -261,6 +261,144 @@ describe("SyncStatusDialog", () => {
     expect(percentText).toBeInTheDocument();
   });
 
+  // ── Intent overlay rendering ────────────────────────────────────
+  // The size row under "Overall progress" prefers the intent manifest's
+  // user-truthful "X of Y" totals when the backend signals intentActive.
+  // Falls back to per-cycle "progressBytes / bytesExpected" otherwise.
+  // We assert on the dialog directly (not via SyncStatusHandler) because
+  // the handler test mocks SyncStatusDialog away — rendering assertions
+  // belong here where the real component runs.
+
+  /** Return the "Overall progress" section element, or null if absent.
+   * Per-file rows live OUTSIDE this subtree, so this lets us assert
+   * about the aggregate size span without false matches from file rows
+   * that also display their own "X / Y" text via formatBytes. */
+  function overallProgressSection(container: HTMLElement): Element | null {
+    const label = Array.from(container.querySelectorAll("span")).find(
+      (el) => el.textContent === "Overall progress",
+    );
+    // The label sits two divs deep inside the wrapper that owns the bar
+    // and the size row (`<div class="px-4 pt-3">…`).
+    return label?.parentElement?.parentElement ?? null;
+  }
+
+  /** Text content of all `text-[0.625rem] text-grey-50` size-line spans
+   * inside the overall-progress section. The intent line and the
+   * fallback per-cycle line both render with this class. */
+  function overallSizeLineTexts(container: HTMLElement): string[] {
+    const section = overallProgressSection(container);
+    if (!section) return [];
+    return Array.from(
+      section.querySelectorAll("span.text-\\[0\\.625rem\\].text-grey-50"),
+    ).map((el) => el.textContent ?? "");
+  }
+
+  it("renders 'X of Y' intent line when intentActive is true", () => {
+    // Multi-file in-progress snapshot — required for the "Overall progress"
+    // section to render (gated by !isSingleFile && effectiveInProgress).
+    const files = [
+      makeFileProgress("a.bin", {
+        status: "inProgress",
+        progressPercent: 50,
+        bytesTransferred: 2_500_000,
+        totalBytes: 5_000_000,
+      }),
+      makeFileProgress("b.bin", {
+        status: "pending",
+        totalBytes: 2_500_000,
+      }),
+    ];
+    const snapshot = makeSnapshot(files, {
+      intentTotalFiles: 100,
+      intentCompletedFiles: 50,
+      intentTotalBytes: 10_000_000_000,
+      intentCompletedBytes: 5_000_000_000,
+      intentActive: true,
+    });
+
+    const { container } = renderWithJotai(
+      <SyncStatusDialog snapshot={snapshot} open={true} />,
+    );
+
+    // formatBytes(10_000_000_000) → "10 GB" (default 2 decimals, trailing
+    // zeros trimmed by parseFloat); formatBytes(5_000_000_000) → "5 GB".
+    const overallTexts = overallSizeLineTexts(container);
+    expect(overallTexts).toContain("5 GB of 10 GB");
+    // Per-cycle slash line must NOT appear at the aggregate level when
+    // intent is active. The two branches are mutually exclusive in the
+    // JSX (`if/else if/null`), so verifying the absence of any
+    // slash-separated total here pins that contract.
+    expect(overallTexts.some((t) => / \/ /.test(t))).toBe(false);
+  });
+
+  it("falls back to per-cycle line when intent fields are undefined", () => {
+    // Legacy / pre-login snapshot shape: no intent overlay. The size row
+    // must keep showing the per-cycle "progressBytes / bytesExpected".
+    const files = [
+      makeFileProgress("a.bin", {
+        status: "inProgress",
+        progressPercent: 50,
+        bytesTransferred: 2_500_000,
+        totalBytes: 5_000_000,
+      }),
+      makeFileProgress("b.bin", {
+        status: "pending",
+        totalBytes: 2_500_000,
+      }),
+    ];
+    const snapshot = makeSnapshot(files);
+    // Sanity check: factory did not silently populate intent fields.
+    expect(snapshot.intentActive).toBeUndefined();
+    expect(snapshot.intentTotalBytes).toBeUndefined();
+
+    const { container } = renderWithJotai(
+      <SyncStatusDialog snapshot={snapshot} open={true} />,
+    );
+
+    // progressBytes = 2.5 MB (a.bin transferred), bytesExpected = 7.5 MB
+    // (a.bin + b.bin totals). formatBytes(7_500_000) → "7.5 MB".
+    const overallTexts = overallSizeLineTexts(container);
+    expect(overallTexts).toContain("2.5 MB / 7.5 MB");
+    // The intent "of <unit>" form must not appear at the aggregate level.
+    expect(overallTexts.some((t) => / of /.test(t))).toBe(false);
+  });
+
+  it("falls back to per-cycle line when intentActive is true but intentTotalBytes is 0", () => {
+    // Manifest exists but is empty — the `> 0` guard on intentTotalBytes
+    // catches this so we do not render "0 B of 0 B". The `??` operator
+    // (not `||`) lets us distinguish absent (undefined) from explicit 0
+    // in the type, even though both fail the guard here.
+    const files = [
+      makeFileProgress("a.bin", {
+        status: "inProgress",
+        progressPercent: 50,
+        bytesTransferred: 2_500_000,
+        totalBytes: 5_000_000,
+      }),
+      makeFileProgress("b.bin", {
+        status: "pending",
+        totalBytes: 2_500_000,
+      }),
+    ];
+    const snapshot = makeSnapshot(files, {
+      intentTotalFiles: 0,
+      intentCompletedFiles: 0,
+      intentTotalBytes: 0,
+      intentCompletedBytes: 0,
+      intentActive: true,
+    });
+
+    const { container } = renderWithJotai(
+      <SyncStatusDialog snapshot={snapshot} open={true} />,
+    );
+
+    const overallTexts = overallSizeLineTexts(container);
+    // Falls back to per-cycle slash line.
+    expect(overallTexts).toContain("2.5 MB / 7.5 MB");
+    // Empty intent banner must not appear.
+    expect(overallTexts.some((t) => t === "0 B of 0 B")).toBe(false);
+  });
+
   it("shows Complete when Rust fixes stalled active session at 100%", () => {
     // Reproduces the bug scenario: hcfs-client leaves is_active=true due to
     // its file watcher detecting self-generated writes (changes_pending stuck).

--- a/app/(pages)/__tests__/SyncStatusHandler.test.tsx
+++ b/app/(pages)/__tests__/SyncStatusHandler.test.tsx
@@ -34,7 +34,11 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 // Mock SyncStatusDialog to inspect props. The widget is rendered iff
 // `open === true` — matching the handler's pass-through of
-// `snapshot.widgetVisible`.
+// `snapshot.widgetVisible`. We surface intent fields as data attributes
+// so we can pin that the handler hands the new optional fields to the
+// dialog without reading or mutating them — they should pass straight
+// through. Rendering of the actual "X of Y" line is verified directly
+// against SyncStatusDialog in `SyncStatusDialog.test.tsx`.
 const mockOnClose = vi.fn();
 vi.mock("../SyncStatusDialog", () => ({
   default: ({ snapshot, open, onClose }: {
@@ -44,7 +48,13 @@ vi.mock("../SyncStatusDialog", () => ({
   }) => {
     mockOnClose.mockImplementation(onClose);
     return open ? (
-      <div data-testid="sync-widget" data-started-at={snapshot.startedAt}>
+      <div
+        data-testid="sync-widget"
+        data-started-at={snapshot.startedAt}
+        data-intent-active={String(snapshot.intentActive ?? "undefined")}
+        data-intent-total-bytes={String(snapshot.intentTotalBytes ?? "undefined")}
+        data-intent-completed-bytes={String(snapshot.intentCompletedBytes ?? "undefined")}
+      >
         Widget visible
       </div>
     ) : null;
@@ -201,6 +211,52 @@ describe("SyncStatusHandler – projection of widgetVisible", () => {
     );
 
     expect(queryByTestId("sync-widget")).not.toBeInTheDocument();
+  });
+
+  // ── Intent overlay passthrough ──────────────────────────────────
+  // The handler is intentionally agnostic about intent semantics —
+  // those fields are computed in Rust and rendered by the dialog.
+  // We pin that the handler does not strip, default, or recompute them,
+  // and that `undefined` (legacy snapshot) and an explicit value travel
+  // through unchanged. The actual "X of Y" rendering test lives in
+  // SyncStatusDialog.test.tsx (this test file mocks the dialog).
+  it("passes intent fields through to the dialog when intentActive is true", () => {
+    const snap = visibleSnapshot({
+      intentTotalFiles: 100,
+      intentCompletedFiles: 50,
+      intentTotalBytes: 10_000_000_000,
+      intentCompletedBytes: 5_000_000_000,
+      intentActive: true,
+    });
+    const store = createTestStore([[snapshotAtom, snap]]);
+
+    const { queryByTestId } = render(
+      <Provider store={store}><SyncStatusHandler /></Provider>,
+    );
+
+    const widget = queryByTestId("sync-widget");
+    expect(widget).toBeInTheDocument();
+    expect(widget?.dataset.intentActive).toBe("true");
+    expect(widget?.dataset.intentTotalBytes).toBe("10000000000");
+    expect(widget?.dataset.intentCompletedBytes).toBe("5000000000");
+  });
+
+  it("passes undefined intent fields through when snapshot omits them", () => {
+    // Legacy / pre-login snapshot shape: factory does not populate intent
+    // fields, so they should arrive at the dialog as `undefined`. The
+    // "undefined" string is what our mock writes when the field is absent.
+    const snap = visibleSnapshot();
+    expect(snap.intentActive).toBeUndefined();
+    const store = createTestStore([[snapshotAtom, snap]]);
+
+    const { queryByTestId } = render(
+      <Provider store={store}><SyncStatusHandler /></Provider>,
+    );
+
+    const widget = queryByTestId("sync-widget");
+    expect(widget).toBeInTheDocument();
+    expect(widget?.dataset.intentActive).toBe("undefined");
+    expect(widget?.dataset.intentTotalBytes).toBe("undefined");
   });
 
   it("keeps widget visible when Rust latches widgetVisible across a heartbeat", () => {

--- a/app/(pages)/shares/page.tsx
+++ b/app/(pages)/shares/page.tsx
@@ -52,11 +52,11 @@ import { formatBytes } from "@/lib/utils/formatBytes";
 import { formatRelative } from "@/app/lib/utils/timeRelative";
 import { useWalletAuth } from "@/app/lib/wallet-auth-context";
 import { cn } from "@/lib/utils";
+import { LIVE_DATA_REFRESH_MS } from "@/lib/constants";
 import { pickHistoryRowDisplay } from "./shareRowDisplay";
 
 const SHARES_QUERY_KEY = "shares-list";
 const HISTORY_QUERY_KEY = "shares-history-list";
-const REFRESH_INTERVAL_MS = 30_000;
 
 // Column width percentages. Active Shares has six columns (Name | Link |
 // Size | Created | Expires | actions); History keeps the original five
@@ -103,7 +103,9 @@ export default function MySharesPage() {
     queryKey: [SHARES_QUERY_KEY, polkadotAddress],
     queryFn: () => listShares(),
     enabled: Boolean(polkadotAddress) && shareEnabled,
-    refetchInterval: REFRESH_INTERVAL_MS,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    refetchInterval: LIVE_DATA_REFRESH_MS,
   });
 
   // History is a separate query because the lists rotate at different
@@ -115,7 +117,9 @@ export default function MySharesPage() {
     queryKey: [HISTORY_QUERY_KEY, polkadotAddress],
     queryFn: () => listShareHistory(),
     enabled: Boolean(polkadotAddress) && shareEnabled,
-    refetchInterval: REFRESH_INTERVAL_MS,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    refetchInterval: LIVE_DATA_REFRESH_MS,
   });
 
   const queueRevoke = (token: string) => setTokenPendingRevoke(token);

--- a/app/components/auth/LoginForm.tsx
+++ b/app/components/auth/LoginForm.tsx
@@ -35,10 +35,14 @@ export function LoginForm({
     // hit "Inject", and the app routes through exactly the same Rust logic a
     // real deep link would trigger.
     //
-    // TODO: remove this panel before shipping to production. It's an active-
-    // debugging aid for OAuth recovery. Tracked with the `DEV_OAUTH_INJECTOR`
-    // comment — grep for it when cleaning up.
-    const showDevOAuthInjector = false; // DEV_OAUTH_INJECTOR
+    // Env-gated so a production build can never ship the panel enabled:
+    // the flag is unset in normal builds, so this resolves to `false`.
+    // Enable it for an OAuth/recovery debugging session with
+    //     NEXT_PUBLIC_DEV_OAUTH_INJECTOR=1 pnpm tauri:dev   (or tauri:static)
+    // Next.js inlines NEXT_PUBLIC_* at `next build`, so the comparison is
+    // a compile-time constant — no runtime env access in the static export.
+    // Tracked with the `DEV_OAUTH_INJECTOR` comment — grep for it when cleaning up.
+    const showDevOAuthInjector = process.env.NEXT_PUBLIC_DEV_OAUTH_INJECTOR === "1"; // DEV_OAUTH_INJECTOR
     const [devOAuthUrl, setDevOAuthUrl] = useState("");
     const [devOAuthStatus, setDevOAuthStatus] = useState<string | null>(null);
 

--- a/app/components/billing/CreditsExhaustedBanner.tsx
+++ b/app/components/billing/CreditsExhaustedBanner.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback } from "react";
+import { useAtom } from "jotai";
+import { creditsExhaustedAtom } from "@/lib/store/syncAtoms";
+import { Icons } from "@/components/ui";
+import { openLinkByKey } from "@/lib/utils/links";
+
+/**
+ * Top-of-page banner shown when the sync engine hits an HTTP 402
+ * `InsufficientBalance` failure on one or more files.
+ *
+ * The banner replaces the generic "Sync Failed" toast (which would
+ * mis-attribute the failure to a sync engine bug) with a billing-
+ * specific CTA: "Top up". It is intentionally dismissible per cycle —
+ * the user might be aware of the situation already (e.g. they kicked
+ * off a top-up in the console and don't need a constant reminder).
+ *
+ * Visibility lifecycle (driven by `useCreditsExhausted` writing to the
+ * atom; see that hook for the contract):
+ *
+ *   - `null`           → banner hidden
+ *   - non-null payload → banner shown
+ *   - dismiss click    → atom set to `null` (banner hides until the
+ *                        next 402 event re-raises it)
+ *   - `hcfs_sync_started` for any drive → atom cleared by the hook
+ *
+ * Design parity with `ConflictsBanner` / `MigrationBanner` —
+ * intentionally so: same horizontal toolbar slot, same dismissal
+ * affordance, same visual weight.
+ */
+export default function CreditsExhaustedBanner() {
+  const [info, setInfo] = useAtom(creditsExhaustedAtom);
+
+  const handleTopUp = useCallback(() => {
+    // Reuse the existing CREDITS console link. The plan deliberately
+    // chose not to introduce new top-up logic in-app — the console
+    // already owns that flow and a stub navigation would duplicate it.
+    void openLinkByKey("CREDITS");
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    setInfo(null);
+  }, [setInfo]);
+
+  if (!info) return null;
+
+  // Cents → dollars for display. Integer math kept upstream so the
+  // banner is the only place we cross the lossy boundary. `toFixed(2)`
+  // is the right call here because the source is a Number already and
+  // the magnitude is small (single-dollar to low-thousands range);
+  // arbitrary-precision is unnecessary for display.
+  const balance = (info.balanceCents / 100).toFixed(2);
+  const required = (info.requiredCents / 100).toFixed(2);
+  const fileWord = info.fileCount === 1 ? "file" : "files";
+
+  return (
+    <div className="flex items-center justify-between gap-3 px-4 py-2 mt-2 rounded-lg border border-warning-50/30 bg-warning-50/5">
+      <div className="flex items-center gap-2 min-w-0">
+        <Icons.OctagonAlert className="size-4 text-warning-50 shrink-0" />
+        <span className="text-sm text-grey-10">
+          Out of credits. Need ${required}, have ${balance}. {info.fileCount}{" "}
+          {fileWord} paused.
+        </span>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          onClick={handleTopUp}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-primary-50 text-white hover:bg-primary-40 shadow-outer-action-button transition-colors"
+        >
+          Top up
+        </button>
+        <button
+          onClick={handleDismiss}
+          className="p-1 rounded hover:bg-grey-90 transition-colors"
+          title="Dismiss — banner reappears on the next 402"
+          aria-label="Dismiss credits-exhausted banner"
+        >
+          <Icons.CloseCircle className="size-4 text-grey-40" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/page-sections/files/FilesContainer.tsx
+++ b/app/components/page-sections/files/FilesContainer.tsx
@@ -48,6 +48,7 @@ import {
 import { FileSelectionProvider } from "@/app/contexts/FileSelectionContext";
 import { SyncPausedAlert, IS_SYNC_PAUSED } from "@/components/ui/SyncPausedAlert";
 import { SyncConnectivityAlert } from "@/components/ui/SyncConnectivityAlert";
+import { MetadataStaleAlert } from "@/components/ui/MetadataStaleAlert";
 import { HcfsSetupDialog } from "../settings/HcfsSetupDialog";
 import { MnemonicBackupDialog } from "../settings/MnemonicBackupDialog";
 import {
@@ -906,6 +907,7 @@ const FilesContainer: FC<{ isRecentFiles?: boolean }> = ({ isRecentFiles = false
               on every authenticated route (not just /files). */}
           <div className="mb-4 space-y-2">
             <SyncConnectivityAlert variant={isRecentFiles ? "compact" : "banner"} />
+            {!isRecentFiles && <MetadataStaleAlert label={selectedFolderTab} />}
           </div>
 
           <FilesHeader

--- a/app/components/page-sections/files/files-table/NameCell.test.tsx
+++ b/app/components/page-sections/files/files-table/NameCell.test.tsx
@@ -1,0 +1,149 @@
+// Renders `NameCell` across the four sync-status states that map to a
+// visible icon (`uploading`, `pending`, `downloading`, `failed`) and pins:
+//
+// 1. Only the icon for the active state is in the DOM.
+// 2. The `failed` icon is a settled (non-pulsing) red AlertCircle — distinct
+//    from the in-flight upload spinner. This is the visual seam the 402
+//    fix relies on: a row stuck on `failed` must not keep masquerading as
+//    `uploading` (the pre-fix bug).
+// 3. `failed` reports an accessible `aria-label="Upload failed"` for AT.
+//
+// We don't exercise the row enricher here — that's covered by integration
+// tests against `files-table/index.tsx`. This file pins the icon-switch
+// contract that the enricher depends on.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import NameCell from "./NameCell";
+
+// `next/link` reaches for the router context; replacing it with a plain
+// `<a>` keeps the icon rendering pure and avoids dragging the App Router
+// shim into a leaf-component test.
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    href: string | { pathname: string };
+  } & Record<string, unknown>) => (
+    <a href={typeof href === "string" ? href : href.pathname} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// `useUrlParams` reads from `useSearchParams`/`usePathname` — both unavailable
+// in jsdom without a Next Router. The cell only uses the parameter values
+// for folder navigation, which is orthogonal to the icon assertion.
+vi.mock("@/app/utils/hooks/useUrlParams", () => ({
+  useUrlParams: () => ({
+    getParam: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+// `SharedLinkBadge` does its own atom + Tauri-IPC dance. The icon under
+// test sits next to it but doesn't depend on it; stubbing keeps the test
+// hermetic.
+vi.mock("@/components/page-sections/files/SharedLinkBadge", () => ({
+  default: () => null,
+}));
+
+// Stub the file-type icon to a no-op so we don't pull in the full
+// `getFileIcon` table — the row's leading icon isn't what we're asserting.
+vi.mock("@/lib/utils/fileTypeUtils", () => ({
+  getFileIcon: () => ({
+    icon: ({ className }: { className?: string }) => (
+      <span data-testid="file-icon" className={className} />
+    ),
+    color: "text-grey-50",
+  }),
+}));
+
+// `MiddleTruncatedName` renders the suffix slot (where the sync-status icon
+// lives) inside a span. We pass the suffix through unchanged so the icon is
+// reachable via testing-library queries.
+vi.mock("@/components/ui/MiddleTruncatedName", () => ({
+  default: ({
+    name,
+    suffix,
+  }: {
+    name: string;
+    suffix?: React.ReactNode;
+  }) => (
+    <span>
+      {name}
+      {suffix}
+    </span>
+  ),
+}));
+
+const baseProps = {
+  rawName: "photo.jpg",
+  actualName: "photo.jpg",
+  arionHash: "0xdeadbeef",
+  isAssigned: true,
+  isFolder: false,
+};
+
+describe("NameCell sync-status icon", () => {
+  it("renders a non-pulsing red AlertCircle with the 'Upload failed' label when syncStatus is 'failed'", () => {
+    render(<NameCell {...baseProps} syncStatus="failed" />);
+
+    const failedIcon = screen.getByTestId("sync-status-failed");
+    expect(failedIcon).toBeInTheDocument();
+    expect(failedIcon).toHaveAttribute("aria-label", "Upload failed");
+    // The pulse is reserved for in-flight states; a settled failure must be
+    // visually static so users can tell it isn't recovering on its own.
+    // (SVG `className` is an `SVGAnimatedString`, not a plain string —
+    // `toHaveClass` handles both; `getAttribute("class")` would also work.)
+    expect(failedIcon).not.toHaveClass("animate-pulse");
+    expect(failedIcon).toHaveClass("text-error-70");
+  });
+
+  // Each non-failed state pins BOTH halves: failed icon absent AND the
+  // expected icon for that state present. Without the positive assertion a
+  // future refactor that made `SyncStatusIcon` return `null` unconditionally
+  // would let all four negative tests pass while regressing the entire row.
+  it("routes 'uploading' to the uploading icon, not the failed icon", () => {
+    render(<NameCell {...baseProps} syncStatus="uploading" />);
+
+    expect(screen.queryByTestId("sync-status-failed")).not.toBeInTheDocument();
+    expect(screen.getByTestId("sync-status-uploading")).toBeInTheDocument();
+  });
+
+  it("routes 'downloading' to the downloading icon, not the failed icon", () => {
+    render(<NameCell {...baseProps} syncStatus="downloading" />);
+
+    expect(screen.queryByTestId("sync-status-failed")).not.toBeInTheDocument();
+    expect(screen.getByTestId("sync-status-downloading")).toBeInTheDocument();
+  });
+
+  it("routes 'pending' to the pending icon, not the failed icon", () => {
+    render(<NameCell {...baseProps} syncStatus="pending" />);
+
+    expect(screen.queryByTestId("sync-status-failed")).not.toBeInTheDocument();
+    expect(screen.getByTestId("sync-status-pending")).toBeInTheDocument();
+  });
+
+  // `synced` and `undefined` are the row's null states — they intentionally
+  // render no sync-status icon at all. The broad `/^sync-status-/` regex
+  // catches any future icon leaking into these branches.
+  it("renders no sync-status icon when syncStatus is 'synced'", () => {
+    render(<NameCell {...baseProps} syncStatus="synced" />);
+
+    expect(screen.queryByTestId(/^sync-status-/)).not.toBeInTheDocument();
+  });
+
+  it("renders no sync-status icon when syncStatus is undefined", () => {
+    // Most `FormattedUserFile` rows arrive without a `syncStatus` set; the
+    // icon switch must stay silent in that case so non-synced legacy rows
+    // don't sprout a stray badge.
+    render(<NameCell {...baseProps} syncStatus={undefined} />);
+
+    expect(screen.queryByTestId(/^sync-status-/)).not.toBeInTheDocument();
+  });
+});

--- a/app/components/page-sections/files/files-table/NameCell.tsx
+++ b/app/components/page-sections/files/files-table/NameCell.tsx
@@ -8,9 +8,14 @@ import { buildFolderPath } from "@/app/utils/folderPathUtils";
 import MiddleTruncatedName from "@/components/ui/MiddleTruncatedName";
 import SharedLinkBadge from "@/components/page-sections/files/SharedLinkBadge";
 import * as Tooltip from "@radix-ui/react-tooltip";
-import { ArrowUpFromLine, ArrowDownToLine } from "lucide-react";
+import { ArrowUpFromLine, ArrowDownToLine, AlertCircle } from "lucide-react";
 
-type SyncStatusType = "synced" | "pending" | "uploading" | "downloading" | "unknown" | "excluded";
+// Mirrors `FormattedUserFile.syncStatus`. `failed` is the FE-facing label for a
+// snapshot file whose Rust-side `FileProgressStatus` is `Error` — e.g. an
+// upload that hit HTTP 402 and won't be retried this cycle. We deliberately
+// expose it as a separate status (rather than collapsing into `uploading`) so
+// the icon, tooltip, and pulse semantics stay truthful.
+type SyncStatusType = "synced" | "pending" | "uploading" | "downloading" | "failed" | "unknown" | "excluded";
 
 type NameCellProps = {
   rawName: string;
@@ -34,11 +39,17 @@ type NameCellProps = {
 const SyncStatusIcon: FC<{ status?: SyncStatusType }> = ({ status }) => {
   if (status === "pending" || status === "uploading") {
     const label = status === "uploading" ? "Uploading" : "Pending upload";
+    // Distinct testids per state (not a shared `sync-status-upload`) so the
+    // unit test for `pending` can't accidentally pass if the switch silently
+    // routed `pending` through the `uploading` branch — they share an icon
+    // glyph but mean different things (in-flight vs. queued).
+    const testId = status === "uploading" ? "sync-status-uploading" : "sync-status-pending";
     return (
       <Tooltip.Provider delayDuration={200}>
         <Tooltip.Root>
           <Tooltip.Trigger asChild>
             <ArrowUpFromLine
+              data-testid={testId}
               className={cn(
                 "ml-1.5 size-3.5 flex-shrink-0",
                 status === "uploading" ? "text-primary-50 animate-pulse" : "text-warning-40"
@@ -64,7 +75,10 @@ const SyncStatusIcon: FC<{ status?: SyncStatusType }> = ({ status }) => {
       <Tooltip.Provider delayDuration={200}>
         <Tooltip.Root>
           <Tooltip.Trigger asChild>
-            <ArrowDownToLine className="ml-1.5 size-3.5 flex-shrink-0 text-primary-50 animate-pulse" />
+            <ArrowDownToLine
+              data-testid="sync-status-downloading"
+              className="ml-1.5 size-3.5 flex-shrink-0 text-primary-50 animate-pulse"
+            />
           </Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Content
@@ -73,6 +87,34 @@ const SyncStatusIcon: FC<{ status?: SyncStatusType }> = ({ status }) => {
               sideOffset={4}
             >
               Downloading
+              <Tooltip.Arrow className="fill-white" />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>
+    );
+  }
+  if (status === "failed") {
+    // No `animate-pulse` here: the pulse is reserved for in-flight states.
+    // A static red icon signals a settled failure that won't resolve on its
+    // own (typically 402 Payment Required — the user must top up credits).
+    return (
+      <Tooltip.Provider delayDuration={200}>
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <AlertCircle
+              data-testid="sync-status-failed"
+              aria-label="Upload failed"
+              className="ml-1.5 size-3.5 flex-shrink-0 text-error-70"
+            />
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content
+              side="top"
+              className="z-50 bg-white border border-grey-80 rounded-[0.5rem] px-3 py-2 text-xs font-medium text-grey-40 shadow-lg"
+              sideOffset={4}
+            >
+              Upload failed
               <Tooltip.Arrow className="fill-white" />
             </Tooltip.Content>
           </Tooltip.Portal>

--- a/app/components/page-sections/files/files-table/index.tsx
+++ b/app/components/page-sections/files/files-table/index.tsx
@@ -183,12 +183,19 @@ const FilesTable: FC<FilesTableProps> = memo(
     const actionSignature = useMemo(() => {
       const parts: string[] = [];
       for (const f of snapshot.files) {
+        // Failed rows are actionable even though their status isn't a
+        // transfer-in-flight phase — include them so the enricher memo
+        // re-runs when a row flips from `inProgress` to `error` (e.g. 402).
         const isInFlight =
           f.status !== "completed" &&
+          f.status !== "error" &&
+          (f.action === "upload" || f.action === "download");
+        const isFailed =
+          f.status === "error" &&
           (f.action === "upload" || f.action === "download");
         const isCompletedDownload =
           f.status === "completed" && f.action === "download";
-        if (isInFlight || isCompletedDownload) {
+        if (isInFlight || isFailed || isCompletedDownload) {
           parts.push(`${f.path}|${f.fileName}|${f.status}|${f.action}`);
         }
       }
@@ -199,17 +206,29 @@ const FilesTable: FC<FilesTableProps> = memo(
     const enrichedAllFiles = useMemo(() => {
       if (actionSignature === "") return allFiles;
 
-      // Index by full path (preferred, no collisions) and basename (fallback)
-      const actionByPath = new Map<string, "upload" | "download">();
-      const actionByName = new Map<string, "upload" | "download">();
+      // Index by full path (preferred, no collisions) and basename (fallback).
+      // We track in-flight transfers and per-file failures separately because
+      // they map to distinct row statuses (`uploading`/`downloading` vs
+      // `failed`), and the failure path must NOT be collapsed into "uploading"
+      // — that's the bug this enrichment fixes (a 402'd file would otherwise
+      // render with the upload spinner forever).
+      type ActionKind = "upload" | "download";
+      const actionByPath = new Map<string, ActionKind>();
+      const actionByName = new Map<string, ActionKind>();
+      const failedByPath = new Map<string, ActionKind>();
+      const failedByName = new Map<string, ActionKind>();
       const completedDownloadPaths = new Set<string>();
       const completedDownloadNames = new Set<string>();
 
       for (const f of snapshot.files) {
-        if (f.status !== "completed" && (f.action === "upload" || f.action === "download")) {
+        if (f.action !== "upload" && f.action !== "download") continue;
+        if (f.status === "error") {
+          failedByPath.set(f.path, f.action);
+          failedByName.set(f.fileName, f.action);
+        } else if (f.status !== "completed") {
           actionByPath.set(f.path, f.action);
           actionByName.set(f.fileName, f.action);
-        } else if (f.status === "completed" && f.action === "download") {
+        } else if (f.action === "download") {
           completedDownloadPaths.add(f.path);
           completedDownloadNames.add(f.fileName);
         }
@@ -217,6 +236,11 @@ const FilesTable: FC<FilesTableProps> = memo(
 
       return allFiles.map((file) => {
         const key = file.actualFileName || file.name;
+        // Failed takes precedence over in-flight: a row can't be both
+        // failed and uploading, and the failure is what the user needs to see.
+        if (failedByPath.has(key) || failedByName.has(key)) {
+          return { ...file, syncStatus: "failed" as const };
+        }
         const action = actionByPath.get(key) ?? actionByName.get(key);
         if (action) {
           const liveSyncStatus: FormattedUserFile["syncStatus"] =

--- a/app/components/page-sections/support/TicketMessage.tsx
+++ b/app/components/page-sections/support/TicketMessage.tsx
@@ -22,14 +22,16 @@ const TicketMessage: React.FC<TicketMessageProps> = ({
   const [loadedImages, setLoadedImages] = useState<Set<number>>(new Set());
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString("en-US", {
-      month: "2-digit",
-      day: "2-digit",
-      year: "2-digit",
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    });
+    const d = new Date(dateString);
+    if (isNaN(d.getTime())) return "Invalid Date";
+    const dd = String(d.getDate()).padStart(2, "0");
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const yyyy = String(d.getFullYear());
+    let hours = d.getHours();
+    const minutes = String(d.getMinutes()).padStart(2, "0");
+    const ampm = hours >= 12 ? "pm" : "am";
+    hours = hours % 12 || 12;
+    return `${dd}/${mm}/${yyyy} ${hours}:${minutes} ${ampm}`;
   };
 
   const isImageFile = (filename: string) => {

--- a/app/components/page-sections/support/TicketsTable.tsx
+++ b/app/components/page-sections/support/TicketsTable.tsx
@@ -81,14 +81,16 @@ const TicketsTable: React.FC<TicketsTableProps> = ({
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString("en-US", {
-      month: "2-digit",
-      day: "2-digit",
-      year: "2-digit",
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    });
+    const d = new Date(dateString);
+    if (isNaN(d.getTime())) return "Invalid Date";
+    const dd = String(d.getDate()).padStart(2, "0");
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const yyyy = String(d.getFullYear());
+    let hours = d.getHours();
+    const minutes = String(d.getMinutes()).padStart(2, "0");
+    const ampm = hours >= 12 ? "pm" : "am";
+    hours = hours % 12 || 12;
+    return `${dd}/${mm}/${yyyy} ${hours}:${minutes} ${ampm}`;
   };
 
   const columns = useMemo(

--- a/app/components/splash-screen/index.tsx
+++ b/app/components/splash-screen/index.tsx
@@ -170,8 +170,32 @@ export default function SplashWrapper({
       // when the updater resolves immediately (cached / offline).
       await runWithMinDuration(updateCheckPromise, MIN_PHASE_DURATION);
 
+      // If an update dialog opened, wait for the user to resolve it
+      // (install / skip / cancel) before continuing to the main
+      // phases. The PRIOR code did `return;` here, which left
+      // `setupStartedRef.current` permanently `true` so `runSetupPhases`
+      // never resumed — `setSplashComplete(true)` at the bottom was
+      // never called, and any consumer gated on the atom (historically
+      // `wallet-auth-context.tsx`'s `initSync`) was stranded forever.
+      // Spinning here resumes naturally once `updateDialogOpenRef`
+      // flips, after which the main phases run and the splash
+      // completes normally. The interval is cheap (a single ref read
+      // every 100ms); the cap is a safety net in case the dialog
+      // state somehow gets stuck — at that point we proceed anyway
+      // because the cost of an orphaned splash overlay is worse than
+      // the cost of the main phases running concurrently with a
+      // visible dialog.
+      const DIALOG_WAIT_CAP_MS = 60_000;
+      const dialogWaitStart = Date.now();
+      while (updateDialogOpenRef.current && Date.now() - dialogWaitStart < DIALOG_WAIT_CAP_MS) {
+        await wait(100);
+      }
       if (updateDialogOpenRef.current) {
-        return;
+        console.warn(
+          "[Setup] Update dialog still open after",
+          DIALOG_WAIT_CAP_MS,
+          "ms — proceeding past update-check phase anyway to avoid stranding splash."
+        );
       }
 
       setIsUpdateCheckPhase(false);

--- a/app/components/ui/MetadataStaleAlert.tsx
+++ b/app/components/ui/MetadataStaleAlert.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * Per-drive banner shown when the bounded-retry "first reconcile"
+ * fails to refresh the server's authoritative `remote_timestamps`
+ * map. Surfaces the condition the previous fix-by-logout pattern
+ * silently hid: the "DATE UPLOADED" column may be sparse until a
+ * later sync cycle backfills the missing timestamps.
+ *
+ * Reads `metadataStaleLabelsAtom`, owned by `useMetadataStale`
+ * (mounted via `SyncEventLogger`). The banner self-hides when the
+ * label disappears from the atom — the listener clears entries on
+ * the next `hcfs_activity_updated` event.
+ *
+ * The user has no actionable affordance here (no retry button) —
+ * the next normal sync cycle handles it. The banner exists to
+ * inform, not to gate.
+ */
+
+import React from "react";
+import { useAtomValue } from "jotai";
+import { AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { metadataStaleLabelsAtom } from "@/app/lib/global-atoms/unpinAtoms";
+
+interface MetadataStaleAlertProps {
+  /**
+   * Drive label to check. When `null` (e.g. the "All" tab is
+   * selected), the banner shows if ANY drive is stale, since the
+   * combined view aggregates across all drives.
+   */
+  label: string | null;
+  className?: string;
+}
+
+export const MetadataStaleAlert: React.FC<MetadataStaleAlertProps> = ({
+  label,
+  className,
+}) => {
+  const stale = useAtomValue(metadataStaleLabelsAtom);
+
+  // For a specific drive: show only when that drive is stale.
+  // For the "All" tab (label == null): show whenever any drive is
+  // stale, since the table aggregates entries from all drives.
+  if (label !== null) {
+    if (!stale.has(label)) return null;
+  } else if (stale.size === 0) {
+    return null;
+  }
+
+  const affectedCount = stale.size;
+  const heading =
+    label !== null
+      ? "Couldn't refresh upload dates for this folder"
+      : affectedCount === 1
+        ? "Couldn't refresh upload dates for 1 folder"
+        : `Couldn't refresh upload dates for ${affectedCount} folders`;
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-3 p-3 bg-amber-50 border border-amber-200 rounded-lg",
+        className
+      )}
+      role="status"
+    >
+      <div className="flex-shrink-0 mt-0.5">
+        <AlertCircle className="size-5 text-amber-600" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-amber-800">{heading}</p>
+        <p className="text-xs text-amber-700 mt-1">
+          The &ldquo;DATE UPLOADED&rdquo; column may show &ldquo;—&rdquo; for some files.
+          This clears automatically the next time syncing succeeds.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default MetadataStaleAlert;

--- a/app/lib/constants/index.ts
+++ b/app/lib/constants/index.ts
@@ -1,2 +1,20 @@
 export * from "./urls";
 export const API_BASE_URL = "https://indexer.hippius.network";
+
+/**
+ * Polling cadence for live on-chain / indexer-backed queries (ms).
+ *
+ * The Hippius parachain produces a block every ~6 s and node stats are
+ * pushed every block, so the freshest a client can ever be is one block
+ * old. Polling faster only burns duplicate round-trips for the same
+ * snapshot; polling slower (the old per-hook 30 s) means the home page,
+ * wallet, and shares views lag the chain by up to five blocks.
+ *
+ * Every live query reads this one constant so they cannot drift onto
+ * different poll phases — the cache-key-sharing hooks (shares page +
+ * `useSharedFiles`) in particular relied on two hand-kept copies of the
+ * interval staying equal; one source removes that footgun. Static config
+ * data (VM flavors/images, SSH keys, referrals) deliberately does NOT
+ * use this — it changes on the order of hours, not blocks.
+ */
+export const LIVE_DATA_REFRESH_MS = 6_000;

--- a/app/lib/global-atoms/unpinAtoms.ts
+++ b/app/lib/global-atoms/unpinAtoms.ts
@@ -89,6 +89,26 @@ export const hasConfiguredDrivesAtom = atom((get) => {
 });
 
 /**
+ * Per-drive "metadata stale" set, keyed by drive label.
+ *
+ * A label appears in this map when Rust's `spawn_reconcile_timestamps`
+ * exhausts its retry budget for that drive (every attempt to fetch
+ * the server's authoritative `remote_timestamps` failed). The value
+ * is the short human-readable reason from the backend, suitable for
+ * display under the banner heading.
+ *
+ * The entry self-clears the next time the same label emits
+ * `hcfs_activity_updated` — the assumption being that any successful
+ * cycle has backfilled the missing timestamps. This avoids an
+ * explicit "retry now" channel; the next normal sync handles it.
+ *
+ * Owned by `useMetadataStaleListener`, which is mounted via
+ * `SyncEventLogger`. Frontend code must never mutate this atom from
+ * a click handler — it mirrors backend state.
+ */
+export const metadataStaleLabelsAtom = atom<Map<string, string>>(new Map());
+
+/**
  * Set to `true` when Rust's `restore_session` successfully rehydrated
  * the session but the OS keychain didn't contain the user's BIP-39
  * mnemonic — so `AuthInfo.mnemonic` is `None` and the sync engine is

--- a/app/lib/hooks/__tests__/useSyncEvents.test.tsx
+++ b/app/lib/hooks/__tests__/useSyncEvents.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Provider, createStore } from "jotai";
+import { queryClientAtom } from "jotai-tanstack-query";
+import { QueryClient } from "@tanstack/react-query";
+import React from "react";
+import { useSyncEvents } from "../useSyncEvents";
+
+// ── Tauri mocks ─────────────────────────────────────────────────────
+//
+// `invoke` resolves the get_sync_engine_health call at mount with a
+// minimal stub.  Tests don't care about its shape — they only care
+// about the window-event dispatches.
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve({})),
+}));
+
+// `listen` captures each event's handler so tests can fire them.
+const listenHandlers = new Map<
+  string,
+  (event: { payload: unknown }) => void
+>();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(
+    (event: string, handler: (e: { payload: unknown }) => void) => {
+      listenHandlers.set(event, handler);
+      // Resolve synchronously-ish so the registration loop in the hook
+      // completes within a single microtask flush.
+      return Promise.resolve(() => {
+        listenHandlers.delete(event);
+      });
+    }
+  ),
+}));
+
+const DEBOUNCE_MS = 250;
+
+function renderHookWithStore() {
+  const store = createStore();
+  // The hook reads queryClientAtom; seed it with a real QueryClient so
+  // invalidateQueries calls are no-ops instead of throwing.
+  store.set(queryClientAtom, new QueryClient());
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return renderHook(() => useSyncEvents(), { wrapper });
+}
+
+async function waitForHandlerRegistration() {
+  await waitFor(() => {
+    expect(listenHandlers.has("hcfs_sync_completed")).toBe(true);
+    expect(listenHandlers.has("hcfs_file_transfer_complete")).toBe(true);
+    expect(listenHandlers.has("hcfs_activity_updated")).toBe(true);
+  });
+}
+
+describe("useSyncEvents — debounced sync_files_completed_changed dispatch", () => {
+  let dispatchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    listenHandlers.clear();
+    // Real timers while the hook registers handlers (uses microtasks
+    // and Promise chains).  Switch to fake timers per-test once setup
+    // is complete.
+    vi.useRealTimers();
+    dispatchSpy = vi.spyOn(window, "dispatchEvent");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    dispatchSpy.mockRestore();
+  });
+
+  // Helper: count CustomEvent dispatches for the target event name.
+  function completedDispatchCount() {
+    return dispatchSpy.mock.calls.filter((call) => {
+      const ev = call[0];
+      return ev instanceof CustomEvent && ev.type === "sync_files_completed_changed";
+    }).length;
+  }
+
+  it("coalesces 3 burst events within the window into a single dispatch", async () => {
+    renderHookWithStore();
+    await waitForHandlerRegistration();
+
+    vi.useFakeTimers();
+
+    const completed = listenHandlers.get("hcfs_sync_completed")!;
+    const transfer = listenHandlers.get("hcfs_file_transfer_complete")!;
+    const activity = listenHandlers.get("hcfs_activity_updated")!;
+
+    // Fire three events well within the 250 ms window (total elapsed
+    // before the last event: ~100 ms).
+    act(() => {
+      completed({
+        payload: {
+          label: "default",
+          files_uploaded: 2,
+          files_downloaded: 0,
+          files_deleted_locally: 0,
+          files_deleted_remotely: 0,
+          conflicts_resolved: 0,
+          conflicts_skipped: 0,
+        },
+      });
+    });
+    act(() => { vi.advanceTimersByTime(50); });
+    act(() => { transfer({ payload: {} }); });
+    act(() => { vi.advanceTimersByTime(50); });
+    act(() => { activity({ payload: {} }); });
+
+    // Mid-window: no dispatch yet — trailing-edge debounce.
+    expect(completedDispatchCount()).toBe(0);
+
+    // Each new event resets the timer, so the dispatch fires 250 ms
+    // after the last event (activity), not 250 ms after the first.
+    act(() => { vi.advanceTimersByTime(DEBOUNCE_MS - 1); });
+    expect(completedDispatchCount()).toBe(0);
+
+    act(() => { vi.advanceTimersByTime(1); });
+    expect(completedDispatchCount()).toBe(1);
+  });
+
+  it("does not dispatch a pending event after unmount", async () => {
+    const { unmount } = renderHookWithStore();
+    await waitForHandlerRegistration();
+
+    vi.useFakeTimers();
+
+    const activity = listenHandlers.get("hcfs_activity_updated")!;
+    act(() => { activity({ payload: {} }); });
+
+    // Unmount while the dispatch is still pending in the debounce window.
+    unmount();
+
+    // Drive the clock well past the window — the cleanup must have
+    // cancelled the pending timer, so no dispatch should occur.
+    act(() => { vi.advanceTimersByTime(DEBOUNCE_MS * 4); });
+    expect(completedDispatchCount()).toBe(0);
+  });
+
+  it("each of the three listeners individually triggers a debounced dispatch", async () => {
+    renderHookWithStore();
+    await waitForHandlerRegistration();
+
+    vi.useFakeTimers();
+
+    const fireAndDrain = (handler: (e: { payload: unknown }) => void, payload: unknown) => {
+      act(() => { handler({ payload }); });
+      act(() => { vi.advanceTimersByTime(DEBOUNCE_MS); });
+    };
+
+    fireAndDrain(listenHandlers.get("hcfs_sync_completed")!, {
+      label: "default",
+      files_uploaded: 1,
+      files_downloaded: 0,
+      files_deleted_locally: 0,
+      files_deleted_remotely: 0,
+      conflicts_resolved: 0,
+      conflicts_skipped: 0,
+    });
+    expect(completedDispatchCount()).toBe(1);
+
+    fireAndDrain(listenHandlers.get("hcfs_file_transfer_complete")!, {});
+    expect(completedDispatchCount()).toBe(2);
+
+    fireAndDrain(listenHandlers.get("hcfs_activity_updated")!, {});
+    expect(completedDispatchCount()).toBe(3);
+  });
+});

--- a/app/lib/hooks/__tests__/useTraySync.test.tsx
+++ b/app/lib/hooks/__tests__/useTraySync.test.tsx
@@ -830,3 +830,183 @@ describe("useTraySync — stalled completion shows Sync Complete", () => {
     unmount();
   });
 });
+
+// ── Preparing state transitions ────────────────────────────────────
+//
+// The Rust `apply_preparing_override` flips `widgetState="preparing"`
+// (and `widgetVisible=true`) on otherwise-invisible snapshots when a
+// file-watcher-triggered sync cycle is between `SyncStarted` and its
+// first session-populated snapshot. The tray must:
+//   1. Treat `widgetState==="preparing"` as `isActive` so the icon
+//      switches to the syncing variant.
+//   2. UNLATCH any previously-latched "Sync Complete" so the label
+//      transitions to "⟳ Preparing sync…" immediately instead of
+//      sticking on the old completion for the several seconds
+//      `scan_local_files`+`fetch_remote_state` runs.
+//   3. Render "⟳ Preparing sync…" as the header label.
+//
+// Pre-fix the tray's `isActive` derivation read `effectiveInProgress
+// || inProgressCount > 0 || (totalFiles > 0 && ...)`. For a preparing
+// snapshot all three are false (the session is empty), so `isActive`
+// stayed false, the latched completion never unwound, and the tray
+// read "✓ Sync Complete" while the user was waiting for their newly-
+// dropped folder to start uploading. This test pins the contract by
+// sequencing a completed snapshot then a preparing snapshot and
+// asserting the label flips.
+
+describe("useTraySync — latched complete → preparing transitions", () => {
+  type ListenCallback = (e: { payload: SyncSnapshot }) => void;
+
+  function installInvokeMock() {
+    vi.mocked(invoke).mockImplementation(
+      (async (cmd: string) => {
+        switch (cmd) {
+          case "sp_get_snapshot":
+            return { ...EMPTY_SNAPSHOT };
+          case "get_tray_menu_data":
+            return { loggedIn: true, credits: 100, substrateAddress: "addr" };
+          default:
+            return null;
+        }
+      }) as unknown as typeof invoke
+    );
+  }
+
+  function installListenMock(): { current: ListenCallback | null } {
+    const capture: { current: ListenCallback | null } = { current: null };
+    vi.mocked(listen).mockImplementation(
+      (async (event: string, cb: ListenCallback) => {
+        if (event === "sync_progress_snapshot") {
+          capture.current = cb;
+        }
+        return () => {
+          /* noop unsub */
+        };
+      }) as unknown as typeof listen
+    );
+    return capture;
+  }
+
+  /**
+   * Build a "completed sync" snapshot that the tray will latch (so
+   * subsequent empty snapshots don't immediately tear down the row
+   * set — see the existing latch logic in useTraySync.ts).
+   */
+  function makeCompletedSnapshot(startedAt: number): SyncSnapshot {
+    return {
+      ...EMPTY_SNAPSHOT,
+      isActive: false,
+      totalFiles: 5,
+      completedFiles: 5,
+      failedFiles: 0,
+      overallPercent: 100,
+      progressBytes: 100,
+      bytesExpected: 100,
+      startedAt,
+      completedAt: startedAt + 100,
+      widgetVisible: true,
+      widgetState: "completed",
+      statusVariant: "success",
+      effectiveInProgress: false,
+      effectiveCompleted: true,
+      syncedCount: 5,
+      actualTotal: 5,
+    };
+  }
+
+  /**
+   * Build a "preparing" snapshot — empty session, but the Rust
+   * override has flipped `widgetVisible=true` and
+   * `widgetState="preparing"` so the tray knows a file-watcher cycle
+   * has begun. `startedAt=null` mirrors production: at the moment
+   * `SyncStarted` fires the runner has not yet created a progress
+   * session, so the snapshot has no `started_at` to compare against.
+   */
+  function makePreparingSnapshot(): SyncSnapshot {
+    return {
+      ...EMPTY_SNAPSHOT,
+      isActive: false,
+      totalFiles: 0,
+      completedFiles: 0,
+      failedFiles: 0,
+      overallPercent: 0,
+      progressBytes: 0,
+      bytesExpected: 0,
+      startedAt: null,
+      completedAt: null,
+      widgetVisible: true,
+      widgetState: "preparing",
+      statusVariant: "progress",
+      effectiveInProgress: false,
+      effectiveCompleted: false,
+    };
+  }
+
+  it("flips tray label from '✓ Sync Complete' to '⟳ Preparing sync…' when a Finder-add lands after a completion", async () => {
+    installInvokeMock();
+    const listenerCapture = installListenMock();
+
+    const { unmount } = await setupHook();
+
+    await waitFor(() => {
+      expect(listenerCapture.current).not.toBeNull();
+      expect(menuRegistry.length).toBeGreaterThan(0);
+    });
+
+    const rootMenu = menuRegistry[0];
+
+    // Step 1: drive the tray to the latched-complete state. The
+    // listener fans this snapshot into `updateTraySyncLabel` which
+    // writes the header MenuItem; the latch capture also fires.
+    await act(async () => {
+      listenerCapture.current!({
+        payload: makeCompletedSnapshot(Date.now()),
+      });
+      for (let i = 0; i < 32; i++) {
+        await Promise.resolve();
+      }
+    });
+
+    await waitFor(async () => {
+      const items = await rootMenu.items();
+      const syncItem = items.find(
+        (i) =>
+          typeof i === "object" &&
+          i !== null &&
+          "id" in i &&
+          (i as { id?: string }).id === "sync"
+      ) as { text?: string } | undefined;
+      expect(syncItem?.text).toBe("✓ Sync Complete");
+    });
+
+    // Step 2: simulate the user dropping a folder via Finder. The
+    // Rust bridge fires SyncStarted → preparing.mark_preparing → an
+    // immediate emit_snapshot. That snapshot lands on the listener
+    // here with widgetState="preparing".
+    await act(async () => {
+      listenerCapture.current!({ payload: makePreparingSnapshot() });
+      for (let i = 0; i < 32; i++) {
+        await Promise.resolve();
+      }
+    });
+
+    // Step 3: the tray label must transition. Both invariants are
+    // load-bearing: the new label must be the preparing one, and the
+    // OLD "Sync Complete" must not still be showing (the bug shape
+    // before this fix).
+    await waitFor(async () => {
+      const items = await rootMenu.items();
+      const syncItem = items.find(
+        (i) =>
+          typeof i === "object" &&
+          i !== null &&
+          "id" in i &&
+          (i as { id?: string }).id === "sync"
+      ) as { text?: string } | undefined;
+      expect(syncItem?.text).toBe("⟳ Preparing sync…");
+      expect(syncItem?.text).not.toContain("Sync Complete");
+    });
+
+    unmount();
+  });
+});

--- a/app/lib/hooks/__tests__/useTraySync.test.tsx
+++ b/app/lib/hooks/__tests__/useTraySync.test.tsx
@@ -1009,4 +1009,97 @@ describe("useTraySync — latched complete → preparing transitions", () => {
 
     unmount();
   });
+
+  /**
+   * Regression: a no-op periodic sync cycle (nothing to upload —
+   * `Computed sync plan uploads=0 downloads=0`) emits SyncStarted
+   * (→ a brief "preparing" snapshot) then SyncCompleted, whose bridge
+   * arm clears the preparing set and emits a fresh, fully-idle
+   * snapshot (no session: widgetState!="preparing", totalFiles=0,
+   * completedFiles=0). `isCompleted` is false (nothing was synced) so
+   * the tray falls into the idle-teardown branch. That branch must
+   * also clear the sync HEADER — otherwise the "⟳ Preparing sync…"
+   * text set during the ~1s SyncStarted window is frozen in the tray
+   * forever (re-set, never cleared, every periodic cycle). This is
+   * the user-reported "stuck on Preparing sync… but nothing is
+   * syncing" bug.
+   */
+  function makeIdleSnapshot(): SyncSnapshot {
+    return {
+      ...EMPTY_SNAPSHOT,
+      isActive: false,
+      totalFiles: 0,
+      completedFiles: 0,
+      failedFiles: 0,
+      overallPercent: 0,
+      progressBytes: 0,
+      bytesExpected: 0,
+      startedAt: null,
+      completedAt: null,
+      widgetVisible: false,
+      widgetState: "idle",
+      statusVariant: "progress",
+      effectiveInProgress: false,
+      effectiveCompleted: false,
+    };
+  }
+
+  it("clears the tray header after a no-op cycle's idle snapshot (not stuck on 'Preparing sync…')", async () => {
+    installInvokeMock();
+    const listenerCapture = installListenMock();
+
+    const { unmount } = await setupHook();
+
+    await waitFor(() => {
+      expect(listenerCapture.current).not.toBeNull();
+      expect(menuRegistry.length).toBeGreaterThan(0);
+    });
+
+    const rootMenu = menuRegistry[0];
+
+    // SyncStarted of a no-op cycle → preparing override snapshot.
+    await act(async () => {
+      listenerCapture.current!({ payload: makePreparingSnapshot() });
+      for (let i = 0; i < 32; i++) {
+        await Promise.resolve();
+      }
+    });
+
+    await waitFor(async () => {
+      const items = await rootMenu.items();
+      const syncItem = items.find(
+        (i) =>
+          typeof i === "object" &&
+          i !== null &&
+          "id" in i &&
+          (i as { id?: string }).id === "sync"
+      ) as { text?: string } | undefined;
+      expect(syncItem?.text).toBe("⟳ Preparing sync…");
+    });
+
+    // SyncCompleted of the no-op cycle → bridge cleared preparing and
+    // emitted a fully-idle snapshot. The tray must remove the sync
+    // header (no "sync" item), exactly as the logout cleanup path
+    // does via updateTraySyncLabel(null).
+    await act(async () => {
+      listenerCapture.current!({ payload: makeIdleSnapshot() });
+      for (let i = 0; i < 32; i++) {
+        await Promise.resolve();
+      }
+    });
+
+    await waitFor(async () => {
+      const items = await rootMenu.items();
+      const syncItem = items.find(
+        (i) =>
+          typeof i === "object" &&
+          i !== null &&
+          "id" in i &&
+          (i as { id?: string }).id === "sync"
+      ) as { text?: string } | undefined;
+      expect(syncItem).toBeUndefined();
+    });
+
+    unmount();
+  });
 });

--- a/app/lib/hooks/api/useAddCreditEvent.ts
+++ b/app/lib/hooks/api/useAddCreditEvent.ts
@@ -1,4 +1,5 @@
 import { keepPreviousData, UseQueryOptions, UseQueryResult } from "@tanstack/react-query";
+import { LIVE_DATA_REFRESH_MS } from "@/lib/constants";
 import { useInvokeQuery } from "./useInvokeQuery";
 
 export interface CreditEventObject {
@@ -31,7 +32,12 @@ export default function useAddCreditEvent(
       limit,
     }),
     options: {
-      refetchInterval: 30000,
+      // Add-credit events land one per block; poll at block cadence and
+      // keep polling when the window is backgrounded so a top-up made
+      // elsewhere shows up without refocusing the app.
+      staleTime: 0,
+      refetchOnWindowFocus: true,
+      refetchInterval: LIVE_DATA_REFRESH_MS,
       refetchIntervalInBackground: true,
       placeholderData: keepPreviousData,
       ...options,

--- a/app/lib/hooks/api/useDriveCreditsTotal.ts
+++ b/app/lib/hooks/api/useDriveCreditsTotal.ts
@@ -1,3 +1,4 @@
+import { LIVE_DATA_REFRESH_MS } from "@/lib/constants";
 import { useInvokeQuery } from "./useInvokeQuery";
 
 /**
@@ -29,7 +30,13 @@ export function useDriveCreditsTotal(options?: { enabled?: boolean }) {
     command: "get_drive_credits_total",
     queryKey: (addr) => [DRIVE_CREDITS_TOTAL_QUERY_KEY, addr],
     options: {
-      staleTime: 60_000,
+      // Credits are consumed on-chain every block; staleTime 0 + a
+      // block-cadence poll keeps the "Total Credit Used" tile in step
+      // with the storage tile so the home page never shows a stale
+      // total next to a fresh size.
+      staleTime: 0,
+      refetchOnWindowFocus: true,
+      refetchInterval: LIVE_DATA_REFRESH_MS,
       enabled: options?.enabled ?? true,
     },
   });

--- a/app/lib/hooks/api/useDriveStorageStats.ts
+++ b/app/lib/hooks/api/useDriveStorageStats.ts
@@ -1,3 +1,4 @@
+import { LIVE_DATA_REFRESH_MS } from "@/lib/constants";
 import { useInvokeQuery } from "./useInvokeQuery";
 
 /**
@@ -28,19 +29,16 @@ export function useDriveStorageStats() {
     command: "get_drive_storage_stats",
     queryKey: (addr) => [DRIVE_STORAGE_STATS_QUERY_KEY, addr],
     options: {
-      // The indexer ingests new shards asynchronously and can run
-      // hours behind the chain when load spikes (observed 26h on
-      // 2026-05-06). We can't fix the lag, but we can make sure the
-      // tile is never the bottleneck once the indexer catches up:
-      //   * staleTime: 0 — every refetch trigger actually refetches.
-      //   * refetchOnWindowFocus — refocusing the desktop after a
-      //     break pulls fresh totals without a manual reload.
-      //   * refetchInterval: 30 s — gentle background poll so an
-      //     idle home page eventually shows the new numbers without
-      //     the user touching anything.
+      // The indexer ingests new shards asynchronously and can run hours
+      // behind the chain when load spikes (observed 26h on 2026-05-06).
+      // We can't fix the lag, but the tile must never be the bottleneck
+      // once the indexer catches up: staleTime 0 so every trigger
+      // refetches, focus refetch for the desktop-resume case, and a
+      // block-cadence poll (LIVE_DATA_REFRESH_MS) so an idle home page
+      // shows new totals within one block of the indexer catching up.
       staleTime: 0,
       refetchOnWindowFocus: true,
-      refetchInterval: 30_000,
+      refetchInterval: LIVE_DATA_REFRESH_MS,
     },
   });
 }

--- a/app/lib/hooks/api/useHippiusBalance.ts
+++ b/app/lib/hooks/api/useHippiusBalance.ts
@@ -1,3 +1,4 @@
+import { LIVE_DATA_REFRESH_MS } from "@/lib/constants";
 import { useInvokeQuery } from "./useInvokeQuery";
 
 /**
@@ -42,7 +43,11 @@ export function useHippiusBalance() {
     queryKey: (addr) => ["hippius-balance", addr],
     params: (polkadotAddress) => ({ address: polkadotAddress }),
     options: {
-      refetchInterval: 30_000,
+      // Balance changes every block (transfers, staking, fees); poll at
+      // block cadence so the wallet header tracks the chain.
+      staleTime: 0,
+      refetchOnWindowFocus: true,
+      refetchInterval: LIVE_DATA_REFRESH_MS,
       select: (balance) => {
         try {
           return {

--- a/app/lib/hooks/api/useMarketplaceCredits.ts
+++ b/app/lib/hooks/api/useMarketplaceCredits.ts
@@ -3,6 +3,7 @@ import {
   UseQueryResult,
   keepPreviousData,
 } from "@tanstack/react-query";
+import { LIVE_DATA_REFRESH_MS } from "@/lib/constants";
 import { useInvokeQuery } from "./useInvokeQuery";
 
 // Define types based on the indexer API response
@@ -65,6 +66,12 @@ export default function useMarketplaceCredits(
       limit,
     }),
     options: {
+      // Wallet-wide marketplace credit feed: same block-cadence poll as
+      // the drive-scoped tile so chart and tile never disagree. Caller
+      // `options` still win via the trailing spread.
+      staleTime: 0,
+      refetchOnWindowFocus: true,
+      refetchInterval: LIVE_DATA_REFRESH_MS,
       select: (data) => {
         return data.events.map((event) => ({
           blockNumber: event.block_number,

--- a/app/lib/hooks/use-user-files/index.ts
+++ b/app/lib/hooks/use-user-files/index.ts
@@ -31,7 +31,11 @@ export type FormattedUserFile = {
   parentFolderId?: string;
   parentFolderName?: string;
   mainReqHash: string;
-  syncStatus?: "synced" | "pending" | "uploading" | "downloading" | "unknown" | "excluded";
+  // `failed` is set by the files-table row enricher when the live sync
+  // snapshot reports `status === "error"` for the matching file (e.g. 402
+  // Payment Required during upload). It keeps the row visually distinct from
+  // an in-flight upload so a stuck failure can't keep masquerading as progress.
+  syncStatus?: "synced" | "pending" | "uploading" | "downloading" | "failed" | "unknown" | "excluded";
   label?: string;
   fileCount?: number;
 };

--- a/app/lib/hooks/useCreditsExhausted.ts
+++ b/app/lib/hooks/useCreditsExhausted.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSetAtom } from "jotai";
+import {
+  creditsExhaustedAtom,
+  type CreditsExhaustedInfo,
+} from "@/lib/store/syncAtoms";
+import { registerTauriListeners } from "@/lib/utils/tauriListeners";
+
+/**
+ * Subscribes to the `hcfs_credits_exhausted` Tauri event and writes
+ * payloads into `creditsExhaustedAtom`, the single source of truth for
+ * the `CreditsExhaustedBanner`.
+ *
+ * Auto-dismiss policy: a fresh `hcfs_sync_started` event clears the
+ * atom (and therefore the banner) so a new cycle starts with no stale
+ * 402 banner from a previous one. The user can also dismiss manually
+ * — that path lives in the banner component (it sets the atom to
+ * `null`). Either way, a subsequent 402 in a new cycle re-raises the
+ * banner, matching the per-cycle ephemerality contract documented in
+ * `syncAtoms.ts`.
+ *
+ * Mount once at the top of the authenticated layout (alongside
+ * `SyncEventLogger`). Multiple mounts would duplicate the listeners
+ * and write the atom twice per event — annoying but not incorrect;
+ * still, prefer a single mount.
+ */
+export function useCreditsExhausted(): void {
+  const setCreditsExhausted = useSetAtom(creditsExhaustedAtom);
+
+  useEffect(() => {
+    const { cleanup } = registerTauriListeners([
+      [
+        "hcfs_credits_exhausted",
+        (event) => {
+          // Payload is shaped by the Rust `CreditsExhaustedPayload`
+          // (camelCase via serde). Trust the wire format; the Rust
+          // side has a regression test
+          // (`payload_serialises_to_camel_case_json`) pinning it.
+          setCreditsExhausted(event.payload as CreditsExhaustedInfo);
+        },
+      ],
+      [
+        "hcfs_sync_started",
+        () => {
+          // A fresh cycle for any drive clears the banner. The next
+          // 402 in this or another drive's cycle will re-raise it
+          // with `fileCount = 1` (the Rust bridge clears its running
+          // counter on `SyncStarted`, so the values stay consistent).
+          setCreditsExhausted(null);
+        },
+      ],
+    ]);
+
+    return cleanup;
+  }, [setCreditsExhausted]);
+}

--- a/app/lib/hooks/useHcfsSync.ts
+++ b/app/lib/hooks/useHcfsSync.ts
@@ -12,6 +12,7 @@ import { listen } from "@tauri-apps/api/event";
 import { migrationLockAtom } from "../global-atoms/migrationAtoms";
 import { appStore } from "@/lib/store/jotaiStore";
 import { isNotReady } from "../utils/dispatchTauriError";
+import { invokeWithTimeout } from "../utils/invokeWithTimeout";
 
 export interface UseHcfsSyncResult {
   tryInitializeSync: (accountId: string, label: string, mnemonic?: string) => Promise<boolean>;
@@ -219,10 +220,20 @@ export async function tryAutoInitSync(
   // than necessary.
   const attempt = async (): Promise<"retry" | boolean> => {
     try {
-      const result = await invoke<AutoInitResult>("auto_init_sync", {
-        accountId,
-        mnemonic: null,
-      });
+      // 15s wall-clock cap per attempt. `auto_init_sync_inner`
+      // contains its own bounded operations (HCFS config read,
+      // credit check, per-drive init fan-out), but a deadlock in
+      // any one of those would otherwise leave this promise
+      // pending forever — and the retry ladder ABOVE relies on
+      // `attempt()` returning so it can decide whether to wait for
+      // `hippius_auth_ready` and try again. With the cap, the worst
+      // case is 3 timeouts (~45s) and a clean false return; without
+      // it, the worst case is "never returns".
+      const result = await invokeWithTimeout<AutoInitResult>(
+        "auto_init_sync",
+        { accountId, mnemonic: null },
+        15_000,
+      );
 
       // Per-drive Active status is emitted by Rust from `auto_init_sync`
       // for each successful drive init — useDriveStatuses picks them up
@@ -231,6 +242,14 @@ export async function tryAutoInitSync(
 
       return result.anyInitialized;
     } catch (err) {
+      // Treat timeout the same as a retryable transient failure:
+      // the next attempt may succeed if the underlying hang clears
+      // (e.g. a Rust-side lock that was briefly held). Bail terminal
+      // only after the full retry budget is exhausted.
+      if (err instanceof Error && err.message.endsWith("timed out")) {
+        console.warn("[AutoSync] auto_init_sync timed out — will retry");
+        return "retry";
+      }
       // `MasterMnemonicUnrecoverable` is the specific signal that auth
       // state hasn't been populated yet. Any other error (insufficient
       // credits, validation, network) is terminal and must not retry.

--- a/app/lib/hooks/useMetadataStale.ts
+++ b/app/lib/hooks/useMetadataStale.ts
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * Mirror Rust's per-drive "metadata stale" state.
+ *
+ * Rust's `spawn_reconcile_timestamps` (in `sync/lifecycle.rs`) emits
+ * `hcfs_metadata_stale` when its bounded-retry reconcile fails for a
+ * drive — typically because the server was unreachable across all
+ * attempts at drive registration. The drive itself stays usable; only
+ * the "DATE UPLOADED" column may be sparse until a later sync cycle
+ * backfills it.
+ *
+ * The banner self-clears when the same drive next emits
+ * `hcfs_activity_updated`. `ACTIVITY_UPDATED` fires after any
+ * successful manifest fetch (including a sync cycle's own
+ * `fetch_remote_state`), so the staleness assumption inverts
+ * automatically — no explicit "retry succeeded" event needed.
+ *
+ * Mount this hook exactly once at the protected layout root via
+ * `SyncEventLogger`. It owns `metadataStaleLabelsAtom` — frontend
+ * code must never mutate that atom directly.
+ */
+
+import { useEffect } from "react";
+import { useSetAtom } from "jotai";
+import { listen } from "@tauri-apps/api/event";
+import { metadataStaleLabelsAtom } from "@/app/lib/global-atoms/unpinAtoms";
+
+const METADATA_STALE = "hcfs_metadata_stale";
+const ACTIVITY_UPDATED = "hcfs_activity_updated";
+
+interface MetadataStalePayload {
+  label: string;
+  reason: string;
+}
+
+export function useMetadataStale() {
+  const setStale = useSetAtom(metadataStaleLabelsAtom);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlistenStale: (() => void) | null = null;
+    let unlistenActivity: (() => void) | null = null;
+
+    (async () => {
+      // 1. METADATA_STALE — add the label with the failure reason.
+      const staleHandle = await listen<MetadataStalePayload>(
+        METADATA_STALE,
+        (event) => {
+          if (cancelled) return;
+          setStale((prev) => {
+            const next = new Map(prev);
+            next.set(event.payload.label, event.payload.reason);
+            return next;
+          });
+        }
+      );
+      if (cancelled) {
+        staleHandle();
+        return;
+      }
+      unlistenStale = staleHandle;
+
+      // 2. ACTIVITY_UPDATED — clear the stale entry for any label whose
+      //    activity changed. The Rust event currently has no payload
+      //    (it's a "kick" signal), so we conservatively clear the
+      //    entire map. In practice only a successful reconcile or sync
+      //    cycle emits this, so clearing all entries on any kick is
+      //    the right behavior: each cleared entry will re-fire its
+      //    METADATA_STALE event on the next bounded-retry failure.
+      const activityHandle = await listen(ACTIVITY_UPDATED, () => {
+        if (cancelled) return;
+        setStale((prev) => {
+          if (prev.size === 0) return prev;
+          return new Map();
+        });
+      });
+      if (cancelled) {
+        activityHandle();
+        return;
+      }
+      unlistenActivity = activityHandle;
+    })();
+
+    return () => {
+      cancelled = true;
+      if (unlistenStale) unlistenStale();
+      if (unlistenActivity) unlistenActivity();
+    };
+  }, [setStale]);
+}

--- a/app/lib/hooks/useSharedFiles.ts
+++ b/app/lib/hooks/useSharedFiles.ts
@@ -28,11 +28,9 @@ import { useAtomValue } from "jotai";
 import { listShares, type ShareSummary } from "@/app/lib/tauri/shares";
 import { shareFeatureEnabledAtom } from "@/app/lib/global-atoms/sharesAtoms";
 import { useWalletAuth } from "@/app/lib/wallet-auth-context";
+import { LIVE_DATA_REFRESH_MS } from "@/lib/constants";
 
 const SHARES_QUERY_KEY = "shares-list";
-// Match the /shares page so the cache is genuinely shared. Bumping
-// either side without the other risks two parallel polls.
-const REFRESH_INTERVAL_MS = 30_000;
 
 type SharedIndex = Map<string, Map<string, ShareSummary[]>>;
 
@@ -73,7 +71,12 @@ export function useSharedFiles(): UseSharedFilesResult {
     queryKey: [SHARES_QUERY_KEY, polkadotAddress],
     queryFn: () => listShares(),
     enabled: Boolean(polkadotAddress) && shareEnabled,
-    refetchInterval: REFRESH_INTERVAL_MS,
+    // Shares the cache key with the /shares page. Both read the one
+    // LIVE_DATA_REFRESH_MS constant, so they can no longer drift onto
+    // two parallel polls the way two hand-kept copies could.
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    refetchInterval: LIVE_DATA_REFRESH_MS,
     select: buildIndex,
   });
 

--- a/app/lib/hooks/useStaking.ts
+++ b/app/lib/hooks/useStaking.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useWalletAuth } from '@/app/lib/wallet-auth-context';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { invoke } from '@tauri-apps/api/core';
+import { LIVE_DATA_REFRESH_MS } from '@/lib/constants';
 
 interface UnbondingPeriod {
     /** Raw planck amount as a decimal-digit string (full precision). */
@@ -59,7 +60,12 @@ export const useStaking = () => {
     const { data, isLoading, error, refetch } = useQuery<StakingInfoResult>({
         queryKey: ['staking-info', polkadotAddress],
         enabled: !!polkadotAddress,
-        refetchInterval: 30_000,
+        // Bonded/rewards/unbonding move every block; poll at block
+        // cadence so stake screens track the chain in step with the
+        // wallet balance (which shares the same constant).
+        staleTime: 0,
+        refetchOnWindowFocus: true,
+        refetchInterval: LIVE_DATA_REFRESH_MS,
         queryFn: () => invoke<StakingInfoResult>('get_staking_info'),
     });
 

--- a/app/lib/hooks/useSyncEvents.ts
+++ b/app/lib/hooks/useSyncEvents.ts
@@ -41,19 +41,39 @@ export function useSyncEvents() {
     let cancelled = false;
     const unsubs: (() => void)[] = [];
 
-    // Debounced recent-files refresh: when individual files finish
-    // uploading/downloading, schedule a refresh after 2 s of quiet.
-    let fileCompletionTimer: ReturnType<typeof setTimeout> | null = null;
-    const scheduleRecentFilesRefresh = () => {
-      if (fileCompletionTimer) clearTimeout(fileCompletionTimer);
-      fileCompletionTimer = setTimeout(() => {
-        fileCompletionTimer = null;
+    // Coalesced "files completed" dispatch (fixes Bug 3 — refresh flicker).
+    //
+    // Three backend events can each trigger a file-list refetch:
+    //   - hcfs_sync_completed         (whole-cycle summary)
+    //   - hcfs_file_transfer_complete (per-file finish)
+    //   - hcfs_activity_updated       (rename / metadata change)
+    //
+    // When a sync cycle finishes, all three can arrive within a few
+    // milliseconds.  Dispatching the window event three times re-runs
+    // the row enricher in `use-recent-files` / `use-user-files` three
+    // times, which the user sees as a visible flicker.  A trailing-
+    // edge 250 ms debounce collapses any burst into a single dispatch
+    // while still being fast enough to feel instantaneous.
+    let pendingDispatchTimer: ReturnType<typeof setTimeout> | null = null;
+    // Carry the largest filesCompleted seen during the burst forward
+    // to the single coalesced dispatch.  `hcfs_activity_updated` reports
+    // 0, but if a sibling `hcfs_sync_completed` reported N>0 we want
+    // the consumer to see N rather than have it overwritten by 0.
+    let pendingFilesCompleted = 0;
+    const DEBOUNCE_MS = 250;
+    const scheduleCompletedDispatch = (filesCompleted: number) => {
+      pendingFilesCompleted = Math.max(pendingFilesCompleted, filesCompleted);
+      if (pendingDispatchTimer) clearTimeout(pendingDispatchTimer);
+      pendingDispatchTimer = setTimeout(() => {
+        const total = pendingFilesCompleted;
+        pendingDispatchTimer = null;
+        pendingFilesCompleted = 0;
         window.dispatchEvent(
           new CustomEvent("sync_files_completed_changed", {
-            detail: { filesCompleted: 1 },
+            detail: { filesCompleted: total },
           })
         );
-      }, 2000);
+      }, DEBOUNCE_MS);
     };
 
     // Query current health state on mount (backend may already be running)
@@ -80,22 +100,14 @@ export function useSyncEvents() {
             p.files_deleted_locally +
             p.files_deleted_remotely;
 
-          // Cancel the debounced per-file refresh — the full sync
-          // completion below supersedes it.
-          if (fileCompletionTimer) {
-            clearTimeout(fileCompletionTimer);
-            fileCompletionTimer = null;
-          }
-
           // Always dispatch so file listings refresh metadata (arion
           // hashes, sync status, timestamps) even when no files were
           // transferred — the first sync after login typically has
-          // zero transfers but populates server-side metadata.
-          window.dispatchEvent(
-            new CustomEvent("sync_files_completed_changed", {
-              detail: { filesCompleted: totalCompleted },
-            })
-          );
+          // zero transfers but populates server-side metadata.  Routed
+          // through the coalescing scheduler so a near-simultaneous
+          // hcfs_file_transfer_complete or hcfs_activity_updated does
+          // not produce a second refetch.
+          scheduleCompletedDispatch(totalCompleted);
 
           if (totalCompleted > 0) {
             queryClient.invalidateQueries({
@@ -103,21 +115,16 @@ export function useSyncEvents() {
             });
           }
         }],
-        // Refresh recent files when individual files finish syncing.
-        // Rust emits this event when bytes == total — no byte-count
-        // interpretation needed in TypeScript.
+        // Per-file completion — Rust emits this when bytes == total.
+        // Coalesced with the rest so a multi-file batch produces one
+        // refetch, not one per file.
         ["hcfs_file_transfer_complete", () => {
-          scheduleRecentFilesRefresh();
+          scheduleCompletedDispatch(1);
         }],
-        // Activity updated (e.g. file renamed on disk) — dispatch
-        // immediately so recent files reflect the new name without
-        // the 2-second debounce used for upload/download completion.
+        // Activity updated (e.g. file renamed on disk) — coalesced
+        // with siblings so a sync-completed burst doesn't flicker.
         ["hcfs_activity_updated", () => {
-          window.dispatchEvent(
-            new CustomEvent("sync_files_completed_changed", {
-              detail: { filesCompleted: 0 },
-            })
-          );
+          scheduleCompletedDispatch(0);
         }],
         // Connectivity health updates
         ["hcfs_connectivity_changed", (e) => {
@@ -152,7 +159,9 @@ export function useSyncEvents() {
 
     return () => {
       cancelled = true;
-      if (fileCompletionTimer) clearTimeout(fileCompletionTimer);
+      // Drop any pending debounced dispatch so an unmount mid-burst
+      // doesn't fire a refetch against a stale store or torn-down hook.
+      if (pendingDispatchTimer) clearTimeout(pendingDispatchTimer);
       unsubs.forEach((u) => u());
     };
   }, [setSyncEngineHealthAtom, queryClient]);

--- a/app/lib/hooks/useTraySync.ts
+++ b/app/lib/hooks/useTraySync.ts
@@ -1053,7 +1053,18 @@ function startSyncActivityWatcher() {
       lastSyncSummarySignature = signature;
 
       if (!isActive && !effectiveCompleted && effectiveDeleteCount === 0) {
-        // No sync activity and no recent deletes — remove summary rows and reset icon
+        // No sync activity and no recent deletes — remove summary rows,
+        // the sync header, and reset the icon.
+        //
+        // Clearing the header (SYNC_ID item) here is load-bearing: a
+        // no-op periodic cycle emits SyncStarted → a ~1s "preparing"
+        // snapshot that sets the header to "⟳ Preparing sync…", then
+        // SyncCompleted whose idle snapshot lands here. Without this
+        // updateTraySyncLabel(null) the header text is never cleared
+        // (the detail-row removals below don't touch SYNC_ID), so the
+        // tray is frozen on "Preparing sync…" forever even though
+        // nothing is syncing. Mirrors the logout-cleanup path.
+        await updateTraySyncLabel(null);
         if (syncProgressItem) {
           try { await menu.remove(syncProgressItem); } catch { /* already removed */ }
           syncProgressItem = null;

--- a/app/lib/hooks/useTraySync.ts
+++ b/app/lib/hooks/useTraySync.ts
@@ -985,7 +985,16 @@ function startSyncActivityWatcher() {
       // uses `effectiveInProgress` / `effectiveCompleted` for the same
       // reason — see `SyncStatusDialog.test.tsx:215` and the design
       // note in `CLAUDE.md` ("Stalled completion fixup").
-      const isActive = progress.effectiveInProgress ||
+      //
+      // `isPreparing` covers the file-watcher-triggered window between
+      // `SyncStarted` and the first session-populated snapshot. Rust
+      // sets `widgetState="preparing"` in `progress.rs::apply_preparing_override`;
+      // including it in `isActive` here makes the tray icon switch to
+      // syncing immediately when the user drops a folder via Finder,
+      // not only after `on_sync_plan_ready` fires several seconds later.
+      const isPreparing = progress.widgetState === "preparing";
+      const isActive = isPreparing ||
+        progress.effectiveInProgress ||
         inProgressCount > 0 ||
         (progress.totalFiles > 0 && progress.completedFiles < progress.totalFiles && progress.failedFiles === 0);
       const hasFailed = progress.failedFiles > 0;
@@ -1003,11 +1012,18 @@ function startSyncActivityWatcher() {
         latchedComplete = true;
         latchedSnapshot = progress;
       }
-      // Unlatch when a NEW session becomes active AND has real files.
-      // The sync loop creates empty sessions (totalFiles=0) between real
-      // sync cycles — unlatching for those would flash the tray state
-      // before the next no-op cycle completes with 0 files.
-      if (isActive && latchedComplete && progress.startedAt !== null && progress.startedAt !== latchedSnapshot?.startedAt && progress.totalFiles > 0) {
+      // Unlatch when a NEW session becomes active AND has real files,
+      // OR when we enter preparing (file-watcher-initiated cycles flip
+      // straight from completed-latched to preparing with no
+      // intermediate files-present state; without this branch the tray
+      // would stay on "Sync Complete" until plan_ready fires several
+      // seconds later instead of immediately switching to
+      // "Preparing sync…"). For preparing the startedAt check is
+      // skipped — the snapshot's session may not have any startedAt
+      // yet at the moment of the preparing flip, so requiring a
+      // distinct value would block the unlatch.
+      if (isActive && latchedComplete && (isPreparing
+        || (progress.startedAt !== null && progress.startedAt !== latchedSnapshot?.startedAt && progress.totalFiles > 0))) {
         latchedComplete = false;
         latchedSnapshot = null;
       }
@@ -1016,9 +1032,11 @@ function startSyncActivityWatcher() {
       // Don't switch away from latched snapshot for empty active sessions
       // (totalFiles=0, before on_sync_plan_ready) — they'd cause a brief
       // flicker in the tray between "Sync Complete" and an empty state.
+      // Preparing is the one empty-session shape we DO want to surface
+      // (the user just dropped a folder; they need feedback now).
       const isNewSessionWithFiles = isActive && progress.startedAt !== null
         && progress.startedAt !== latchedSnapshot?.startedAt && progress.totalFiles > 0;
-      const effectiveCompleted = isCompleted || (latchedComplete && !isNewSessionWithFiles);
+      const effectiveCompleted = isCompleted || (latchedComplete && !isPreparing && !isNewSessionWithFiles);
       const effectiveSnapshot = effectiveCompleted && !isCompleted && latchedSnapshot
         ? latchedSnapshot
         : progress;

--- a/app/lib/hooks/useTraySync.ts
+++ b/app/lib/hooks/useTraySync.ts
@@ -1107,7 +1107,15 @@ function startSyncActivityWatcher() {
               ? `${progress.completedFiles} of ${progress.totalFiles} ${progress.totalFiles === 1 ? 'file' : 'files'} synced`
               : "Preparing files…";
           }
-          if (progress.bytesExpected > 0) {
+          // Prefer the intent overlay's "X of Y" while the user-dragged
+          // batch is in flight — this matches what the user expects to
+          // see ("I added 10 GB; 5 GB done"), unlike the per-cycle bytes
+          // which restart each sync attempt. `??` (not `||`) preserves
+          // the 0-vs-undefined distinction: an explicit `intentTotalBytes: 0`
+          // fails the `> 0` guard and we fall through to the per-cycle line.
+          if (progress.intentActive && (progress.intentTotalBytes ?? 0) > 0) {
+            sizeText = `${formatBytes(progress.intentCompletedBytes ?? 0)} of ${formatBytes(progress.intentTotalBytes ?? 0)}`;
+          } else if (progress.bytesExpected > 0) {
             sizeText = `${formatBytes(progress.progressBytes)} / ${formatBytes(progress.bytesExpected)}`;
           }
         } else if (effectiveCompleted && (effectiveSnapshot.failedFiles > 0)) {

--- a/app/lib/polkadot-api-context/index.tsx
+++ b/app/lib/polkadot-api-context/index.tsx
@@ -29,13 +29,33 @@ export function PolkadotApiProvider({ children }: { children: ReactNode }) {
 
     setState((prev) => ({ ...prev, isConnecting: true }));
 
-    // Start the Rust block subscription
-    invoke("start_block_subscription").catch((err) => {
-      console.warn("[PolkadotApi] Failed to start block subscription:", err);
-      if (!destroyed) {
-        setState((prev) => ({ ...prev, isConnecting: false }));
-      }
-    });
+    // Start the Rust block subscription. `isConnecting` is also
+    // cleared by:
+    //
+    // - the `.catch` below, if the IPC itself failed
+    // - the `block_number_updated` listener, if at least one finalized
+    //   block has arrived from the subscription
+    //
+    // Neither of those clears triggers when the IPC succeeds (so no
+    // catch) but the subscription stays silent (no blocks for a long
+    // window, e.g. the WS connected but the chain hasn't produced a
+    // new finalized block yet). The UI would then sit on "Connecting"
+    // indefinitely. Clearing `isConnecting` on successful IPC return
+    // collapses the steady "connected, no block yet" state into the
+    // post-connect view; `isConnected` correctly stays false until
+    // the listener flips it.
+    invoke("start_block_subscription")
+      .then(() => {
+        if (!destroyed) {
+          setState((prev) => ({ ...prev, isConnecting: false }));
+        }
+      })
+      .catch((err) => {
+        console.warn("[PolkadotApi] Failed to start block subscription:", err);
+        if (!destroyed) {
+          setState((prev) => ({ ...prev, isConnecting: false }));
+        }
+      });
 
     // Listen for block updates from Rust
     listen<BlockUpdate>("block_number_updated", (e) => {

--- a/app/lib/store/syncAtoms.ts
+++ b/app/lib/store/syncAtoms.ts
@@ -58,3 +58,31 @@ export interface FailedFileInfo {
 
 /** Files that have repeatedly failed to sync (null when no failures at threshold). */
 export const failedFilesAtom = atom<FailedFileInfo[] | null>(null);
+
+/**
+ * Payload of the `hcfs_credits_exhausted` Tauri event. Mirrors the Rust
+ * `CreditsExhaustedPayload` (camelCase via serde). `balanceCents` and
+ * `requiredCents` are integers in cents — the FE divides by 100 only at
+ * the render site so arithmetic stays loss-free.
+ */
+export interface CreditsExhaustedInfo {
+  label: string;
+  balanceCents: number;
+  requiredCents: number;
+  /** Running count of 402'd files in the current sync cycle. */
+  fileCount: number;
+}
+
+/**
+ * Latest `hcfs_credits_exhausted` payload, or `null` when the banner
+ * should be hidden (no 402 yet this session, dismissed by the user, or
+ * cleared by a fresh `hcfs_sync_started`). The banner reads this atom;
+ * `useCreditsExhausted` is the only writer (the corresponding Rust IPC
+ * does not exist by design — banner state is event-driven, not RPC).
+ *
+ * Dismissal sets it to `null`; a subsequent `hcfs_credits_exhausted`
+ * event re-raises the banner. This matches the per-cycle ephemerality
+ * contract: dismissing the banner does NOT permanently hide it for
+ * future failures.
+ */
+export const creditsExhaustedAtom = atom<CreditsExhaustedInfo | null>(null);

--- a/app/lib/types/syncSnapshot.ts
+++ b/app/lib/types/syncSnapshot.ts
@@ -59,6 +59,22 @@ export interface SyncSnapshot {
   effectiveInProgress: boolean;
   /** True only when session complete AND no files still processing */
   effectiveCompleted: boolean;
+
+  /** Intent manifest totals — present only when an account is logged in
+   * and the backend successfully read the desktop-side intent overlay.
+   *
+   * `undefined` = no overlay available (e.g. early boot / DB error /
+   * legacy snapshot). `0` = the manifest exists but is empty.
+   * Frontend must treat absent and 0 differently when deciding to show
+   * the "X of Y" line. */
+  intentTotalFiles?: number;
+  intentTotalBytes?: number;
+  intentCompletedFiles?: number;
+  intentCompletedBytes?: number;
+  /** True iff intentTotalFiles > intentCompletedFiles. Gate for showing
+   * the "X of Y" line — backend computes this so the FE doesn't have
+   * to redo the comparison. */
+  intentActive?: boolean;
 }
 
 export const EMPTY_SNAPSHOT: SyncSnapshot = {

--- a/app/lib/utils/dateUtils.ts
+++ b/app/lib/utils/dateUtils.ts
@@ -21,14 +21,14 @@ export const normalizeIsoToMillis = (iso?: string): number | null => {
 };
 
 /**
- * Formats a date to compact format: MM/DD/YY H:MM am/pm
+ * Formats a date to compact format: DD/MM/YYYY H:MM am/pm
  * @param date - Date object to format
- * @returns Formatted date string like "09/22/25 4:59 pm"
+ * @returns Formatted date string like "22/09/2025 4:59 pm"
  */
 export function formatCompactDate(date: Date): string {
-  const month = (date.getMonth() + 1).toString().padStart(2, "0"); // MM
   const day = date.getDate().toString().padStart(2, "0"); // DD
-  const year = date.getFullYear().toString().slice(-2); // YY (last 2 digits)
+  const month = (date.getMonth() + 1).toString().padStart(2, "0"); // MM
+  const year = date.getFullYear().toString(); // YYYY
 
   let hours = date.getHours(); // Get hours in 24-hour format
   const minutes = date.getMinutes().toString().padStart(2, "0"); // MM
@@ -37,12 +37,12 @@ export function formatCompactDate(date: Date): string {
   hours = hours % 12;
   hours = hours ? hours : 12; // Convert hour '0' (midnight) to '12'
 
-  return `${month}/${day}/${year} ${hours}:${minutes} ${ampm}`;
+  return `${day}/${month}/${year} ${hours}:${minutes} ${ampm}`;
 }
 
 export function formatUploadDate(dateString: string | number): string {
   const date = new Date(dateString);
-  const day = date.getDate(); // D
+  const day = date.getDate().toString().padStart(2, "0"); // DD
   const month = (date.getMonth() + 1).toString().padStart(2, "0"); // MM
   const year = date.getFullYear(); // YYYY
 
@@ -53,7 +53,7 @@ export function formatUploadDate(dateString: string | number): string {
   hours = hours % 12;
   hours = hours ? hours : 12; // Convert hour '0' (midnight) to '12' for H format (1-12)
 
-  return `${day}-${month}-${year} at ${hours}:${minutes} ${ampm}`;
+  return `${day}/${month}/${year} at ${hours}:${minutes} ${ampm}`;
 }
 
 /**

--- a/app/lib/utils/formatters/formatDate.ts
+++ b/app/lib/utils/formatters/formatDate.ts
@@ -1,15 +1,18 @@
-export const formatDate = (input: Date | string | number): string => {
+/**
+ * Format a Date / ISO string / Unix timestamp as `DD/MM/YYYY H:MM am/pm`
+ * in the user's local timezone.
+ */
+export const formatDate = (input: Date | string | number | bigint): string => {
   let date: Date;
 
   if (input instanceof Date) {
     date = input;
   } else if (typeof input === "number") {
-    // Handle Unix timestamps - if the number is less than 13 digits, it's likely in seconds
-    // Convert to milliseconds by multiplying by 1000
+    // Unix timestamp — treat ≤10-digit numbers as seconds.
     const timestamp = input.toString().length <= 10 ? input * 1000 : input;
     date = new Date(timestamp);
   } else if (typeof input === "bigint") {
-    // Handle BigInt timestamps from Polkadot API
+    // BigInt timestamps from Polkadot API.
     const num = Number(input);
     const timestamp = num.toString().length <= 10 ? num * 1000 : num;
     date = new Date(timestamp);
@@ -17,38 +20,29 @@ export const formatDate = (input: Date | string | number): string => {
     date = new Date(input);
   }
 
-  // Validate the date
-  if (isNaN(date.getTime())) {
-    return "Invalid Date";
-  }
+  if (isNaN(date.getTime())) return "Invalid Date";
 
-  const formatter = new Intl.DateTimeFormat(undefined, {
-    month: "2-digit",
-    day: "2-digit",
-    year: "2-digit",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-    timeZone: undefined, // Uses user's local timezone
-  });
+  const dd = String(date.getDate()).padStart(2, "0");
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const yyyy = String(date.getFullYear());
 
-  return formatter
-    .format(date)
-    .replace(",", "")
-    .replace("AM", "am")
-    .replace("PM", "pm");
+  let hours = date.getHours();
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const ampm = hours >= 12 ? "pm" : "am";
+  hours = hours % 12 || 12;
+
+  return `${dd}/${mm}/${yyyy} ${hours}:${minutes} ${ampm}`;
 };
 
-export function formatDateWithouteTime(input: Date | string | number): string {
+/** Format a Date / ISO string / Unix timestamp as `DD/MM/YYYY` (date only). */
+export function formatDateWithouteTime(
+  input: Date | string | number
+): string {
   const d = input instanceof Date ? input : new Date(input);
+  if (isNaN(d.getTime())) return "Invalid Date";
 
-  // Validate the date
-  if (isNaN(d.getTime())) {
-    return "Invalid Date";
-  }
-
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
   const dd = String(d.getDate()).padStart(2, "0");
-  const yy = String(d.getFullYear()).slice(-2);
-  return `${mm}/${dd}/${yy}`;
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const yyyy = String(d.getFullYear());
+  return `${dd}/${mm}/${yyyy}`;
 }

--- a/app/lib/utils/invokeWithTimeout.ts
+++ b/app/lib/utils/invokeWithTimeout.ts
@@ -1,0 +1,71 @@
+import { invoke, type InvokeArgs } from "@tauri-apps/api/core";
+
+/**
+ * Wrap a Tauri `invoke()` call with a wall-clock timeout.
+ *
+ * Tauri IPC has no built-in client-side deadline — an `invoke()` that
+ * never returns (Rust hangs on a lock, awaits a never-fulfilled
+ * future, panics inside a `spawn_blocking` task whose result is then
+ * orphaned, etc.) leaves the FE promise pending forever. The first
+ * surface bug fixed with this pattern was `get_user_files` spinning
+ * the Files page indefinitely; `use-user-files/index.ts` inlined the
+ * `Promise.race` + `clearTimeout` dance and the comment there
+ * explains the original reasoning in full.
+ *
+ * This helper extracts that pattern so other IPCs that orchestrate
+ * the sync engine (auto_init_sync, ensure_sync_mnemonic, stop_sync,
+ * restore_session) can opt into the same wall-clock cap without
+ * recopying the boilerplate. The timer is cleared in `finally`, so
+ * the happy path doesn't leak a pending `setTimeout` per call —
+ * which would accumulate noticeably under TanStack Query refetch
+ * storms or event-driven re-issues.
+ *
+ * @param command   Tauri command name, identical to `invoke()`'s first arg.
+ * @param args      Tauri command args, identical to `invoke()`'s second arg.
+ * @param timeoutMs Wall-clock timeout in milliseconds. A throw with a
+ *                  predictable message (`"<command> timed out"`) lets
+ *                  callers match on it without reflection.
+ *
+ * @returns The same `Promise<T>` shape `invoke()` returns.
+ * @throws  The original error from `invoke()` if the IPC itself
+ *          rejected; otherwise a `new Error("<command> timed out")`
+ *          when the budget elapses.
+ *
+ * Caller pattern:
+ * ```ts
+ * try {
+ *   const result = await invokeWithTimeout<MyResult>(
+ *     "my_command",
+ *     { someArg: 1 },
+ *     5_000,
+ *   );
+ * } catch (err) {
+ *   if (err instanceof Error && err.message.endsWith("timed out")) {
+ *     // surface timeout-specific UX
+ *   } else {
+ *     throw err;
+ *   }
+ * }
+ * ```
+ */
+export async function invokeWithTimeout<T>(
+  command: string,
+  args: InvokeArgs | undefined,
+  timeoutMs: number,
+): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(
+      () => reject(new Error(`${command} timed out`)),
+      timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([
+      invoke<T>(command, args),
+      timeout,
+    ]);
+  } finally {
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+  }
+}

--- a/app/lib/wallet-auth-context.tsx
+++ b/app/lib/wallet-auth-context.tsx
@@ -330,26 +330,48 @@ export function WalletAuthProvider({
         scheduleLogout(result.logoutTimeMs);
       }
 
-      // Init sync
+      // Init sync.
+      //
+      // `ensure_sync_mnemonic` parks on Rust's recovery gate
+      // (`sync/mnemonic.rs::await_recovery_resolved`) when the gate
+      // is `Pending` — set by `session_restore.rs:311` for OAuth
+      // users whose recommended recovery flow is anything other
+      // than `Proceed`. Awaiting this IPC before `initSync` meant
+      // any stall in the recovery dialog (it never renders, the
+      // user dismisses it without resolving, the event listener
+      // missed `oauth_recovery_check_needed`) stranded `initSync`
+      // forever — auto_init_sync was never invoked,
+      // `runner.drives` stayed empty, every upload hit the 60s
+      // `upload_processing` watchdog.
+      //
+      // Fix: fire `ensure_sync_mnemonic` in the background and call
+      // `initSync` immediately. Rust's `auto_init_sync` already has
+      // a retry ladder gated on the `hippius_auth_ready` event
+      // (subscribed BEFORE its first attempt, see
+      // `useHcfsSync.ts::tryAutoInitSync`). Both success paths of
+      // `ensure_sync_mnemonic` now emit `hippius_auth_ready` so
+      // when the mnemonic finally lands in `AuthInfo` (either from
+      // the cache hit, the recovery branch, or the freshly
+      // generated branch), the next retry picks it up. If
+      // `ensure_sync_mnemonic` fails with
+      // `MasterMnemonicUnrecoverable` (encrypted state exists but
+      // can't be decrypted), the catch flips the reauth banner —
+      // same UX as before, just without the gate.
       if (result.substrateAddress) {
         if (result.needsSyncMnemonic) {
-          try {
-            // Rust caches the mnemonic in AuthInfo; we don't read it back.
-            await invoke<void>("ensure_sync_mnemonic", { accountId: result.substrateAddress });
-          } catch (err) {
-            console.error("[WalletAuth] ensure_sync_mnemonic failed:", err);
-            // Rust refuses to mint a fresh mnemonic when encrypted
-            // state already exists on disk — returning
-            // `NotReady(MasterMnemonicUnrecoverable)`. Flip the
-            // reauth banner so the user can recover via re-entering
-            // their seed phrase, instead of silently falling through
-            // to `initSync` which would surface as the opaque
-            // `Crypto: decryption failed` error on the next drive
-            // resume.
-            if (isMasterMnemonicUnrecoverable(err)) {
-              appStore.set(syncRequiresReauthAtom, true);
+          // Fire-and-forget. NOT awaited.
+          void (async () => {
+            try {
+              await invoke<void>("ensure_sync_mnemonic", {
+                accountId: result.substrateAddress,
+              });
+            } catch (err) {
+              console.error("[WalletAuth] ensure_sync_mnemonic failed:", err);
+              if (isMasterMnemonicUnrecoverable(err)) {
+                appStore.set(syncRequiresReauthAtom, true);
+              }
             }
-          }
+          })();
         }
         initSync(result.substrateAddress);
       }

--- a/app/lib/wallet-auth-context.tsx
+++ b/app/lib/wallet-auth-context.tsx
@@ -201,21 +201,29 @@ export function WalletAuthProvider({
   }
 
   /** Start sync for the given account, called after any successful auth.
-   *  Defers until the splash screen is done so sync doesn't race the loading screen.
    *
    *  No longer takes a mnemonic argument — Rust's `auto_init_sync` resolves
    *  the mnemonic from `AuthInfo` via the 5-stage `get_mnemonic_for_account`
    *  fallback chain, and `login_with_mnemonic` / `ensure_sync_mnemonic`
    *  populate `AuthInfo` before this is called. Passing the phrase through
    *  JavaScript added no capability and kept it alive in heap memory longer
-   *  than necessary. */
+   *  than necessary.
+   *
+   *  Previously this gated on `splashCompleteAtom` to "defer sync init
+   *  until the splash screen finishes." The gate stranded init forever
+   *  on cold starts where the splash bailed early (the update-dialog
+   *  branch in `splash-screen/index.tsx:174` returns from
+   *  `runSetupPhases` without ever calling `setSplashComplete(true)`),
+   *  so `auto_init_sync` was never invoked, `runner.drives` stayed
+   *  empty, and every user upload sat on the 60 s
+   *  `upload_processing` watchdog because `trigger_sync` found no
+   *  drives. The gate is unnecessary anyway: `auto_init_sync` runs in
+   *  the Rust backend and doesn't render UI, and the splash component
+   *  renders over its children (`isReady && children`) until it's
+   *  ready — so backend sync events can't visibly "race the loading
+   *  screen". */
   function initSync(accountId: string) {
     if (syncInitialized.current) return;
-    if (!splashComplete) {
-      // Splash still showing — defer until it finishes
-      pendingSyncInit.current = { accountId };
-      return;
-    }
     syncInitialized.current = true;
     pendingSyncInit.current = null;
     invoke("stop_sync")
@@ -228,13 +236,17 @@ export function WalletAuthProvider({
     triggerMigrationCheck();
   }
 
-  // Trigger deferred sync init once the splash screen finishes
+  // Backward-compat: a previous version deferred init via
+  // `pendingSyncInit.current` when the splash wasn't ready. The gate
+  // is gone now, but this effect stays as a safety net — if any
+  // legacy code path stashes a pending init, fire it once
+  // `splashComplete` flips. In the steady state, `pendingSyncInit`
+  // is always null and this is a no-op.
   useEffect(() => {
     if (splashComplete && pendingSyncInit.current && !syncInitialized.current) {
       const { accountId } = pendingSyncInit.current;
       initSync(accountId);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [splashComplete]);
 
   // Boot: restore session from Rust DB or localStorage OAuth session

--- a/app/lib/wallet-auth-context.tsx
+++ b/app/lib/wallet-auth-context.tsx
@@ -16,6 +16,7 @@ import { useRouter } from "next/navigation";
 import { logger } from "@/lib/utils/logger";
 
 import { invoke } from "@tauri-apps/api/core";
+import { invokeWithTimeout } from "./utils/invokeWithTimeout";
 import { useTrayInit, clearLoginStatusCache } from "./hooks/useTraySync";
 import { tryAutoInitSync } from "./hooks/useHcfsSync";
 import { appStore } from "./store/jotaiStore";
@@ -226,8 +227,17 @@ export function WalletAuthProvider({
     if (syncInitialized.current) return;
     syncInitialized.current = true;
     pendingSyncInit.current = null;
-    invoke("stop_sync")
-      .catch(() => { })
+    // Wrap `stop_sync` in a wall-clock timeout so a Rust-side hang
+    // (poisoned mutex, deadlocked sync loop, etc.) can't strand
+    // login. `stop_sync` is normally <500ms (GRACEFUL_SHUTDOWN +
+    // abort fallback in lifecycle.rs), so 8s is roomy. Whatever the
+    // outcome (success / Rust error / timeout) we proceed to
+    // `tryAutoInitSync` — fresh login should never block on
+    // teardown of state that may not even exist yet.
+    invokeWithTimeout<void>("stop_sync", undefined, 8_000)
+      .catch((err) => {
+        console.warn("[WalletAuth] stop_sync failed or timed out:", err);
+      })
       .then(() => {
         tryAutoInitSync(accountId).catch((err) =>
           console.error("[WalletAuth] Failed to start sync:", err)
@@ -274,8 +284,13 @@ export function WalletAuthProvider({
         ? (isNaN(Number(storedExpiry)) ? new Date(storedExpiry).getTime() : parseInt(storedExpiry, 10))
         : null;
 
-      // Single Rust call handles all validation, token checking, fallback
-      const result = await invoke<{
+      // Single Rust call handles all validation, token checking, fallback.
+      // 15s wall-clock cap protects the boot flow from a Rust-side hang
+      // (DB pool starvation, blockchain subscription init blocked on
+      // network, keychain access hanging). Without the cap a stuck
+      // `restore_session` would leave the entire auth context in its
+      // initial state forever — no login UI, no sync, no error.
+      const result = await invokeWithTimeout<{
         authenticated: boolean;
         substrateAddress: string | null;
         authType: string | null;
@@ -288,10 +303,14 @@ export function WalletAuthProvider({
          *  restore, so sync is wedged until the user re-enters their
          *  seed phrase. Surfaces the <SyncReauthRequiredAlert /> banner. */
         syncRequiresReauth: boolean;
-      }>("restore_session", {
-        oauthSessionJson: storedSession ?? null,
-        oauthExpiryMs: oauthExpiryMs ?? null,
-      });
+      }>(
+        "restore_session",
+        {
+          oauthSessionJson: storedSession ?? null,
+          oauthExpiryMs: oauthExpiryMs ?? null,
+        },
+        15_000,
+      );
 
       // Clear localStorage if Rust says so
       if (result.shouldClearOauth) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hippius",
   "private": true,
-  "version": "0.1.99",
+  "version": "0.1.100",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3383,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "hcfs-client"
 version = "0.1.9"
-source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=ce60d47#ce60d475b86c59f63c94f9586b0d42e6cdb7c089"
+source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=fedd17e#fedd17ebfb6270b2b9a2fbb9d7b3c43e6b1606c3"
 dependencies = [
  "argon2",
  "async-stream",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "hcfs-shared"
 version = "0.1.8"
-source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=ce60d47#ce60d475b86c59f63c94f9586b0d42e6cdb7c089"
+source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=fedd17e#fedd17ebfb6270b2b9a2fbb9d7b3c43e6b1606c3"
 dependencies = [
  "blake3",
  "ed25519-dalek",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1061,8 +1061,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -2269,7 +2269,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2582,7 +2582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3383,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "hcfs-client"
 version = "0.1.9"
-source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=157c1c7#157c1c72d9dbb9463b90f51be33fce237c13f413"
+source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=48d2207#48d22073247b1301232a56a4b5067fc0d7990f70"
 dependencies = [
  "argon2",
  "async-stream",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "hcfs-shared"
 version = "0.1.8"
-source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=157c1c7#157c1c72d9dbb9463b90f51be33fce237c13f413"
+source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=48d2207#48d22073247b1301232a56a4b5067fc0d7990f70"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -3670,7 +3670,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4789,7 +4789,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5134,7 +5134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5848,7 +5848,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6310,7 +6310,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6390,7 +6390,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7341,7 +7341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8387,7 +8387,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8886,7 +8886,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9487,7 +9487,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1061,8 +1061,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -2269,7 +2269,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2582,7 +2582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3383,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "hcfs-client"
 version = "0.1.9"
-source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=fedd17e#fedd17ebfb6270b2b9a2fbb9d7b3c43e6b1606c3"
+source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=250a523#250a523950b699065c74bcd1610bb65722a6df54"
 dependencies = [
  "argon2",
  "async-stream",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "hcfs-shared"
 version = "0.1.8"
-source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=fedd17e#fedd17ebfb6270b2b9a2fbb9d7b3c43e6b1606c3"
+source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=250a523#250a523950b699065c74bcd1610bb65722a6df54"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -3670,7 +3670,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4789,7 +4789,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5134,7 +5134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5848,7 +5848,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6310,7 +6310,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6390,7 +6390,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7341,7 +7341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8387,7 +8387,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8886,7 +8886,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9487,7 +9487,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Hippius"
-version = "0.1.99"
+version = "0.1.100"
 dependencies = [
  "aes",
  "alloy-signer",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3383,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "hcfs-client"
 version = "0.1.9"
-source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=250a523#250a523950b699065c74bcd1610bb65722a6df54"
+source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=d576086#d576086cb61c4218b9ac9e4f8eca825df23bfe29"
 dependencies = [
  "argon2",
  "async-stream",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "hcfs-shared"
 version = "0.1.8"
-source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=250a523#250a523950b699065c74bcd1610bb65722a6df54"
+source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=d576086#d576086cb61c4218b9ac9e4f8eca825df23bfe29"
 dependencies = [
  "blake3",
  "ed25519-dalek",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3383,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "hcfs-client"
 version = "0.1.9"
-source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=d576086#d576086cb61c4218b9ac9e4f8eca825df23bfe29"
+source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=157c1c7#157c1c72d9dbb9463b90f51be33fce237c13f413"
 dependencies = [
  "argon2",
  "async-stream",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "hcfs-shared"
 version = "0.1.8"
-source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=d576086#d576086cb61c4218b9ac9e4f8eca825df23bfe29"
+source = "git+ssh://git@github.com/thenervelab/hcfs.git?rev=157c1c7#157c1c72d9dbb9463b90f51be33fce237c13f413"
 dependencies = [
  "blake3",
  "ed25519-dalek",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,12 +89,12 @@ alloy-signer = { version = "0.8", default-features = false }
 alloy-signer-local = { version = "0.8", default-features = false, features = [
     "mnemonic",
 ] }
-hcfs-client = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "250a523" }
+hcfs-client = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "d576086" }
 # hcfs-shared pulls in the `network` module types (RegisterRelativePathEntry,
 # MAX_REGISTER_RELATIVE_PATHS_BATCH, ...) that hcfs-client takes/returns on
 # its public API but does not re-export. Pinned to the same git rev so the
 # wire types stay in lockstep with the client.
-hcfs-shared = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "250a523" }
+hcfs-shared = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "d576086" }
 # NFC-normalise relative_path strings before posting them to the server's
 # register_relative_paths endpoint. macOS APFS hands filenames back in NFD
 # and the server's path_validator hard-rejects anything non-NFC — see the

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -167,6 +167,16 @@ items_after_statements = "allow"
 needless_raw_string_hashes = "allow"
 
 [dev-dependencies]
+# `tauri` is also listed as a normal dependency above; the dev-deps entry
+# adds the `test` feature so unit tests in `src-tauri/src/sync/` can
+# build an `AppHandle<MockRuntime>` via `tauri::test::mock_app()` without
+# spinning up a real Wry runtime. Cargo merges features per build kind:
+# tests get `test` enabled, production binaries don't. The `test` feature
+# is a pure gate (`test = []` in tauri's Cargo.toml) so it adds no
+# transitive deps to either build. Required for in-module tests of
+# callbacks like `build_file_synced_callback` whose signature now takes
+# `&AppHandle<R>`.
+tauri = { version = "2", features = ["test"] }
 tokio = { version = "1", features = [
     "macros",
     "rt-multi-thread",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Hippius"
-version = "0.1.99"
+version = "0.1.100"
 description = "Hippius Desktop App"
 authors = ["you"]
 edition = "2024"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,12 +89,12 @@ alloy-signer = { version = "0.8", default-features = false }
 alloy-signer-local = { version = "0.8", default-features = false, features = [
     "mnemonic",
 ] }
-hcfs-client = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "ce60d47" }
+hcfs-client = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "fedd17e" }
 # hcfs-shared pulls in the `network` module types (RegisterRelativePathEntry,
 # MAX_REGISTER_RELATIVE_PATHS_BATCH, ...) that hcfs-client takes/returns on
 # its public API but does not re-export. Pinned to the same git rev so the
 # wire types stay in lockstep with the client.
-hcfs-shared = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "ce60d47" }
+hcfs-shared = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "fedd17e" }
 # NFC-normalise relative_path strings before posting them to the server's
 # register_relative_paths endpoint. macOS APFS hands filenames back in NFD
 # and the server's path_validator hard-rejects anything non-NFC — see the

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,12 +89,12 @@ alloy-signer = { version = "0.8", default-features = false }
 alloy-signer-local = { version = "0.8", default-features = false, features = [
     "mnemonic",
 ] }
-hcfs-client = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "fedd17e" }
+hcfs-client = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "250a523" }
 # hcfs-shared pulls in the `network` module types (RegisterRelativePathEntry,
 # MAX_REGISTER_RELATIVE_PATHS_BATCH, ...) that hcfs-client takes/returns on
 # its public API but does not re-export. Pinned to the same git rev so the
 # wire types stay in lockstep with the client.
-hcfs-shared = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "fedd17e" }
+hcfs-shared = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "250a523" }
 # NFC-normalise relative_path strings before posting them to the server's
 # register_relative_paths endpoint. macOS APFS hands filenames back in NFD
 # and the server's path_validator hard-rejects anything non-NFC — see the

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,12 +89,12 @@ alloy-signer = { version = "0.8", default-features = false }
 alloy-signer-local = { version = "0.8", default-features = false, features = [
     "mnemonic",
 ] }
-hcfs-client = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "d576086" }
+hcfs-client = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "157c1c7" }
 # hcfs-shared pulls in the `network` module types (RegisterRelativePathEntry,
 # MAX_REGISTER_RELATIVE_PATHS_BATCH, ...) that hcfs-client takes/returns on
 # its public API but does not re-export. Pinned to the same git rev so the
 # wire types stay in lockstep with the client.
-hcfs-shared = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "d576086" }
+hcfs-shared = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "157c1c7" }
 # NFC-normalise relative_path strings before posting them to the server's
 # register_relative_paths endpoint. macOS APFS hands filenames back in NFD
 # and the server's path_validator hard-rejects anything non-NFC — see the

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,12 +89,12 @@ alloy-signer = { version = "0.8", default-features = false }
 alloy-signer-local = { version = "0.8", default-features = false, features = [
     "mnemonic",
 ] }
-hcfs-client = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "157c1c7" }
+hcfs-client = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "48d2207" }
 # hcfs-shared pulls in the `network` module types (RegisterRelativePathEntry,
 # MAX_REGISTER_RELATIVE_PATHS_BATCH, ...) that hcfs-client takes/returns on
 # its public API but does not re-export. Pinned to the same git rev so the
 # wire types stay in lockstep with the client.
-hcfs-shared = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "157c1c7" }
+hcfs-shared = { git = "ssh://git@github.com/thenervelab/hcfs.git", rev = "48d2207" }
 # NFC-normalise relative_path strings before posting them to the server's
 # register_relative_paths endpoint. macOS APFS hands filenames back in NFD
 # and the server's path_validator hard-rejects anything non-NFC — see the

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -172,6 +172,7 @@ tokio = { version = "1", features = [
     "rt-multi-thread",
     "time",
     "process",
+    "test-util",
 ] }
 anyhow = "1"
 aes = "0.8"

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -51,6 +51,14 @@ pub struct AppState {
     /// handler suppresses `mark_preparing` when the banner is
     /// already raised). See `crate::sync::preparing`.
     pub preparing: std::sync::Arc<crate::sync::preparing::PreparingState>,
+    /// Per-label running count of `InsufficientBalance` per-file
+    /// failures in the current sync cycle. Read by the `FileFailed`
+    /// arm of the bridge to attach `file_count` to the
+    /// `hcfs_credits_exhausted` payload, cleared on every cycle
+    /// boundary (`SyncStarted`, `SyncStopped`, the non-cancel branch
+    /// of `SyncError`, and globally on `SyncReset`). See
+    /// `crate::sync::credits_exhausted`.
+    pub credits_exhausted: std::sync::Arc<crate::sync::credits_exhausted::CreditsExhaustedState>,
     /// Monotonically increasing counter, incremented on every
     /// `SyncStarted` event. The `UploadProcessingState` clear gate
     /// reads this to distinguish events from a cycle that began
@@ -139,6 +147,7 @@ impl AppState {
             migration: MigrationState::new(),
             upload_processing: std::sync::Arc::new(crate::sync::upload_processing::UploadProcessingState::new()),
             preparing: std::sync::Arc::new(crate::sync::preparing::PreparingState::new()),
+            credits_exhausted: std::sync::Arc::new(crate::sync::credits_exhausted::CreditsExhaustedState::new()),
             sync_session_epoch: AtomicU64::new(0),
             health_client,
             // Explicit timeouts. Without them a hung connection (e.g. a

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -42,6 +42,15 @@ pub struct AppState {
     /// uploads. Drives the top-of-page processing banner. See
     /// `crate::sync::upload_processing`.
     pub upload_processing: std::sync::Arc<crate::sync::upload_processing::UploadProcessingState>,
+    /// Tracks the scan + remote-state-fetch + plan-build window for
+    /// file-watcher-initiated sync cycles. Drives the bottom-right
+    /// widget's "Preparing sync…" badge so the user has feedback
+    /// between `SyncStarted` and the first ProgressSnapshot with
+    /// files. IPC uploads use `upload_processing` instead — the two
+    /// surfaces are intentionally exclusive (the `SyncStarted`
+    /// handler suppresses `mark_preparing` when the banner is
+    /// already raised). See `crate::sync::preparing`.
+    pub preparing: std::sync::Arc<crate::sync::preparing::PreparingState>,
     /// Monotonically increasing counter, incremented on every
     /// `SyncStarted` event. The `UploadProcessingState` clear gate
     /// reads this to distinguish events from a cycle that began
@@ -129,6 +138,7 @@ impl AppState {
             oauth: OAuthState::new(),
             migration: MigrationState::new(),
             upload_processing: std::sync::Arc::new(crate::sync::upload_processing::UploadProcessingState::new()),
+            preparing: std::sync::Arc::new(crate::sync::preparing::PreparingState::new()),
             sync_session_epoch: AtomicU64::new(0),
             health_client,
             // Explicit timeouts. Without them a hung connection (e.g. a

--- a/src-tauri/src/auth/logout.rs
+++ b/src-tauri/src/auth/logout.rs
@@ -69,5 +69,23 @@ pub async fn logout_full(app: tauri::AppHandle, account_id: String) -> Result<()
         warn!("sp_clear_all_data during logout failed: {e}");
     }
 
+    // 4. Clear intent manifest rows for this account. Intent represents
+    //    in-flight upload intent; logging out should not leak it into the
+    //    next session if a different user logs in. Best-effort: a stale
+    //    row would only show wrong totals in the widget, not affect sync
+    //    correctness. Symmetric with how the auth_session row is cleared
+    //    in step 2. Account-scoped (NOT unconditional) so a different
+    //    account sharing the SQLite file is unaffected — the invariant
+    //    lives at the SQL layer in `IntentRepo::clear_account`.
+    match state.pool() {
+        Ok(pool) => {
+            let repo = crate::sync::intent::IntentRepo::new(pool.clone());
+            if let Err(e) = repo.clear_account(&account_id).await {
+                warn!("clear_account during logout failed: {e}");
+            }
+        }
+        Err(e) => warn!("pool unavailable during logout clear_account: {e}"),
+    }
+
     Ok(())
 }

--- a/src-tauri/src/billing/credits.rs
+++ b/src-tauri/src/billing/credits.rs
@@ -95,7 +95,11 @@ pub struct SyncEligibility {
 pub async fn check_sync_eligibility(state: tauri::State<'_, crate::app_state::AppState>, account_id: String) -> Result<SyncEligibility, AppError> {
     use crate::billing::eligibility::{InsufficientCreditsAction, check_action_eligibility_inner};
 
-    let result = check_action_eligibility_inner(&state, &account_id, InsufficientCreditsAction::FolderSync).await?;
+    // Legacy alias preserves the pre-Task-3.1 semantic: `> 0` floor, no
+    // bytes-priced layer. Callers that need price-aware gating should
+    // call `check_action_eligibility` directly with an explicit byte
+    // count (see `useCreditCheck` migration plan).
+    let result = check_action_eligibility_inner(&state, &account_id, InsufficientCreditsAction::FolderSync, 0).await?;
     if result.eligible {
         return Ok(SyncEligibility {
             eligible: true,

--- a/src-tauri/src/billing/eligibility.rs
+++ b/src-tauri/src/billing/eligibility.rs
@@ -37,30 +37,108 @@ use crate::api::client::ApiClient;
 use crate::error::{AppError, NotReadyKind, Result};
 use serde::{Deserialize, Serialize};
 
-/// Per-action credit thresholds. **The only place credit pricing lives.**
+/// Per-action credit pricing. **The only place credit pricing lives.**
+///
+/// Two kinds of pricing coexist here:
+///
+/// 1. **Static thresholds** (`VM_CREATION`) — actions whose cost is
+///    fixed regardless of payload size.
+/// 2. **Per-byte rate** (`CREDITS_PER_BYTE_MONTHLY`) — upload actions
+///    (`FileUpload`, `FolderUpload`, `FolderSync`, `Sharing`) where the
+///    real cost scales with the bytes the user is about to commit to
+///    paid storage. The static thresholds for upload actions are kept
+///    at `0.0` (legacy "any positive balance" floor) but the
+///    [`required_credits`](InsufficientCreditsAction::required_credits)
+///    accessor combines them with the bytes-priced layer so the IPC gate
+///    refuses uploads the user cannot afford BEFORE hcfs-server returns
+///    a 402.
 ///
 /// Changing the price for an action means editing one constant here.
 /// Frontend and tests stay untouched.
 pub mod thresholds {
-    /// Minimum credits required for a single file upload. Strictly
-    /// greater than zero — any positive balance is enough.
+    /// Minimum credits required for a single file upload. Combined with
+    /// [`CREDITS_PER_BYTE_MONTHLY`] times the file's byte length at the
+    /// gate. The constant itself stays at `0.0` so a zero-byte sentinel
+    /// upload (or a proactive FE check that doesn't yet know the size)
+    /// falls back to the legacy "any positive balance" floor.
     pub const FILE_UPLOAD: f64 = 0.0;
     /// Minimum credits required for a folder upload (which expands into
-    /// many file uploads server-side). Same `> 0` rule.
+    /// many file uploads server-side). Combined with the recursive byte
+    /// sum at the gate. Same `0.0` floor rationale as [`FILE_UPLOAD`].
     pub const FOLDER_UPLOAD: f64 = 0.0;
-    /// Minimum credits required to add a new sync folder. Same `> 0`
-    /// rule — used by the existing `check_sync_eligibility` flow.
+    /// Minimum credits required to add a new sync folder. Combined with
+    /// the byte sum of the folder's existing contents (since those
+    /// bytes are about to be uploaded by the sync engine). Same `0.0`
+    /// floor rationale as [`FILE_UPLOAD`].
     pub const FOLDER_SYNC: f64 = 0.0;
     /// Minimum credits required to provision a virtual machine. The
     /// VM provisioning extrinsic charges this much from the account
     /// up-front, so a balance below this guarantees a failed extrinsic.
+    /// Bytes-priced layer does NOT apply — VM creation has no upload
+    /// payload.
     pub const VM_CREATION: f64 = 10.0;
-    /// Minimum credits required to mint a public share link. Same
-    /// "any positive balance" rule as file/folder uploads — sharing
-    /// pulls the ciphertext from the same paid storage backend so we
-    /// gate it on the same threshold instead of giving away anonymous
-    /// downloads to a fully-drained account.
+    /// Minimum credits required to mint a public share link. Combined
+    /// with the shared file's byte length at the gate (sharing pulls the
+    /// ciphertext from the same paid storage backend, so a fully drained
+    /// account would generate broken share links).
     pub const SHARING: f64 = 0.0;
+
+    /// Credits charged per byte for one month of IPFS-tier storage,
+    /// derived from `billing::charts::calculate_storage_cost_internal`
+    /// (`("ipfs", "per-month", 1.0)`). The per-month projection is the
+    /// price the dashboard quotes to users (the per-block charge model
+    /// in `charts.rs` integrated over `2.628e6` seconds), so gating on it
+    /// matches the displayed price model rather than the larger
+    /// first-hour-only fee.
+    ///
+    /// **Value derivation** (kept inline so a code review can spot a
+    /// drift without leaving this file):
+    ///
+    /// ```text
+    /// per_block_charge   = 6.7878e-9  credits / GB / 6s
+    /// first_hour_charge  = 3.15e-5    credits / GB / first hour
+    /// per_month_duration = 2.628e6 s  (≈ 30.42 days)
+    /// blocks_after_h1    = (2.628e6 - 3600) / 6
+    ///                    = 437_400
+    /// per_gb_per_month   = first_hour_charge + per_block_charge * blocks_after_h1
+    ///                    = 3.15e-5 + 6.7878e-9 * 437_400
+    ///                    ≈ 2.9994e-3 credits / GB / month
+    /// per_byte_monthly   = per_gb_per_month / 1_073_741_824  (1 GiB)
+    ///                    ≈ 2.7935e-12 credits / byte / month
+    /// ```
+    ///
+    /// Pin a slightly conservative round number so a user with the
+    /// displayed balance can always actually upload the displayed
+    /// capacity (off-by-one rounding on the server would otherwise 402
+    /// the gate's most-eligible files). The constant is `3.0e-12` —
+    /// ~7% above the derived rate so the gate is a defensible floor.
+    ///
+    /// TODO(rate-sync): Phase 4 / follow-up. Replace this hardcoded
+    /// constant with a fetch from hcfs-server's pricing endpoint at boot
+    /// (cached, refetched on 402) so client/server pricing can't drift.
+    /// Tracked in the 2026-05-13 sync-402 plan.
+    pub const CREDITS_PER_BYTE_MONTHLY: f64 = 3.0e-12;
+}
+
+/// Pure cost function: credits required to upload `bytes` to paid
+/// storage for one month at the IPFS tier. Saturating-multiply on the
+/// `f64` side is a no-op (IEEE-754 overflow → `+inf`), but the input is
+/// already a `u64` from a real on-disk byte count so overflow is
+/// practically impossible. The function is `const`-friendly except for
+/// the float multiply; kept as a regular `fn` for testability via the
+/// [`#[cfg(test)]` block below](self::tests).
+///
+/// Why a free function rather than a method on [`InsufficientCreditsAction`]:
+/// the function is action-agnostic. Folder walks need to sum *bytes*
+/// before knowing which action to gate on, and the test fixtures need
+/// to assert pricing properties in isolation.
+#[must_use]
+pub fn cost_for_bytes(bytes: u64) -> f64 {
+    // The conversion `u64 -> f64` loses precision above 2^53 bytes
+    // (~9 EB), well beyond any realistic upload. Accept the loss.
+    #[allow(clippy::cast_precision_loss)]
+    let bytes_f = bytes as f64;
+    bytes_f * thresholds::CREDITS_PER_BYTE_MONTHLY
 }
 
 /// Which action the user is requesting eligibility for. Wire format is
@@ -79,7 +157,11 @@ pub enum InsufficientCreditsAction {
 }
 
 impl InsufficientCreditsAction {
-    /// Look up the credit threshold for this action.
+    /// Look up the static credit threshold for this action. Does NOT
+    /// include the per-byte priced layer — use
+    /// [`required_credits`](Self::required_credits) at the gate site
+    /// instead, which combines the threshold with `cost_for_bytes` for
+    /// upload actions.
     pub fn min_credits(self) -> f64 {
         match self {
             Self::FileUpload => thresholds::FILE_UPLOAD,
@@ -87,6 +169,35 @@ impl InsufficientCreditsAction {
             Self::FolderSync => thresholds::FOLDER_SYNC,
             Self::VmCreation => thresholds::VM_CREATION,
             Self::Sharing => thresholds::SHARING,
+        }
+    }
+
+    /// Whether this action's cost scales with an upload byte count.
+    /// `VmCreation` does not (its threshold is the up-front extrinsic
+    /// fee); every other action gates payload bytes through paid
+    /// storage and therefore is upload-priced.
+    pub fn is_upload(self) -> bool {
+        matches!(self, Self::FileUpload | Self::FolderUpload | Self::FolderSync | Self::Sharing)
+    }
+
+    /// Total credits required for this action with `bytes` of upload
+    /// payload. Combines [`min_credits`](Self::min_credits) (the static
+    /// threshold floor) with [`cost_for_bytes`] for upload actions; for
+    /// non-upload actions the bytes argument is ignored.
+    ///
+    /// Floor semantics: when an upload action sees `bytes == 0` (FE
+    /// proactive check before the size is known, or a zero-byte file)
+    /// the per-byte layer evaluates to `0.0` and the result is exactly
+    /// the static threshold. This preserves the legacy "any positive
+    /// balance" check for the proactive FE path.
+    pub fn required_credits(self, bytes: u64) -> f64 {
+        let threshold = self.min_credits();
+        if self.is_upload() {
+            // Use the larger of the static floor and the bytes-priced
+            // cost — neither layer should ever silently relax the other.
+            threshold.max(cost_for_bytes(bytes))
+        } else {
+            threshold
         }
     }
 
@@ -149,9 +260,10 @@ pub(crate) async fn check_action_eligibility_inner(
     state: &crate::app_state::AppState,
     account_id: &str,
     action: InsufficientCreditsAction,
+    bytes: u64,
 ) -> Result<ActionEligibility> {
     let pool = state.pool()?;
-    let required = action.min_credits();
+    let required = action.required_credits(bytes);
 
     // 1. Live marketplace credit fetch. NO caching — the whole point of
     //    moving this to Rust is to fix the staleness bug. Done first
@@ -165,10 +277,11 @@ pub(crate) async fn check_action_eligibility_inner(
 
     // 2. Threshold comparison. The user must always have a strictly
     //    positive balance (matches legacy `credits <= BigInt(0)` blocks
-    //    in `useCreditCheck`), AND if there's a non-zero threshold the
-    //    balance must meet it (matches legacy `creditsNumber < 10` for
-    //    VM creation). Both legacy semantics combined into one check
-    //    that doesn't require a float-equality comparison against zero.
+    //    in `useCreditCheck`), AND if there's a positive `required`
+    //    cost the balance must meet it. The `required` value combines
+    //    the static action threshold (e.g. ≥10 for VmCreation) with the
+    //    per-byte upload cost via `required_credits`, so a single
+    //    comparison covers both legacy and bytes-priced paths.
     let credits_ok = credits > 0.0 && (required <= 0.0 || credits >= required);
     if !credits_ok {
         return Ok(ActionEligibility {
@@ -222,13 +335,22 @@ pub(crate) async fn check_action_eligibility_inner(
 
 /// Tauri command for the proactive eligibility check. Called by the
 /// frontend `useCreditCheck` hook before opening any gated action modal.
+///
+/// `bytes` is optional. The proactive FE path that gates a click before
+/// the user has picked a file omits it (defaults to `0`) and the gate
+/// falls back to the legacy "any positive balance" floor. Callers that
+/// already know the byte count (e.g. an in-app dialog summarizing the
+/// files about to be uploaded) should pass it so `required_balance` in
+/// the structured response is the actual computed cost — that lets the
+/// FE render "$1.38 needed, $0.33 available" instead of a constant.
 #[tauri::command]
 pub async fn check_action_eligibility(
     state: tauri::State<'_, crate::app_state::AppState>,
     account_id: String,
     action: InsufficientCreditsAction,
+    bytes: Option<u64>,
 ) -> Result<ActionEligibility> {
-    check_action_eligibility_inner(&state, &account_id, action).await
+    check_action_eligibility_inner(&state, &account_id, action, bytes.unwrap_or(0)).await
 }
 
 /// Enforcement helper called as the FIRST line of every gated action
@@ -236,19 +358,40 @@ pub async fn check_action_eligibility(
 /// can't afford the action — making the gate atomic with the action
 /// and impossible to bypass via direct IPC calls or stale FE cache.
 ///
+/// For upload actions, the IPC MUST pass the actual byte count of the
+/// payload it is about to commit (file size for `add_file`, sum of
+/// sizes for `add_files`, recursive folder byte total for `add_folder`
+/// and `add_local_sync_folder`). Pass `0` only for VmCreation or for
+/// the very-first proactive check that doesn't yet know the size —
+/// `0` falls back to the legacy "any positive balance" floor.
+///
+/// # Race window
+///
+/// Balance can drop between this gate firing and the upload actually
+/// committing (concurrent device drains the wallet, billing tick rolls
+/// over, hcfs-server's view of the balance lags this client's view).
+/// The gate is a best-effort proactive refusal, NOT a transactional
+/// reservation — this is accepted by design. Phase 2's per-file
+/// `SyncEvent::FileFailed { kind: InsufficientBalance }` path (mapped
+/// from hcfs-server's 402 response) is the last line of defense and
+/// the only layer that sees the true committed balance at upload time.
+/// See `docs/plans/2026-05-13-sync-402-data-integrity.md` for the full
+/// data-integrity layering and how the two layers interact.
+///
 /// Action commands should write:
 ///
 /// ```rust,ignore
 /// #[tauri::command]
 /// pub async fn add_file(state, account_id, /* ... */) -> Result<...> {
+///     let bytes = tokio::fs::metadata(&file_path).await?.len();
 ///     crate::billing::eligibility::require_eligible(
-///         &state, &account_id, InsufficientCreditsAction::FileUpload,
+///         &state, &account_id, InsufficientCreditsAction::FileUpload, bytes,
 ///     ).await?;
 ///     // ... existing body ...
 /// }
 /// ```
-pub async fn require_eligible(state: &crate::app_state::AppState, account_id: &str, action: InsufficientCreditsAction) -> Result<()> {
-    let result = check_action_eligibility_inner(state, account_id, action).await?;
+pub async fn require_eligible(state: &crate::app_state::AppState, account_id: &str, action: InsufficientCreditsAction, bytes: u64) -> Result<()> {
+    let result = check_action_eligibility_inner(state, account_id, action, bytes).await?;
     if result.eligible {
         Ok(())
     } else {
@@ -348,5 +491,97 @@ mod tests {
     fn matches_eligibility(credits: f64, required: f64) -> Option<()> {
         let eligible = credits > 0.0 && (required <= 0.0 || credits >= required);
         eligible.then_some(())
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Bytes-priced pricing layer (Task 3.1)
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn cost_for_bytes_is_zero_at_zero() {
+        // The proactive FE path passes `bytes = 0` before the user has
+        // picked a file. The gate must fall back to the static
+        // threshold in that case, not over-charge a phantom zero-byte
+        // upload — pinned here so `cost_for_bytes(0)` stays at exactly
+        // `0.0`. Bit-pattern compare dodges clippy::float_cmp.
+        assert_eq!(super::cost_for_bytes(0).to_bits(), 0.0_f64.to_bits());
+    }
+
+    #[test]
+    fn cost_for_bytes_scales_with_size() {
+        // Monotonicity (axiom `rust_quality_111`-style invariant on a
+        // pure function): doubling the bytes must at least double the
+        // cost. Pin the relationship so a future refactor that swaps
+        // the constant for a per-step pricing curve still holds the
+        // monotone contract.
+        let small = super::cost_for_bytes(1024);
+        let large = super::cost_for_bytes(1024 * 1024);
+        assert!(small < large, "1024 bytes should cost less than 1MiB: {small} vs {large}");
+        // Cost should be finite and non-negative; pin to catch a sign
+        // flip in the constant.
+        assert!(small.is_finite() && small >= 0.0);
+        assert!(large.is_finite() && large >= 0.0);
+    }
+
+    #[test]
+    fn cost_for_bytes_one_gib_matches_charts_per_month() {
+        // Pin the derived constant against the documented per-GB
+        // per-month value. The constant `CREDITS_PER_BYTE_MONTHLY`
+        // was chosen ~7% above the derived rate (deliberate
+        // conservative floor); the test asserts the rate sits in the
+        // expected order of magnitude so a typo in the exponent (e.g.
+        // `3.0e-11` vs `3.0e-12`) gets caught.
+        let one_gib = super::cost_for_bytes(1024 * 1024 * 1024);
+        // Documented derived value ≈ 2.9994e-3 credits/GB/month;
+        // constant pinned at 3.0e-12 / byte → ~3.22e-3 / GiB.
+        assert!(one_gib > 2.0e-3, "1 GiB cost must exceed 0.002 credits/month: {one_gib}");
+        assert!(one_gib < 1.0e-2, "1 GiB cost must stay below 0.01 credits/month: {one_gib}");
+    }
+
+    #[test]
+    fn required_credits_is_max_of_threshold_and_byte_cost() {
+        // Bytes-priced upload action: cost dominates the zero floor.
+        let big = 10u64 * 1024 * 1024 * 1024; // 10 GiB
+        let upload_cost = InsufficientCreditsAction::FileUpload.required_credits(big);
+        let raw_cost = super::cost_for_bytes(big);
+        assert!(upload_cost >= raw_cost);
+
+        // Non-upload action: bytes are ignored; threshold dominates.
+        let vm_cost = InsufficientCreditsAction::VmCreation.required_credits(big);
+        assert_eq!(vm_cost.to_bits(), thresholds::VM_CREATION.to_bits());
+
+        // Zero-byte upload: required is exactly the static floor.
+        let zero_upload = InsufficientCreditsAction::FileUpload.required_credits(0);
+        assert_eq!(zero_upload.to_bits(), thresholds::FILE_UPLOAD.to_bits());
+    }
+
+    #[test]
+    fn is_upload_classifies_all_variants() {
+        // Pin the upload/non-upload partition so a new variant added to
+        // `InsufficientCreditsAction` must explicitly choose a side —
+        // otherwise the bytes-priced gate would silently default to
+        // ignoring the payload size for that new action.
+        assert!(InsufficientCreditsAction::FileUpload.is_upload());
+        assert!(InsufficientCreditsAction::FolderUpload.is_upload());
+        assert!(InsufficientCreditsAction::FolderSync.is_upload());
+        assert!(InsufficientCreditsAction::Sharing.is_upload());
+        assert!(!InsufficientCreditsAction::VmCreation.is_upload());
+    }
+
+    #[test]
+    fn eligibility_threshold_logic_handles_byte_priced_uploads() {
+        // Tiny upload (1 byte): cost is far below any positive balance.
+        let tiny = super::cost_for_bytes(1);
+        assert!(matches_eligibility(0.33, tiny).is_some(), "1 byte fits in $0.33 balance");
+
+        // 100 MiB upload: 100 * 1024 * 1024 * 3e-12 ≈ 3.14e-4 credits.
+        // Still affordable on a $0.33 balance.
+        let medium = super::cost_for_bytes(100 * 1024 * 1024);
+        assert!(matches_eligibility(0.33, medium).is_some(), "100 MiB upload fits in $0.33 balance");
+
+        // 1 TiB upload: ≈ 3.3 credits. NOT affordable on $0.33.
+        let huge = super::cost_for_bytes(1024u64 * 1024 * 1024 * 1024);
+        assert!(matches_eligibility(0.33, huge).is_none(), "1 TiB upload does NOT fit in $0.33 balance");
+        assert!(matches_eligibility(10.0, huge).is_some(), "1 TiB upload fits in 10-credit balance");
     }
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -46,6 +46,14 @@ pub enum AppError {
     #[error("Lock poisoned: {0}")]
     Lock(String),
 
+    /// Failures from the persistent sync-intent manifest.
+    ///
+    /// Wrapped as a typed module error (not folded into `Db`) so callers
+    /// distinguish intent-store I/O from generic database operations and
+    /// `IntentError`'s `source()` chain remains intact through `?`.
+    #[error("Sync intent error: {0}")]
+    Intent(#[from] crate::sync::intent::IntentError),
+
     #[error("{0}")]
     Other(String),
 }
@@ -153,6 +161,7 @@ impl Serialize for AppError {
             Self::NotReady(_) => "NotReady",
             Self::Progress(_) => "Progress",
             Self::Lock(_) => "Lock",
+            Self::Intent(_) => "Intent",
             Self::Other(_) => "Other",
         };
 
@@ -461,6 +470,9 @@ mod tests {
             AppError::NotReady(NotReadyKind::ConfigMissing),
             AppError::Progress("tracker".into()),
             AppError::Lock("poisoned".into()),
+            AppError::Intent(crate::sync::intent::IntentError::Db(sqlx::Error::ColumnNotFound(
+                "test_col".into(),
+            ))),
             AppError::Other("misc".into()),
         ];
         let expected_kinds = [
@@ -475,6 +487,7 @@ mod tests {
             "NotReady",
             "Progress",
             "Lock",
+            "Intent",
             "Other",
         ];
 

--- a/src-tauri/src/infra/vm.rs
+++ b/src-tauri/src/infra/vm.rs
@@ -126,7 +126,10 @@ pub async fn create_vm(
     // Enforce credit eligibility at the IPC boundary. Refuses to call
     // the spawn endpoint if the user has fewer than 10 credits OR a zero
     // chain balance — see `crate::billing::eligibility::thresholds`.
-    crate::billing::eligibility::require_eligible(&state, &account_id, crate::billing::eligibility::InsufficientCreditsAction::VmCreation).await?;
+    // VM creation has no upload payload; pass `bytes = 0` so the
+    // bytes-priced layer is a no-op and the gate falls back to the
+    // static `VM_CREATION` threshold (10 credits).
+    crate::billing::eligibility::require_eligible(&state, &account_id, crate::billing::eligibility::InsufficientCreditsAction::VmCreation, 0).await?;
 
     info!(
         name = %params.name,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -506,7 +506,13 @@ pub fn setup(builder: Builder<Wry>) -> Builder<Wry> {
         // Single AppState holds all mutable state — zero statics.
         let app_state = crate::app_state::AppState::new();
         app_state.sync_bridge.set_app_handle(app_handle.clone());
+        // Downgrade BEFORE `manage` consumes the AppState. The
+        // watchdog holds a `Weak<UploadProcessingState>` so app
+        // shutdown can drop the state without keeping it alive via
+        // a long-lived background task. See `spawn_watchdog`.
+        let upload_processing_weak = std::sync::Arc::downgrade(&app_state.upload_processing);
         app_handle.manage(app_state);
+        crate::sync::upload_processing::spawn_watchdog(upload_processing_weak, app_handle.clone());
         let win = app.get_webview_window("main").expect("main window not found");
 
         // Open devtools on startup when `HIPPIUS_DEVTOOLS=1` is set in the

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -511,8 +511,16 @@ pub fn setup(builder: Builder<Wry>) -> Builder<Wry> {
         // shutdown can drop the state without keeping it alive via
         // a long-lived background task. See `spawn_watchdog`.
         let upload_processing_weak = std::sync::Arc::downgrade(&app_state.upload_processing);
+        // Same Weak-before-manage discipline for the preparing-override
+        // watchdog: it self-clears a stuck "Preparing sync…" when
+        // hcfs-client drops a terminal event (drive removed mid-cycle).
+        // It needs the runner too, to force the snapshot re-emit that
+        // pushes the cleared state to the FE.
+        let preparing_weak = std::sync::Arc::downgrade(&app_state.preparing);
+        let sync_weak = std::sync::Arc::downgrade(&app_state.sync);
         app_handle.manage(app_state);
         crate::sync::upload_processing::spawn_watchdog(upload_processing_weak, app_handle.clone());
+        crate::sync::preparing::spawn_watchdog(preparing_weak, sync_weak);
         let win = app.get_webview_window("main").expect("main window not found");
 
         // Open devtools on startup when `HIPPIUS_DEVTOOLS=1` is set in the

--- a/src-tauri/src/shares/commands.rs
+++ b/src-tauri/src/shares/commands.rs
@@ -274,8 +274,15 @@ pub async fn hcfs_create_share(state: tauri::State<'_, AppState>, folder_label: 
     // anonymous HTTP request; we accept the round-trip so that an old
     // server hides the feature instead of failing create_share with a
     // 404 several KB into a multipart upload.
+    //
+    // Sharing's bytes-priced layer is intentionally `0`: the file
+    // already exists in paid storage (the user paid to upload it), and
+    // minting a share token serves anonymous reads from the SAME
+    // ciphertext, not a new upload. The static `Sharing` threshold
+    // (any positive balance) is the right gate here — keeps the
+    // pre-Task-3.1 behavior unchanged for shares.
     require_shares_supported(&state, &account_id).await?;
-    require_eligible(&state, &account_id, InsufficientCreditsAction::Sharing).await?;
+    require_eligible(&state, &account_id, InsufficientCreditsAction::Sharing, 0).await?;
 
     create_share_inner(&state, &account_id, &folder_label, &relative_path).await
 }
@@ -304,7 +311,10 @@ pub async fn hcfs_reshare(state: tauri::State<'_, AppState>, share_token: String
     let account_id = state.current_account_id().map_err(AppError::Other)?;
 
     require_shares_supported(&state, &account_id).await?;
-    require_eligible(&state, &account_id, InsufficientCreditsAction::Sharing).await?;
+    // Sharing's bytes-priced layer is `0` — same rationale as
+    // `hcfs_create_share`: the file already exists in paid storage; a
+    // reshare mints a new token over the same ciphertext.
+    require_eligible(&state, &account_id, InsufficientCreditsAction::Sharing, 0).await?;
 
     let pool = state.pool()?;
 

--- a/src-tauri/src/sync/config.rs
+++ b/src-tauri/src/sync/config.rs
@@ -201,6 +201,10 @@ pub(crate) fn build_hcfs_config(server_url: &str, bearer_token: &str, account_id
         billing_bypass_token: None,
         ss58_address: account_id.to_string(),
         folder_hash: folder_hash.to_string(),
+        // `None` selects hcfs-client's `DEFAULT_READ_TIMEOUT_SECS` (60s).
+        // The desktop has no reason to override yet — set explicitly only
+        // if a deployment profile needs a different per-read deadline.
+        read_timeout_ms: None,
     }
 }
 

--- a/src-tauri/src/sync/credits_exhausted.rs
+++ b/src-tauri/src/sync/credits_exhausted.rs
@@ -1,0 +1,232 @@
+//! Per-label running counter for `InsufficientBalance` file failures.
+//!
+//! Bridges the gap between an individual `FileFailed { kind: InsufficientBalance }`
+//! event and the "Out of credits" banner UX (Task 3.2 of
+//! `docs/plans/2026-05-13-sync-402-data-integrity.md`): the banner needs to
+//! report how many files in the *current* sync cycle have been blocked by
+//! the 402, not just the most recent one. Without a counter, the FE would
+//! either flicker (one event per file replacing the previous payload) or
+//! under-count (showing only "1 file paused" while N files actually were).
+//!
+//! ## Why a separate module
+//!
+//! Mirrors the [`crate::sync::preparing::PreparingState`] composition
+//! pattern exactly: an owned `Arc<Mutex<HashMap<String, u32>>>` field on
+//! `AppState`, methods that take `&self`, no internal `.await` so the
+//! sync-mutex-across-await axiom can never be tripped. Co-locating with
+//! `PreparingState` would conflate two different lifecycles
+//! ("scan-and-plan window" vs. "running 402 count") with no upside.
+//!
+//! ## Lifecycle invariants
+//!
+//! - [`CreditsExhaustedState::record_failure`] — called from the
+//!   `TauriSyncBridge` `FileFailed { kind: InsufficientBalance, .. }` arm.
+//!   Returns the post-increment count for that label so the bridge can
+//!   attach it to the outgoing `hcfs_credits_exhausted` payload in a
+//!   single lock acquisition (read-modify-read would otherwise need two).
+//! - [`CreditsExhaustedState::clear`] — called from `SyncStarted`,
+//!   `SyncStopped`, and the `SyncError` non-cancel branch for the label
+//!   whose cycle is opening or closing. A fresh cycle MUST start at zero
+//!   so the banner's "N files paused" count reflects only the current
+//!   cycle's outstanding failures.
+//! - [`CreditsExhaustedState::clear_all`] — called from `SyncReset`
+//!   (logout / account switch / reset) where every per-label counter
+//!   must be wiped before a different account's data could touch it.
+//!
+//! ## Concurrency
+//!
+//! The inner `std::sync::Mutex` is locked only for the duration of a
+//! single map operation. The bridge handlers that invoke these methods
+//! are synchronous (`SyncEventHandler::on_event` has no `.await`), so the
+//! sync-mutex-across-await axiom holds by construction. A future refactor
+//! that made `on_event` async would need to drop the guard before any
+//! `.await` (the methods here already return owned values, so the guard
+//! never escapes a method).
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+/// Map of drive label → number of `InsufficientBalance` failures observed
+/// in the current sync cycle. Reset to zero on the next `SyncStarted` for
+/// that label, cleared entirely on `SyncReset`.
+///
+/// Owned by [`crate::app_state::AppState`] behind an `Arc`, matching the
+/// existing [`crate::sync::preparing::PreparingState`] /
+/// [`crate::sync::upload_processing::UploadProcessingState`] pattern.
+pub struct CreditsExhaustedState {
+    /// `u32` is sized for the only operation the banner needs: "how many
+    /// files have been 402'd in this cycle?". A drive with more than
+    /// 4 billion 402'd files in one cycle is not a real scenario; if it
+    /// were, the OOM from the file list itself would arrive first.
+    inner: Mutex<HashMap<String, u32>>,
+}
+
+impl Default for CreditsExhaustedState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CreditsExhaustedState {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Acquire the inner mutex with a single poison-message helper.
+    ///
+    /// Centralises the `expect` panic message so future additions to the
+    /// API can't introduce a new wording variant. Poison is fatal for
+    /// this state because the only writer is the (single-threaded)
+    /// bridge handler — if it panicked while holding the guard, the
+    /// invariant the counter encodes is already corrupt.
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, u32>> {
+        self.inner.lock().expect("credits-exhausted mutex poisoned")
+    }
+
+    /// Record one `InsufficientBalance` failure for `label`. Returns the
+    /// post-increment count for the same label.
+    ///
+    /// Returning the post-increment value avoids a follow-up read on the
+    /// same lock acquisition: the bridge needs the count anyway for the
+    /// `file_count` field of the emitted payload, and a separate read
+    /// would either re-lock (waste) or expose a non-atomic "increment
+    /// then read" window where a concurrent `clear` could zero the
+    /// counter between the two operations.
+    pub fn record_failure(&self, label: &str) -> u32 {
+        let mut g = self.lock();
+        let entry = g.entry(label.to_string()).or_insert(0);
+        *entry = entry.saturating_add(1);
+        *entry
+    }
+
+    /// Remove `label` from the map. Returns `true` if the label was
+    /// present (caller can use this to skip a redundant re-emit when
+    /// nothing changed).
+    ///
+    /// Called on `SyncStarted` (fresh cycle), `SyncStopped` (drive paused
+    /// / removed), and the non-cancel branch of `SyncError` (so a
+    /// transport-level cycle failure doesn't leave a stale per-file 402
+    /// count hanging around — a new cycle will re-count from zero).
+    pub fn clear(&self, label: &str) -> bool {
+        self.lock().remove(label).is_some()
+    }
+
+    /// Remove every label's counter. Called from `SyncReset` (logout /
+    /// account switch / reset). Returns `true` if the map was non-empty
+    /// before the clear, mirroring [`PreparingState::clear_all`]'s
+    /// signature so the call sites can be symmetric.
+    pub fn clear_all(&self) -> bool {
+        let mut g = self.lock();
+        let had_entries = !g.is_empty();
+        g.clear();
+        had_entries
+    }
+
+    /// Current count for `label`, or `0` if no failure has been recorded
+    /// this cycle. Read-only diagnostic — tests and the bridge already
+    /// use the value returned by [`record_failure`] so this method is
+    /// not on the hot path.
+    #[doc(hidden)]
+    pub fn count_for(&self, label: &str) -> u32 {
+        self.lock().get(label).copied().unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_failure_returns_running_count() {
+        let state = CreditsExhaustedState::new();
+        assert_eq!(state.record_failure("drive-a"), 1);
+        assert_eq!(state.record_failure("drive-a"), 2);
+        assert_eq!(state.record_failure("drive-a"), 3);
+    }
+
+    #[test]
+    fn record_failure_is_per_label() {
+        let state = CreditsExhaustedState::new();
+        assert_eq!(state.record_failure("drive-a"), 1);
+        assert_eq!(state.record_failure("drive-b"), 1);
+        assert_eq!(state.record_failure("drive-a"), 2);
+        assert_eq!(state.count_for("drive-a"), 2);
+        assert_eq!(state.count_for("drive-b"), 1);
+    }
+
+    #[test]
+    fn clear_resets_a_single_label() {
+        let state = CreditsExhaustedState::new();
+        state.record_failure("drive-a");
+        state.record_failure("drive-a");
+        state.record_failure("drive-b");
+        assert!(state.clear("drive-a"));
+        assert_eq!(state.count_for("drive-a"), 0);
+        // The other label survives — invariant: per-label scoping.
+        assert_eq!(state.count_for("drive-b"), 1);
+    }
+
+    #[test]
+    fn clear_returns_false_when_absent() {
+        let state = CreditsExhaustedState::new();
+        assert!(!state.clear("nobody"));
+    }
+
+    #[test]
+    fn clear_all_removes_every_label() {
+        let state = CreditsExhaustedState::new();
+        state.record_failure("drive-a");
+        state.record_failure("drive-b");
+        assert!(state.clear_all());
+        assert_eq!(state.count_for("drive-a"), 0);
+        assert_eq!(state.count_for("drive-b"), 0);
+    }
+
+    #[test]
+    fn clear_all_returns_false_on_empty() {
+        let state = CreditsExhaustedState::new();
+        assert!(!state.clear_all());
+    }
+
+    #[test]
+    fn count_for_returns_zero_for_unknown_label() {
+        let state = CreditsExhaustedState::new();
+        assert_eq!(state.count_for("never-failed"), 0);
+    }
+
+    /// Re-entrancy guardrail (parallels `PreparingState::mark_then_read_does_not_deadlock_in_sequence`).
+    ///
+    /// `record_failure` MUST release the inner mutex before returning so
+    /// the bridge can call it and then call `count_for`/`clear` in
+    /// sequence on the same thread. `std::sync::Mutex` is non-reentrant
+    /// — a refactor that extended the guard's lifetime (e.g. returning
+    /// the guard alongside the count) would deadlock at runtime.
+    #[test]
+    fn record_then_read_does_not_deadlock_in_sequence() {
+        let state = CreditsExhaustedState::new();
+        assert_eq!(state.record_failure("drive-a"), 1);
+        assert_eq!(state.count_for("drive-a"), 1);
+        assert!(state.clear("drive-a"));
+        assert_eq!(state.count_for("drive-a"), 0);
+    }
+
+    /// `u32::saturating_add(1)` clamps at `u32::MAX` instead of wrapping
+    /// to zero. The banner would otherwise report "0 files paused" after
+    /// the 4-billion-and-first failure — wrong, but a textbook overflow.
+    /// Saturating is the right semantic: hitting the cap means "very
+    /// many files failed", and clamping preserves the "≥1" invariant the
+    /// banner reads.
+    #[test]
+    fn record_failure_saturates_instead_of_wrapping() {
+        let state = CreditsExhaustedState::new();
+        // Seed the counter at u32::MAX via direct map access. Going
+        // through `record_failure` u32::MAX times is not feasible in a
+        // unit test, so we reach into the lock once and seed.
+        state.lock().insert("drive-a".to_string(), u32::MAX);
+        // Next `record_failure` MUST stay at u32::MAX, not wrap to 0.
+        assert_eq!(state.record_failure("drive-a"), u32::MAX);
+        assert_eq!(state.count_for("drive-a"), u32::MAX);
+    }
+}

--- a/src-tauri/src/sync/events.rs
+++ b/src-tauri/src/sync/events.rs
@@ -72,6 +72,16 @@ pub const FILE_FAILED: &str = "hcfs_file_failed";
 /// banner while `active = true`. State is owned by
 /// `crate::sync::upload_processing::UploadProcessingState`.
 pub const UPLOAD_PROCESSING: &str = "hcfs_upload_processing";
+/// Emitted when an `InsufficientBalance` (HTTP 402) per-file failure
+/// arrives at the bridge. Carries the latest `balance_cents` /
+/// `required_cents` from the server response plus a running
+/// `file_count` of 402'd files in the current cycle. The FE renders a
+/// dedicated "Out of credits" banner — distinct from the generic
+/// `hcfs_file_failed` per-file detail event so the banner can show a
+/// "Top up" CTA and survive across multiple 402'd files without
+/// flickering. State is owned by
+/// `crate::sync::credits_exhausted::CreditsExhaustedState`.
+pub const CREDITS_EXHAUSTED: &str = "hcfs_credits_exhausted";
 
 /// Exact stringification of [`hcfs_client::sync::SyncError::Cancelled`].
 ///
@@ -389,4 +399,31 @@ pub struct FileFailedPayload {
     pub file_id: String,
     pub kind: FileFailureKindPayload,
     pub http_status: Option<u16>,
+}
+
+/// Payload for [`CREDITS_EXHAUSTED`] — emitted alongside (not in place of)
+/// `FILE_FAILED` whenever a per-file failure carries the
+/// `InsufficientBalance` kind.
+///
+/// `balance_cents` / `required_cents` reflect the **latest** server
+/// response — concurrent failures inside the same cycle may report
+/// different values if the user partially tops up mid-cycle; the FE
+/// banner shows the most recent values, matching server truth at the
+/// last observed failure. `file_count` is the running total of 402'd
+/// files for `label` in the current sync cycle, sourced from
+/// [`crate::sync::credits_exhausted::CreditsExhaustedState::record_failure`].
+/// It resets to zero on the next `SyncStarted` for that label.
+///
+/// Note: this event is NOT a substitute for `FILE_FAILED`. The bridge
+/// emits both — the FE row icon listens to `FILE_FAILED`, the banner
+/// listens to this. Routing them through one event would force the
+/// banner to filter by kind and would make Task 2.7's per-file-row
+/// invariant fragile.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreditsExhaustedPayload {
+    pub label: String,
+    pub balance_cents: i64,
+    pub required_cents: i64,
+    pub file_count: u32,
 }

--- a/src-tauri/src/sync/events.rs
+++ b/src-tauri/src/sync/events.rs
@@ -82,6 +82,28 @@ pub const UPLOAD_PROCESSING: &str = "hcfs_upload_processing";
 /// flickering. State is owned by
 /// `crate::sync::credits_exhausted::CreditsExhaustedState`.
 pub const CREDITS_EXHAUSTED: &str = "hcfs_credits_exhausted";
+/// Emitted when the per-drive first-reconcile retry budget is
+/// exhausted (every attempt failed with either retryable or
+/// terminal errors). Tells the frontend to surface a per-drive
+/// "couldn't refresh upload dates" banner so the user knows the
+/// "DATE UPLOADED" column may be sparse for this drive. Cleared
+/// when the same drive next emits `ACTIVITY_UPDATED` (e.g. after a
+/// successful sync cycle backfills the missing timestamps).
+///
+/// Payload is [`MetadataStalePayload`]: `{ label, reason }` where
+/// `reason` is a short human-readable string. Distinct from the
+/// per-cycle `SYNC_ERROR` channel because reconcile failure is a
+/// metadata-only condition — the drive itself is still usable.
+pub const METADATA_STALE: &str = "hcfs_metadata_stale";
+
+/// Wire payload for [`METADATA_STALE`]. `label` is the drive's
+/// stable label string; `reason` is for display only (the FE
+/// renders it under the banner heading).
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct MetadataStalePayload {
+    pub label: String,
+    pub reason: String,
+}
 
 /// Exact stringification of [`hcfs_client::sync::SyncError::Cancelled`].
 ///

--- a/src-tauri/src/sync/events.rs
+++ b/src-tauri/src/sync/events.rs
@@ -55,6 +55,17 @@ pub const DRIVE_STATUS_CHANGED: &str = "hcfs_drive_status_changed";
 pub const DRIVE_REMOVED: &str = "hcfs_drive_removed";
 /// Emitted when files have repeatedly failed to sync (threshold reached).
 pub const FILES_FAILED_REPEATEDLY: &str = "hcfs_files_failed_repeatedly";
+/// Emitted the moment hcfs-client classifies a per-file upload or download
+/// as failed (e.g. server returned 402 InsufficientBalance, 5xx, network
+/// error). Carries a typed [`FileFailureKindPayload`] so the FE can switch
+/// on the failure category without parsing display strings.
+///
+/// Per-file failures are NOT cycle failures — the existing
+/// `hcfs_sync_error` channel is reserved for cycle-level errors (cancel,
+/// auth, etc.). A single 402'd file inside an otherwise-healthy cycle
+/// surfaces here and through the snapshot's `FileProgressStatus::Error`
+/// row; cycle-level `SyncCompleted` still fires with the survivors.
+pub const FILE_FAILED: &str = "hcfs_file_failed";
 /// Emitted when a user-initiated upload (`add_file` / `add_files` /
 /// `add_folder`) is in its disk-copy + encryption window before any
 /// byte of network transfer fires. The frontend renders a top-of-page
@@ -291,4 +302,91 @@ pub struct AuthRequiredPayload {
 #[serde(rename_all = "camelCase")]
 pub struct FilesFailedRepeatedlyPayload {
     pub files: Vec<crate::sync::failure_tracking::FailedFileInfo>,
+}
+
+/// Desktop-side serializable mirror of [`hcfs_client::engine::events::FileFailureKind`].
+///
+/// The upstream enum does NOT derive `Serialize` (verified at
+/// `hcfs-client/src/engine/events.rs:33`), so we cannot forward it as-is
+/// through Tauri's JSON IPC. Translating to a local enum is the right
+/// boundary: it (a) gives us a `Serialize` impl without forking
+/// hcfs-client, (b) pins the wire format the FE consumes independently of
+/// upstream variant additions (the upstream type is `#[non_exhaustive]`),
+/// and (c) keeps the FE's `kind` discriminant stable in `camelCase` per
+/// existing convention. The `#[non_exhaustive]` annotation matches the
+/// upstream's stability contract — future upstream variants will be
+/// surfaced as `Other` until we extend the translation map.
+///
+/// Wire shape (tagged union, internally discriminated by `kind`):
+/// ```json
+/// {"kind":"insufficientBalance","balanceCents":12,"requiredCents":100}
+/// {"kind":"serverError","status":500}
+/// {"kind":"network"}
+/// {"kind":"other","message":"unrecognised upload failure"}
+/// ```
+#[derive(Serialize, Clone, Debug)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+#[non_exhaustive]
+pub enum FileFailureKindPayload {
+    /// Server returned HTTP 402 — account credit balance is below the
+    /// storage cost. Mirrors `FileFailureKind::InsufficientBalance`.
+    #[serde(rename_all = "camelCase")]
+    InsufficientBalance { balance_cents: i64, required_cents: i64 },
+    /// Server returned a non-402 HTTP error code (5xx, 416, 429, …).
+    /// `status` is the wire status the FE may dispatch on.
+    ServerError { status: u16 },
+    /// Transport-layer failure — connection refused, DNS, TLS, timeout.
+    /// No HTTP status because no response was received.
+    Network,
+    /// Fallback for failures we have not categorised. `message` is for
+    /// display only — the FE MUST NOT parse it as a stable contract.
+    Other { message: String },
+}
+
+impl From<&hcfs_client::engine::events::FileFailureKind> for FileFailureKindPayload {
+    fn from(kind: &hcfs_client::engine::events::FileFailureKind) -> Self {
+        use hcfs_client::engine::events::FileFailureKind as K;
+        match kind {
+            K::InsufficientBalance {
+                balance_cents,
+                required_cents,
+            } => Self::InsufficientBalance {
+                balance_cents: *balance_cents,
+                required_cents: *required_cents,
+            },
+            K::ServerError { status } => Self::ServerError { status: *status },
+            K::Network => Self::Network,
+            // Upstream `Other(String)` carries display text. Clone-on-translate is
+            // unavoidable (we own the wire payload); the alternative would be borrowing
+            // and the bridge needs an owned struct for `app.emit`.
+            K::Other(msg) => Self::Other { message: msg.clone() },
+            // `#[non_exhaustive]` upstream: future variants render as `Other` with
+            // their debug form. The translation map should be extended when a new
+            // upstream variant ships — until then, the FE's `other` branch
+            // keeps the wire contract intact.
+            other => Self::Other {
+                message: format!("{other:?}"),
+            },
+        }
+    }
+}
+
+/// Payload for [`FILE_FAILED`] — emitted once per per-file failure inside
+/// a sync cycle (in addition to, not in place of, the per-cycle
+/// `SyncCompleted.files_failed` counter and the per-file snapshot row).
+///
+/// `path` is the **plan-time** snapshot from
+/// `hcfs_client::engine::events::SyncEvent::FileFailed::path`, not the
+/// live filesystem path. If the local file was renamed between plan and
+/// failure, this is the pre-rename path — the FE may need to reconcile
+/// against the live filesystem (see upstream doc comment on
+/// `SyncEvent::FileFailed::path`).
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct FileFailedPayload {
+    pub label: String,
+    pub path: String,
+    pub file_id: String,
+    pub kind: FileFailureKindPayload,
+    pub http_status: Option<u16>,
 }

--- a/src-tauri/src/sync/events.rs
+++ b/src-tauri/src/sync/events.rs
@@ -341,7 +341,7 @@ pub enum FileFailureKindPayload {
     /// Server returned HTTP 402 — account credit balance is below the
     /// storage cost. Mirrors `FileFailureKind::InsufficientBalance`.
     #[serde(rename_all = "camelCase")]
-    InsufficientBalance { balance_cents: i64, required_cents: i64 },
+    InsufficientBalance { balance_cents: u64, required_cents: u64 },
     /// Server returned a non-402 HTTP error code (5xx, 416, 429, …).
     /// `status` is the wire status the FE may dispatch on.
     ServerError { status: u16 },
@@ -423,7 +423,7 @@ pub struct FileFailedPayload {
 #[serde(rename_all = "camelCase")]
 pub struct CreditsExhaustedPayload {
     pub label: String,
-    pub balance_cents: i64,
-    pub required_cents: i64,
+    pub balance_cents: u64,
+    pub required_cents: u64,
     pub file_count: u32,
 }

--- a/src-tauri/src/sync/files.rs
+++ b/src-tauri/src/sync/files.rs
@@ -116,13 +116,28 @@ pub async fn add_file(
     sync_path: String,
     file_path: String,
 ) -> Result<String> {
-    // Enforce credit eligibility at the IPC boundary. Even if a stale
-    // FE cache let the user click the upload button, this fails the
-    // operation here so we never copy the file into the sync folder
-    // (and thus never trigger an upload that would silently fail
-    // server-side for billing reasons).
+    // Enforce credit eligibility at the IPC boundary, priced by actual
+    // file size. The FE may still hit a 402 from hcfs-server if the
+    // balance drops between gate and upload (concurrent device or
+    // billing tick), but this gate prevents the common case where the
+    // user obviously cannot afford the upload — addresses sync-402
+    // plan Task 3.1.
+    //
+    // A `metadata` failure (file removed between picker and IPC,
+    // permission denied, broken symlink) gates with `bytes = 0` so the
+    // legacy `> 0` floor still applies — the subsequent `copy_dir_recursive`
+    // / `tokio::fs::copy` will surface the I/O error to the user with
+    // its native message. Don't `?`-bail here: a missing-file diagnostic
+    // is clearer than "insufficient credits because we couldn't size it".
     let account_id = state.current_account_id().map_err(crate::error::AppError::Other)?;
-    crate::billing::eligibility::require_eligible(&state, &account_id, crate::billing::eligibility::InsufficientCreditsAction::FileUpload).await?;
+    let bytes = tokio::fs::metadata(Path::new(&file_path)).await.map_or(0, |m| m.len());
+    crate::billing::eligibility::require_eligible(
+        &state,
+        &account_id,
+        crate::billing::eligibility::InsufficientCreditsAction::FileUpload,
+        bytes,
+    )
+    .await?;
 
     // Mark the processing window. Released either by the first upload
     // chunk of the NEXT sync cycle (success path, gated by
@@ -165,9 +180,20 @@ pub async fn add_folder(
     subfolder: Option<String>,
 ) -> Result<String> {
     // Enforce credit eligibility at the IPC boundary — same rationale
-    // as `add_file`.
+    // as `add_file`, but priced by the recursive byte total of the
+    // source folder. A folder with permission-denied subdirectories
+    // returns a best-effort lower bound (see `sum_regular_file_bytes`),
+    // which under-charges rather than over-charging the user — the
+    // server's 402 path is still the last line of defense.
     let account_id = state.current_account_id().map_err(crate::error::AppError::Other)?;
-    crate::billing::eligibility::require_eligible(&state, &account_id, crate::billing::eligibility::InsufficientCreditsAction::FolderUpload).await?;
+    let bytes = sum_regular_file_bytes(Path::new(&folder_path)).await;
+    crate::billing::eligibility::require_eligible(
+        &state,
+        &account_id,
+        crate::billing::eligibility::InsufficientCreditsAction::FolderUpload,
+        bytes,
+    )
+    .await?;
 
     // Pre-walk the source tree so the banner shows an accurate count.
     // Cheap relative to the full copy (no file-content reads).
@@ -306,6 +332,90 @@ async fn count_regular_files(root: &std::path::Path) -> u64 {
         }
     }
     count
+}
+
+/// Sum the byte size of regular files (non-directory, non-symlink) under
+/// `root`, recursively. Used by the credit-eligibility gate in
+/// `add_folder`, `add_files`, and `add_local_sync_folder` to compute the
+/// total upload payload BEFORE invoking
+/// `crate::billing::eligibility::require_eligible`.
+///
+/// Same invariants as [`count_regular_files`]:
+/// - Iterative depth-first walk via explicit stack (no recursive async
+///   boxing); cap depth at [`FOLDER_BYTE_WALK_MAX_DEPTH`] entries on the
+///   stack to defend against symlink-cycle pathological cases. The cap
+///   bounds the stack, not the total file count; the walk reads only
+///   directory entries (no file content), so the I/O cost is the same
+///   as `copy_dir_recursive` is already about to pay.
+/// - Per-subdirectory I/O errors (permission denied, hardware faults)
+///   are silently skipped via `continue` so the gate doesn't fail an
+///   upload because ONE unreadable subdir made the byte-sum
+///   undercount — the legitimate uploads still get gated on the
+///   surviving bytes. A wholly-unreadable root returns `0`, which
+///   correctly falls back to the static `> 0` threshold floor.
+/// - Symlinks are NOT followed (`DirEntry::file_type` is lstat-shaped),
+///   matching `count_regular_files` and avoiding loops.
+/// - Each per-file size comes from `DirEntry::metadata`, which calls
+///   `stat` on the entry itself (NOT the symlink target, since `ft`
+///   already classified it as a regular file). Sizes are summed via
+///   `saturating_add` so a malicious sparse file or `u64::MAX` length
+///   can't panic.
+pub(super) async fn sum_regular_file_bytes(root: &std::path::Path) -> u64 {
+    use tokio::fs;
+
+    let mut bytes: u64 = 0;
+    let mut stack: Vec<std::path::PathBuf> = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        // Defense in depth: a symlink cycle could push entries forever
+        // even though we don't follow symlinks at the entry level — a
+        // legitimate `mount --bind` cycle, hardlinked directories on
+        // non-POSIX filesystems, or an attacker pre-seeding the
+        // directory tree could push the stack arbitrarily. The cap
+        // matches the recursion depth used elsewhere in this module
+        // (`copy_dir_recursive`).
+        if stack.len() > FOLDER_BYTE_WALK_MAX_DEPTH {
+            break;
+        }
+        let Ok(mut entries) = fs::read_dir(&dir).await else { continue };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let Ok(ft) = entry.file_type().await else { continue };
+            if ft.is_dir() {
+                stack.push(entry.path());
+            } else if ft.is_file()
+                && let Ok(meta) = entry.metadata().await
+            {
+                bytes = bytes.saturating_add(meta.len());
+            }
+        }
+    }
+    bytes
+}
+
+/// Stack-depth cap for [`sum_regular_file_bytes`]. Sized to match the
+/// 64-level cap that `copy_dir_recursive` already enforces — a folder
+/// deeper than this would fail the subsequent copy anyway, so refusing
+/// to walk further is consistent with the rest of the module.
+const FOLDER_BYTE_WALK_MAX_DEPTH: usize = 4096;
+
+/// Recursively sum the byte size of a heterogeneous batch of paths
+/// (a mix of regular files and directories). Used by `add_files` to
+/// compute the credit-eligibility byte total. Each direct file path is
+/// sized via `tokio::fs::metadata`; each directory is walked through
+/// [`sum_regular_file_bytes`]. Per-path metadata failures degrade to
+/// zero so a missing or unreadable entry doesn't reject the rest of
+/// the batch — the subsequent copy loop surfaces the real I/O error.
+async fn sum_batch_bytes(paths: &[String]) -> u64 {
+    let mut total: u64 = 0;
+    for fp in paths {
+        let p = std::path::Path::new(fp);
+        let add = if p.is_dir() {
+            sum_regular_file_bytes(p).await
+        } else {
+            tokio::fs::metadata(p).await.map_or(0, |m| m.len())
+        };
+        total = total.saturating_add(add);
+    }
+    total
 }
 
 /// Internal folder copy — no sync trigger (caller handles it).
@@ -504,13 +614,20 @@ pub async fn add_files(
     // boundary. The per-file `add_file_internal` calls inside the loop
     // below do NOT re-check — there's no point hammering the billing
     // API once per file when the batch is treated as a single unit.
+    //
+    // The byte sum drives the price: each direct file path is sized via
+    // `tokio::fs::metadata`, each directory path is walked recursively
+    // via `sum_regular_file_bytes`. Per-path metadata failures degrade
+    // to 0 so a missing file in the input list doesn't reject the rest
+    // of the batch — the subsequent copy loop surfaces the I/O error.
     let account_id = state.current_account_id().map_err(crate::error::AppError::Other)?;
     let action = if for_folder {
         crate::billing::eligibility::InsufficientCreditsAction::FolderUpload
     } else {
         crate::billing::eligibility::InsufficientCreditsAction::FileUpload
     };
-    crate::billing::eligibility::require_eligible(&state, &account_id, action).await?;
+    let total_bytes = sum_batch_bytes(&file_paths).await;
+    crate::billing::eligibility::require_eligible(&state, &account_id, action, total_bytes).await?;
 
     // Sum the file count for the banner. Each direct file path counts
     // as 1; each directory path gets a recursive walk via

--- a/src-tauri/src/sync/files.rs
+++ b/src-tauri/src/sync/files.rs
@@ -835,7 +835,15 @@ use hcfs_client::engine::types::{SyncedFileInfo, build_synced_paths_from_state};
 /// is also refreshed. When the lock is unavailable (sync in progress),
 /// falls back to the last cached snapshot so the file browser still
 /// shows accurate sync status instead of "unknown".
+///
+/// Waits up to [`FIRST_RECONCILE_WAIT_BUDGET`] for the per-drive
+/// reconcile readiness gate so the cache contains authoritative
+/// timestamps on cold start. See
+/// [`synced_paths_and_excludes_for_label`] for the full rationale.
 async fn synced_paths_for_label(sync: &SyncRunner, label: &str) -> Option<HashMap<String, SyncedFileInfo>> {
+    let _ = sync
+        .wait_for_first_reconcile(label, FIRST_RECONCILE_WAIT_BUDGET)
+        .await;
     let arc = match acquire_drive_arc(sync, label) {
         DriveArcOutcome::Acquired(arc) => arc,
         DriveArcOutcome::CacheFallback => return sync.get_cached_synced_paths(label),
@@ -861,11 +869,29 @@ async fn synced_paths_for_label(sync: &SyncRunner, label: &str) -> Option<HashMa
 /// Read both the synced-paths map and the exclusion patterns for `label`
 /// behind a single outer-drives lock acquisition.
 ///
-/// Eliminates the two-acquire pattern flagged by the perf audit: callers
-/// like `list_sync_folder_inner` previously locked `sync.drives` once for
-/// synced paths and again for exclude patterns. Both values are produced
-/// from the same `manager` borrow in a single per-drive lock window.
+/// Before reading the cache, wait up to [`FIRST_RECONCILE_WAIT_BUDGET`]
+/// for the per-drive readiness gate to settle. This closes the cold-
+/// start race where `get_user_files` would observe a stale cache
+/// (with `uploaded_at = 0` for any file the local `sync_state.json`
+/// is missing timestamps for) before the background reconcile
+/// finished its first attempt. Net effect: first Files-page render
+/// after login shows correct upload dates instead of "—" until the
+/// user logs out and back in. Per-drive wait, parallel across
+/// drives because `get_user_files` fans out via `join_all`, so the
+/// worst-case latency is bounded by the budget itself, not by drive
+/// count.
 async fn synced_paths_and_excludes_for_label(sync: &SyncRunner, label: &str) -> (Option<HashMap<String, SyncedFileInfo>>, Vec<String>) {
+    // Block reads until the first reconcile has settled (or the
+    // budget elapses). We discard the outcome here — the cache
+    // contents are what we read below; this wait only serves to
+    // delay the read until those contents are trustworthy. A
+    // `Timeout` / `NotRegistered` falls through to whatever stale
+    // state we have, matching the existing graceful-degradation
+    // contract.
+    let _ = sync
+        .wait_for_first_reconcile(label, FIRST_RECONCILE_WAIT_BUDGET)
+        .await;
+
     let arc = match acquire_drive_arc(sync, label) {
         DriveArcOutcome::Acquired(arc) => arc,
         DriveArcOutcome::CacheFallback => return (sync.get_cached_synced_paths(label), Vec::new()),
@@ -887,6 +913,16 @@ async fn synced_paths_and_excludes_for_label(sync: &SyncRunner, label: &str) -> 
         Err(_) => (sync.get_cached_synced_paths(label), Vec::new()),
     }
 }
+
+/// Maximum time `synced_paths_and_excludes_for_label` is willing to
+/// wait for a drive's first reconcile to settle before reading the
+/// cache. Sized to comfortably cover the production retry schedule
+/// (0s / 2s / 5s = up to ~7s for the third attempt to start) with a
+/// small margin: at 6s we accept that an extremely slow third
+/// attempt may finish after we've returned and let the
+/// `ACTIVITY_UPDATED` event refresh the FE — the worst case is
+/// one extra refetch, not a stale forever read.
+const FIRST_RECONCILE_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(6);
 
 /// Outcome of locating a per-drive `DriveManager` Arc behind the outer
 /// drives map. Either we got the Arc, or the outer/inner lookup failed and
@@ -2611,5 +2647,106 @@ mod tests {
         assert_eq!(count, 2, "fresh walk must count files");
 
         dir_stats_cache().lock().expect("lock").remove(dir);
+    }
+
+    // ── first-reconcile readiness wait ────────────────────────────────
+
+    /// Regression test for the cold-start race: a `wait_for_first_reconcile`
+    /// call against a registered-but-unsettled gate must block until the
+    /// gate settles, NOT return immediately. Without this guard,
+    /// `synced_paths_and_excludes_for_label` would observe an empty cache
+    /// and `get_user_files` would return rows with `uploaded_at = 0`,
+    /// rendering "—" in the UI until the user logged out and back in.
+    #[tokio::test]
+    async fn wait_for_first_reconcile_blocks_until_settle() {
+        use hcfs_client::drive::ReconcileOutcome;
+        use hcfs_client::engine::events::{NoopCallbacks, NoopEventHandler};
+        use hcfs_client::engine::runner::{SyncRunner, WaitOutcome};
+        use std::sync::Arc;
+        use std::time::{Duration, Instant};
+
+        let sync = Arc::new(SyncRunner::new(
+            Arc::new(NoopEventHandler),
+            Arc::new(NoopCallbacks),
+            reqwest::Client::new(),
+        ));
+
+        // Producer side: pre-register the gate (mirrors what
+        // `spawn_reconcile_timestamps` does the moment the drive is
+        // registered, before its background task starts running).
+        let label = "drive-cold-start";
+        let _gate = sync.first_reconcile_gate(label);
+
+        // Settle the gate after a delay shorter than the wait budget.
+        // The consumer must observe the outcome via the `changed()`
+        // path on `watch::Receiver`, not the initial `borrow()`
+        // fast path.
+        let sync_settle = Arc::clone(&sync);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(40)).await;
+            sync_settle
+                .first_reconcile_gate("drive-cold-start")
+                .settle(ReconcileOutcome::Reconciled { duration_ms: 5 });
+        });
+
+        let start = Instant::now();
+        let outcome = sync
+            .wait_for_first_reconcile(label, Duration::from_millis(500))
+            .await;
+        let elapsed = start.elapsed();
+
+        match outcome {
+            WaitOutcome::Ready(ReconcileOutcome::Reconciled { duration_ms }) => {
+                assert_eq!(duration_ms, 5);
+            }
+            other => panic!("expected Ready(Reconciled), got {other:?}"),
+        }
+        // The wait must have BLOCKED at least until the settle fired
+        // (~40ms) — proving the cache-read isn't racing the producer.
+        // Generous lower bound to absorb scheduler jitter.
+        assert!(
+            elapsed >= Duration::from_millis(20),
+            "wait returned too quickly ({}ms) — the readiness gate is not actually blocking",
+            elapsed.as_millis(),
+        );
+        // And the wait must NOT have run the full budget. If we hit
+        // the budget, the settle didn't reach the awaiter.
+        assert!(
+            elapsed < Duration::from_millis(450),
+            "wait exhausted budget ({}ms) — settle was missed",
+            elapsed.as_millis(),
+        );
+    }
+
+    /// When no gate is registered for a label (e.g. drive not in the
+    /// registry yet, or already torn down), `wait_for_first_reconcile`
+    /// must return `NotRegistered` immediately — never block on a
+    /// missing producer. The desktop's read paths interpret this as
+    /// "fall through to cache", same as `Timeout`.
+    #[tokio::test]
+    async fn wait_for_first_reconcile_does_not_block_on_missing_label() {
+        use hcfs_client::engine::events::{NoopCallbacks, NoopEventHandler};
+        use hcfs_client::engine::runner::{SyncRunner, WaitOutcome};
+        use std::sync::Arc;
+        use std::time::{Duration, Instant};
+
+        let sync = Arc::new(SyncRunner::new(
+            Arc::new(NoopEventHandler),
+            Arc::new(NoopCallbacks),
+            reqwest::Client::new(),
+        ));
+
+        let start = Instant::now();
+        let outcome = sync
+            .wait_for_first_reconcile("does-not-exist", Duration::from_secs(5))
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(matches!(outcome, WaitOutcome::NotRegistered), "got {outcome:?}");
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "NotRegistered must return immediately, took {}ms",
+            elapsed.as_millis(),
+        );
     }
 }

--- a/src-tauri/src/sync/files.rs
+++ b/src-tauri/src/sync/files.rs
@@ -139,13 +139,26 @@ pub async fn add_file(
     )
     .await?;
 
+    // Resolve the local sync-root path to its drive label. The
+    // banner state is per-label (Task 4.1) so an active banner on
+    // drive A no longer suppresses drive B's preparing widget. If
+    // the row is gone (race with a drive removal) `label_opt` is
+    // `None` and every banner write becomes a no-op for this IPC.
+    let pool = state.pool()?;
+    let label_opt = crate::sync::paths::label_for_sync_path(pool, &account_id, &sync_path)
+        .await
+        .ok()
+        .flatten();
+
     // Mark the processing window. Released either by the first upload
     // chunk of the NEXT sync cycle (success path, gated by
     // `sync_session_epoch` in `handle_transfer_progress`) or by the
     // error guard below (failure path — IPC failed before any cycle
     // ran, so unconditional `reset` is correct).
     let epoch = state.sync_session_epoch.load(std::sync::atomic::Ordering::SeqCst);
-    state.upload_processing.begin(&app, 1, epoch);
+    if let Some(label) = label_opt.as_deref() {
+        state.upload_processing.begin(&app, label, 1, epoch);
+    }
 
     // Canonicalize the sync path once and pass it to the internal helper
     // so the helper can be cheap when called per-file from the batch path.
@@ -157,14 +170,18 @@ pub async fn add_file(
     let canonical_parent = match tokio::fs::canonicalize(Path::new(&sync_path)).await {
         Ok(p) => p,
         Err(e) => {
-            state.upload_processing.reset(&app);
+            if let Some(label) = label_opt.as_deref() {
+                state.upload_processing.reset(&app, label);
+            }
             return Err(crate::error::AppError::Other(format!("Invalid sync path: {e}")));
         }
     };
     match add_file_internal(&canonical_parent, &file_path).await {
         Ok(name) => Ok(name),
         Err(e) => {
-            state.upload_processing.reset(&app);
+            if let Some(label) = label_opt.as_deref() {
+                state.upload_processing.reset(&app, label);
+            }
             Err(e)
         }
     }
@@ -195,6 +212,15 @@ pub async fn add_folder(
     )
     .await?;
 
+    // Resolve `sync_path` → drive label so the banner state can be
+    // scoped per-label (Task 4.1). Banner writes degrade to no-op
+    // when the row is absent (drive removed mid-IPC race).
+    let pool = state.pool()?;
+    let label_opt = crate::sync::paths::label_for_sync_path(pool, &account_id, &sync_path)
+        .await
+        .ok()
+        .flatten();
+
     // Pre-walk the source tree so the banner shows an accurate count.
     // Cheap relative to the full copy (no file-content reads).
     //
@@ -206,9 +232,11 @@ pub async fn add_folder(
     // can complete without firing `SyncCompleted` in some hcfs-client
     // configurations).
     let count = count_regular_files(Path::new(&folder_path)).await;
-    if count > 0 {
+    if count > 0
+        && let Some(label) = label_opt.as_deref()
+    {
         let epoch = state.sync_session_epoch.load(std::sync::atomic::Ordering::SeqCst);
-        state.upload_processing.begin(&app, count, epoch);
+        state.upload_processing.begin(&app, label, count, epoch);
     }
 
     let result = add_folder_with_app_inner(&sync_path, &folder_path, subfolder.as_deref()).await;
@@ -222,8 +250,11 @@ pub async fn add_folder(
         }
         Err(e) => {
             // IPC failed before any sync cycle ran — unconditional
-            // reset is correct (no cycle epoch to gate on).
-            state.upload_processing.reset(&app);
+            // reset is correct (no cycle epoch to gate on). No-op
+            // when no label resolved or when `begin` was skipped.
+            if let Some(label) = label_opt.as_deref() {
+                state.upload_processing.reset(&app, label);
+            }
             Err(e)
         }
     }
@@ -602,6 +633,10 @@ pub struct AddFilesResult {
 /// would silently use the wrong threshold if the FE classified
 /// incorrectly.
 #[tauri::command]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Linear early-return flow with per-step banner reset (Task 4.1); splitting into helpers would either re-route the banner reset through trait/closure plumbing or fragment the canonicalize-then-validate sequence."
+)]
 pub async fn add_files(
     app: AppHandle,
     state: tauri::State<'_, crate::app_state::AppState>,
@@ -650,49 +685,67 @@ pub async fn add_files(
             total_count = total_count.saturating_add(1);
         }
     }
-    if total_count > 0 {
+    // Resolve `sync_path` → drive label once before any banner write
+    // so the per-label state (Task 4.1) can route every `begin`/`reset`
+    // for this IPC to the right drive. Banner writes degrade to no-op
+    // when the row is absent.
+    let pool = state.pool()?;
+    let label_opt = crate::sync::paths::label_for_sync_path(pool, &account_id, &sync_path)
+        .await
+        .ok()
+        .flatten();
+
+    if total_count > 0
+        && let Some(label) = label_opt.as_deref()
+    {
         let epoch = state.sync_session_epoch.load(std::sync::atomic::Ordering::SeqCst);
-        state.upload_processing.begin(&app, total_count, epoch);
+        state.upload_processing.begin(&app, label, total_count, epoch);
     }
+
+    // Reset helper: scoped to the resolved label, no-op when none.
+    // Each fallible early-return path below calls this before
+    // returning so the banner doesn't sit until the watchdog timeout.
+    // Unconditional reset is correct here because the IPC failed
+    // before any sync cycle could run.
+    let reset_banner = |app: &AppHandle, state: &crate::app_state::AppState| {
+        if let Some(label) = label_opt.as_deref() {
+            state.upload_processing.reset(app, label);
+        }
+    };
 
     // When a subfolder is specified, resolve the effective target directory.
     // This replaces the path-join logic that was previously in TypeScript.
     // Async canonicalize so a slow filesystem doesn't block the tokio worker.
-    //
-    // After `begin` above, every fallible early-return path here MUST call
-    // `reset` first — otherwise the banner sits there until the watchdog
-    // timeout while the IPC has already failed. Unconditional `reset` is
-    // correct because the IPC failed before any sync cycle could run.
     let target_path = if let Some(ref sub) = subfolder {
         // Reject traversal components
         if sub.contains("..") {
-            state.upload_processing.reset(&app);
+            reset_banner(&app, &state);
             return Err(crate::error::AppError::Other("Subfolder path contains traversal component".into()));
         }
         let target = Path::new(&sync_path).join(sub);
         if !target.exists()
             && let Err(e) = std::fs::create_dir_all(&target)
         {
-            state.upload_processing.reset(&app);
+            reset_banner(&app, &state);
             return Err(crate::error::AppError::Other(format!("Failed to create subfolder: {e}")));
         }
         // Verify resolved path stays within sync root.
         let canonical_root = match tokio::fs::canonicalize(Path::new(&sync_path)).await {
             Ok(p) => p,
             Err(e) => {
-                state.upload_processing.reset(&app);
+                reset_banner(&app, &state);
                 return Err(crate::error::AppError::Other(format!("Invalid sync path: {e}")));
             }
         };
         let canonical_target = match tokio::fs::canonicalize(&target).await {
             Ok(p) => p,
             Err(e) => {
-                state.upload_processing.reset(&app);
+                reset_banner(&app, &state);
                 return Err(crate::error::AppError::Other(format!("Invalid subfolder path: {e}")));
             }
         };
         if !canonical_target.starts_with(&canonical_root) {
-            state.upload_processing.reset(&app);
+            reset_banner(&app, &state);
             return Err(crate::error::AppError::Other("Subfolder escapes sync folder".into()));
         }
         target.to_string_lossy().to_string()
@@ -706,7 +759,7 @@ pub async fn add_files(
     let canonical_target = match tokio::fs::canonicalize(Path::new(&target_path)).await {
         Ok(p) => p,
         Err(e) => {
-            state.upload_processing.reset(&app);
+            reset_banner(&app, &state);
             return Err(crate::error::AppError::Other(format!("Invalid sync path: {e}")));
         }
     };
@@ -754,10 +807,10 @@ pub async fn add_files(
     // Unconditional `reset` is correct: the batch never produced any
     // upload work, so there is no future cycle whose epoch we need
     // to gate against. `reset` is safe even if `begin` was never
-    // called (e.g. `total_count` was 0 above): it short-circuits when
-    // state is already inactive.
+    // called (e.g. `total_count` was 0 above): the per-label `remove`
+    // short-circuits when no entry exists.
     if added.is_empty() {
-        state.upload_processing.reset(&app);
+        reset_banner(&app, &state);
     }
 
     // Always trigger sync so successfully added files get uploaded
@@ -2262,14 +2315,9 @@ mod tests {
             .await
             .expect_err("must reject sync root as source");
         let msg = err.to_string();
-        assert!(
-            msg.contains("Cannot add the sync folder"),
-            "unexpected error message: {msg}"
-        );
+        assert!(msg.contains("Cannot add the sync folder"), "unexpected error message: {msg}");
 
-        let nested = sync_dir
-            .path()
-            .join(sync_dir.path().file_name().unwrap());
+        let nested = sync_dir.path().join(sync_dir.path().file_name().unwrap());
         assert!(!nested.exists(), "no recursive child must be created");
     }
 
@@ -2285,10 +2333,7 @@ mod tests {
             .await
             .expect_err("must reject ancestor as source");
         let msg = err.to_string();
-        assert!(
-            msg.contains("Cannot add the sync folder"),
-            "unexpected error message: {msg}"
-        );
+        assert!(msg.contains("Cannot add the sync folder"), "unexpected error message: {msg}");
 
         let outer_name = outer.path().file_name().unwrap();
         assert!(!sync_dir.join(outer_name).exists());
@@ -2304,10 +2349,7 @@ mod tests {
             .await
             .expect_err("must reject sync root as source");
         let msg = err.to_string();
-        assert!(
-            msg.contains("Cannot add the sync folder"),
-            "unexpected error message: {msg}"
-        );
+        assert!(msg.contains("Cannot add the sync folder"), "unexpected error message: {msg}");
     }
 
     // --- filter_file_entries / apply_file_filters ---

--- a/src-tauri/src/sync/folders.rs
+++ b/src-tauri/src/sync/folders.rs
@@ -136,6 +136,7 @@ pub(crate) async fn list_remote_folders_internal(pool: &SqlitePool, account_id: 
         billing_bypass_token: None,
         ss58_address: account_id.to_string(),
         folder_hash: String::new(),
+        read_timeout_ms: None,
     };
 
     let client = hcfs_client::client::HcfsClient::new(client_config).map_err(|e| crate::error::AppError::Hcfs(e.to_string()))?;
@@ -179,6 +180,7 @@ pub async fn list_remote_folders(state: tauri::State<'_, crate::app_state::AppSt
         billing_bypass_token: None,
         ss58_address: account_id.clone(),
         folder_hash: String::new(),
+        read_timeout_ms: None,
     };
 
     let client = hcfs_client::client::HcfsClient::new(client_config).map_err(|e| crate::error::AppError::Hcfs(e.to_string()))?;
@@ -384,6 +386,7 @@ pub async fn delete_remote_folder(
         billing_bypass_token: None,
         ss58_address: account_id.clone(),
         folder_hash: fhash.clone(),
+        read_timeout_ms: None,
     };
 
     let client = hcfs_client::client::HcfsClient::new(client_config).map_err(|e| crate::error::AppError::Hcfs(e.to_string()))?;

--- a/src-tauri/src/sync/intent.rs
+++ b/src-tauri/src/sync/intent.rs
@@ -1,0 +1,366 @@
+//! Persistent upload-intent manifest for the sync widget.
+//!
+//! Backs the `sync_intent` table (declared in `utils/schema.rs`). The widget
+//! used to lose progress after app restart because the only "what should be
+//! synced" record was the in-memory snapshot. `IntentRepo` is the durable
+//! shadow: the planner records intended uploads here, and later tasks mark
+//! them complete, so post-restart `totals_for_drive` can answer "how much of
+//! the plan have we actually finished?" without a fresh re-plan.
+//!
+//! This file lands the **read/append** half of the repo (Task 2):
+//! `record_plan` upserts pending rows preserving original `added_at_ms`, and
+//! `totals_for_drive` aggregates counts and bytes for one drive. Compaction,
+//! completion, and clear/prune operations are added in Tasks 3 and 4.
+//!
+//! # Concurrency
+//!
+//! `IntentRepo` holds an `sqlx::SqlitePool` clone, which is `Send + Sync` and
+//! reference-counted internally — instances can be cloned and shared freely
+//! across tasks. All methods are `&self`; SQLite serializes writes inside the
+//! pool, so callers don't need an external mutex.
+
+use sqlx::sqlite::SqlitePool;
+
+/// Repository handle backed by the `sync_intent` SQLite table.
+///
+/// Clone is cheap: the inner `SqlitePool` is `Arc`-backed by sqlx.
+#[derive(Debug, Clone)]
+pub struct IntentRepo {
+    pool: SqlitePool,
+}
+
+/// Aggregate counts and byte sums for one drive's intent manifest.
+///
+/// `Copy` so call sites can pattern-match without consuming the value; later
+/// tasks compare snapshots of totals to detect changes worth emitting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IntentTotals {
+    /// Total number of rows in the manifest for this drive (pending +
+    /// completed).
+    pub total_files: u64,
+    /// Sum of `size_bytes` across all rows for this drive.
+    pub total_bytes: u64,
+    /// Rows with `completed_at_ms IS NOT NULL`.
+    pub completed_files: u64,
+    /// Sum of `size_bytes` across completed rows only.
+    pub completed_bytes: u64,
+}
+
+/// Errors raised by `IntentRepo`.
+///
+/// # Stability
+///
+/// `Db` is a stable contract — callers may match on it. The enum is
+/// `#[non_exhaustive]` because later tasks add variants (e.g. clock-skew
+/// failure modes for `mark_completed`); new variants may be added in any
+/// minor release.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum IntentError {
+    /// SQLite I/O failure surfaced via sqlx.
+    #[error("intent db error: {0}")]
+    Db(#[from] sqlx::Error),
+}
+
+impl IntentRepo {
+    /// Construct a new repo from a shared pool. Cloning the pool is cheap;
+    /// callers typically build one `IntentRepo` per drive event handler.
+    #[must_use]
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    /// Upsert pending intent rows for the files the planner reports as
+    /// pending uploads.
+    ///
+    /// **Semantics on conflict.** When a row already exists for
+    /// `(account_id, drive_label, relative_path)`, only `size_bytes` is
+    /// refreshed (the file may have grown between plan cycles). The original
+    /// `added_at_ms` is preserved so the manifest remains a durable
+    /// "since-when" record, and `completed_at_ms` is left untouched so an
+    /// already-completed row is NOT reverted to pending. The latter matters
+    /// because the planner's view of "still needs uploading" can disagree
+    /// briefly with the file-synced callback during sync teardown — Task 3
+    /// handles the explicit "no longer in plan" compaction.
+    ///
+    /// **Empty input.** An empty `plan_uploads` slice returns `Ok(())`
+    /// without touching the database — the caller's planner can be wired
+    /// unconditionally without a guard.
+    ///
+    /// `added_at_ms` for new rows is computed inside SQLite via
+    /// `CAST((julianday('now') - 2440587.5) * 86400000.0 AS INTEGER)`, which
+    /// yields **true millisecond-granularity** Unix time. The earlier
+    /// `strftime('%s','now') * 1000` form rendered as the column's `_ms`
+    /// suffix promised but only delivered second precision (always `…000`);
+    /// the julianday math fixes that contract mismatch and avoids any
+    /// `unixepoch('now','subsec')` version dependency (julianday has been
+    /// in SQLite since 3.0; subsec arrived in 3.42). The value is monotonic
+    /// with the transaction commit order on the DB connection and immune
+    /// to client clock skew between the caller and SQLite.
+    ///
+    /// # Errors
+    /// Returns [`IntentError::Db`] if any SQLite operation fails (including
+    /// transaction commit). On failure the transaction is rolled back —
+    /// either no rows or all rows for this call are visible.
+    pub async fn record_plan(
+        &self,
+        account_id: &str,
+        drive_label: &str,
+        plan_uploads: &[(String, u64)],
+    ) -> Result<(), IntentError> {
+        // Short-circuit so the caller can invoke this unconditionally without
+        // paying for a transaction round-trip when the plan is empty.
+        if plan_uploads.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx = self.pool.begin().await?;
+
+        // One INSERT per row, all inside the same transaction so partial
+        // failures don't leave the manifest half-written. `excluded` in
+        // SQLite refers to the row that would have been inserted; we
+        // deliberately reference ONLY `excluded.size_bytes` so `added_at_ms`
+        // (and `completed_at_ms`) keep their existing values on conflict.
+        //
+        // `added_at_ms` uses `julianday('now')` rather than `strftime('%s')`
+        // because the latter is second-granular and would render the `_ms`
+        // suffix a lie — every value would end in `000`. 2440587.5 is the
+        // Julian Day Number of the Unix epoch (1970-01-01 00:00:00 UTC);
+        // multiplying the fractional-day difference by 86_400_000 ms/day
+        // yields exact Unix time in milliseconds. The CAST truncates the
+        // sub-millisecond remainder to a SQLite INTEGER (i64). Source:
+        // https://www.sqlite.org/lang_datefunc.html — julianday returns a
+        // REAL (IEEE-754 f64), valid range 4714-11-24 BCE … 9999-12-31.
+        for (rel_path, size_bytes) in plan_uploads {
+            sqlx::query(
+                "INSERT INTO sync_intent
+                    (account_id, drive_label, relative_path, size_bytes, added_at_ms, completed_at_ms)
+                 VALUES (?, ?, ?, ?, CAST((julianday('now') - 2440587.5) * 86400000.0 AS INTEGER), NULL)
+                 ON CONFLICT(account_id, drive_label, relative_path)
+                 DO UPDATE SET size_bytes = excluded.size_bytes",
+            )
+            .bind(account_id)
+            .bind(drive_label)
+            .bind(rel_path)
+            // SQLite INTEGER is i64; file sizes ≪ 2^63 in practice.
+            .bind(*size_bytes as i64)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Aggregate counts and byte sums for one `(account_id, drive_label)`
+    /// pair. Returns zeros for a drive with no rows.
+    ///
+    /// **SQLite `SUM` edge case.** `SUM` over zero matching rows returns
+    /// SQL NULL, not 0. The query wraps both byte sums in `COALESCE(..., 0)`
+    /// so the binding to `i64` can never fail with "unexpected NULL".
+    /// Source: https://www.sqlite.org/lang_aggfunc.html#sumunc — "If there
+    /// are no non-NULL input rows then sum() returns NULL".
+    ///
+    /// # Errors
+    /// Returns [`IntentError::Db`] on SQLite I/O failure.
+    pub async fn totals_for_drive(
+        &self,
+        account_id: &str,
+        drive_label: &str,
+    ) -> Result<IntentTotals, IntentError> {
+        // Each aggregate runs in a single index scan over
+        // (account_id, drive_label, completed_at_ms) — the covering index
+        // declared alongside the table.
+        let row: (i64, i64, i64, i64) = sqlx::query_as(
+            "SELECT
+                COUNT(*)                                                                AS total_files,
+                COALESCE(SUM(size_bytes), 0)                                            AS total_bytes,
+                COUNT(CASE WHEN completed_at_ms IS NOT NULL THEN 1 END)                 AS completed_files,
+                COALESCE(SUM(CASE WHEN completed_at_ms IS NOT NULL THEN size_bytes END), 0) AS completed_bytes
+             FROM sync_intent
+             WHERE account_id = ? AND drive_label = ?",
+        )
+        .bind(account_id)
+        .bind(drive_label)
+        .fetch_one(&self.pool)
+        .await?;
+
+        // SQLite INTEGER columns return as i64; the queries above can never
+        // produce a negative result (COUNT is non-negative, SUM of u64-sourced
+        // values is non-negative, COALESCE protects NULL → 0), so the
+        // i64 → u64 cast is always lossless here.
+        Ok(IntentTotals {
+            total_files: row.0 as u64,
+            total_bytes: row.1 as u64,
+            completed_files: row.2 as u64,
+            completed_bytes: row.3 as u64,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    /// Build a fresh in-memory pool with `ensure_table_schema` applied.
+    ///
+    /// `max_connections(1)` is critical: SQLite `:memory:` databases are
+    /// per-connection (each new connection sees a different empty DB), so a
+    /// multi-connection pool would route different queries to different DBs.
+    async fn fresh_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory db");
+        crate::utils::schema::ensure_table_schema(&pool)
+            .await
+            .expect("ensure_table_schema");
+        pool
+    }
+
+    #[tokio::test]
+    async fn record_plan_inserts_pending_rows_with_correct_totals() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+
+        repo.record_plan(
+            "acct",
+            "drive",
+            &[("a.txt".to_string(), 100), ("b.txt".to_string(), 200)],
+        )
+        .await
+        .unwrap();
+
+        let totals = repo.totals_for_drive("acct", "drive").await.unwrap();
+        assert_eq!(totals.total_files, 2);
+        assert_eq!(totals.total_bytes, 300);
+        assert_eq!(totals.completed_files, 0);
+        assert_eq!(totals.completed_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn record_plan_preserves_added_at_on_conflict() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool.clone());
+
+        repo.record_plan("acct", "drive", &[("a.txt".to_string(), 100)])
+            .await
+            .unwrap();
+        let row1: (i64, i64) = sqlx::query_as(
+            "SELECT added_at_ms, size_bytes FROM sync_intent WHERE relative_path = 'a.txt'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Cross a millisecond boundary so a re-derived "now" would differ
+        // if the column ever lost added_at_ms-preservation. With the
+        // julianday-based ms-precision timestamp, 10ms is plenty — the
+        // previous 1.1s wait was a tax forced by the old second-granular
+        // strftime('%s') value.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Same path, different size (file grew). added_at_ms must NOT
+        // change; only size_bytes is in the DO UPDATE clause.
+        repo.record_plan("acct", "drive", &[("a.txt".to_string(), 150)])
+            .await
+            .unwrap();
+        let row2: (i64, i64) = sqlx::query_as(
+            "SELECT added_at_ms, size_bytes FROM sync_intent WHERE relative_path = 'a.txt'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(row1.0, row2.0, "added_at_ms must be preserved on conflict");
+        assert_eq!(row2.1, 150, "size_bytes must be refreshed");
+    }
+
+    #[tokio::test]
+    async fn record_plan_writes_millisecond_precision_timestamp() {
+        // Regression: the SQL must use julianday-based ms math, not
+        // strftime('%s') * 1000. If someone reverts to seconds, every
+        // added_at_ms ends in `000` and this test will fail with
+        // overwhelming probability — the modulo-1000 result is uniform
+        // over 0..=999 for julianday('now'), so a single sample lands
+        // on a `…000` boundary only ~0.1% of the time. We collect a
+        // handful of samples spaced by short sleeps and require at
+        // least one non-zero remainder, eliminating the residual flake.
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool.clone());
+
+        let mut saw_subsecond = false;
+        for i in 0..8u32 {
+            // Distinct paths per iteration so each INSERT takes the
+            // VALUES branch (not the conflict path) and writes a fresh
+            // added_at_ms. Sleeping ~3ms between samples spreads the
+            // captures across multiple millisecond ticks.
+            let path = format!("f{i}.txt");
+            repo.record_plan("acct", "drive", &[(path.clone(), 1)])
+                .await
+                .unwrap();
+            let row: (i64,) = sqlx::query_as(
+                "SELECT added_at_ms FROM sync_intent WHERE relative_path = ?",
+            )
+            .bind(&path)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            if row.0 % 1000 != 0 {
+                saw_subsecond = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(3)).await;
+        }
+        assert!(
+            saw_subsecond,
+            "added_at_ms is still second-granular (all 8 samples ended in …000); \
+             the SQL likely reverted to strftime('%s') * 1000"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_plan_empty_input_is_noop() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        repo.record_plan("acct", "drive", &[]).await.unwrap();
+        let totals = repo.totals_for_drive("acct", "drive").await.unwrap();
+        assert_eq!(totals.total_files, 0);
+        assert_eq!(totals.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn totals_for_drive_empty_returns_zeros() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        let totals = repo.totals_for_drive("acct", "drive").await.unwrap();
+        assert_eq!(
+            totals,
+            IntentTotals {
+                total_files: 0,
+                total_bytes: 0,
+                completed_files: 0,
+                completed_bytes: 0,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn record_plan_scopes_by_account_and_drive() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        repo.record_plan("acct1", "drive_a", &[("a.txt".into(), 100)]).await.unwrap();
+        repo.record_plan("acct1", "drive_b", &[("b.txt".into(), 200)]).await.unwrap();
+        repo.record_plan("acct2", "drive_a", &[("c.txt".into(), 300)]).await.unwrap();
+
+        let t1a = repo.totals_for_drive("acct1", "drive_a").await.unwrap();
+        let t1b = repo.totals_for_drive("acct1", "drive_b").await.unwrap();
+        let t2a = repo.totals_for_drive("acct2", "drive_a").await.unwrap();
+
+        assert_eq!(t1a.total_bytes, 100);
+        assert_eq!(t1b.total_bytes, 200);
+        assert_eq!(t2a.total_bytes, 300);
+    }
+}

--- a/src-tauri/src/sync/intent.rs
+++ b/src-tauri/src/sync/intent.rs
@@ -7,10 +7,17 @@
 //! them complete, so post-restart `totals_for_drive` can answer "how much of
 //! the plan have we actually finished?" without a fresh re-plan.
 //!
-//! This file lands the **read/append** half of the repo (Task 2):
-//! `record_plan` upserts pending rows preserving original `added_at_ms`, and
-//! `totals_for_drive` aggregates counts and bytes for one drive. Compaction,
-//! completion, and clear/prune operations are added in Tasks 3 and 4.
+//! Methods landed across Tasks 2–4:
+//!
+//! * `record_plan` — upsert pending rows preserving original `added_at_ms`
+//!   (Task 2) and compact pending rows no longer in the plan (Task 3).
+//! * `totals_for_drive` — aggregate counts and bytes for one drive (Task 2).
+//! * `mark_completed` — flip a single row from pending to completed,
+//!   idempotently (Task 4).
+//! * `clear_drive` / `clear_account` — drop every row for a drive or for
+//!   an entire account (Task 4; wiring in Tasks 8 and 9).
+//! * `prune_settled` — delete completed rows older than a threshold,
+//!   returning the deleted-row count (Task 4).
 //!
 //! # Concurrency
 //!
@@ -241,6 +248,155 @@ impl IntentRepo {
 
         tx.commit().await?;
         Ok(())
+    }
+
+    /// Mark a single file as completed at `now_ms`. Idempotent: calling
+    /// twice leaves the row's `completed_at_ms` set to the FIRST call's
+    /// value (a later mark is ignored). Unknown paths are a no-op success.
+    ///
+    /// # Why the `IS NULL` guard, not "last write wins"
+    ///
+    /// The first completion timestamp is the truthful one. `record_plan`'s
+    /// `DO UPDATE SET size_bytes = excluded.size_bytes` deliberately does
+    /// not clear `completed_at_ms`, so a once-completed row stays completed
+    /// across plan cycles. A second `mark_completed` ping for the same path
+    /// therefore can only be a redundant callback from hcfs-client (its
+    /// per-file completion can fire more than once on retry paths) — and
+    /// overwriting the original timestamp would silently lose the truthful
+    /// "when did this actually finish" record. The `AND completed_at_ms IS
+    /// NULL` predicate enforces first-write-wins at the storage layer so
+    /// no Rust callsite can break it by reordering.
+    ///
+    /// # Unknown-path semantics
+    ///
+    /// SQLite's `UPDATE` returns success (not an error) when no rows match;
+    /// `rows_affected()` is 0. Source: https://www.sqlite.org/lang_update.html
+    /// — "It is not an error if the UPDATE statement does not match any
+    /// rows." We propagate that contract: an unknown `(account_id,
+    /// drive_label, relative_path)` triple returns `Ok(())` silently. The
+    /// caller is hcfs-client's per-file callback which fires after the
+    /// upload succeeds — by the time it runs, the planner has already
+    /// recorded the row, so a missing row genuinely means "nothing to do
+    /// here" (e.g. the drive was cleared mid-sync).
+    ///
+    /// # Errors
+    /// Returns [`IntentError::Db`] on SQLite I/O failure.
+    pub async fn mark_completed(
+        &self,
+        account_id: &str,
+        drive_label: &str,
+        relative_path: &str,
+        now_ms: i64,
+    ) -> Result<(), IntentError> {
+        // The `AND completed_at_ms IS NULL` predicate is the idempotence
+        // anchor — without it a stale callback would overwrite the truthful
+        // first timestamp. It is also the WHY this method is not a plain
+        // SET: we want the storage layer to enforce first-write-wins so the
+        // Rust callsite cannot accidentally violate it by reordering.
+        sqlx::query(
+            "UPDATE sync_intent
+                SET completed_at_ms = ?
+              WHERE account_id = ?
+                AND drive_label = ?
+                AND relative_path = ?
+                AND completed_at_ms IS NULL",
+        )
+        .bind(now_ms)
+        .bind(account_id)
+        .bind(drive_label)
+        .bind(relative_path)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Drop every row for one drive (both pending and completed).
+    /// Called by `remove_drive`.
+    ///
+    /// # Why both kinds
+    ///
+    /// `remove_drive` deletes the entire `sync_paths` row and wipes the
+    /// on-disk baseline — the intent manifest is just the third leg of that
+    /// teardown. Keeping completed rows around for a removed drive would
+    /// leak them into a future drive of the same label.
+    ///
+    /// # Errors
+    /// Returns [`IntentError::Db`] on SQLite I/O failure.
+    pub async fn clear_drive(
+        &self,
+        account_id: &str,
+        drive_label: &str,
+    ) -> Result<(), IntentError> {
+        sqlx::query(
+            "DELETE FROM sync_intent
+              WHERE account_id = ? AND drive_label = ?",
+        )
+        .bind(account_id)
+        .bind(drive_label)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Drop every row for one account across all drives. Called by
+    /// `stop_sync` on logout.
+    ///
+    /// # Why account-scoped, not unconditional
+    ///
+    /// Multiple accounts can share the desktop's SQLite file (sub-accounts,
+    /// account switching without uninstall). A `DELETE FROM sync_intent`
+    /// with no predicate would wipe the other account's manifest too —
+    /// silently corrupting their widget on next login. The `account_id`
+    /// scope makes the destruction explicit and bounded.
+    ///
+    /// # Errors
+    /// Returns [`IntentError::Db`] on SQLite I/O failure.
+    pub async fn clear_account(&self, account_id: &str) -> Result<(), IntentError> {
+        sqlx::query("DELETE FROM sync_intent WHERE account_id = ?")
+            .bind(account_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Delete completed rows older than `older_than_ms`. Returns the row
+    /// count deleted (use 0 when nothing matched). Pending rows are
+    /// preserved regardless of age — they represent in-flight intent.
+    ///
+    /// # Why the explicit `IS NOT NULL`
+    ///
+    /// SQLite's `<` comparison against `NULL` evaluates to `NULL` (SQL
+    /// 3VL), which is treated as false by `WHERE`, so a pending row could
+    /// never be deleted by `completed_at_ms < ?` alone. But the predicate
+    /// is included anyway as explicit intent — it documents the invariant
+    /// at the SQL site and prevents a future "ah, let's also prune by some
+    /// other clock" refactor from accidentally widening the destruction.
+    /// Source: https://www.sqlite.org/lang_expr.html §NULL Handling.
+    ///
+    /// # Errors
+    /// Returns [`IntentError::Db`] on SQLite I/O failure.
+    pub async fn prune_settled(
+        &self,
+        account_id: &str,
+        drive_label: &str,
+        older_than_ms: i64,
+    ) -> Result<u64, IntentError> {
+        // `rows_affected()` on the returned `SqliteQueryResult` is `u64`.
+        // Source: existing call site `migrate_account_keys` at
+        // src-tauri/src/utils/schema.rs:626 uses the same shape.
+        let result = sqlx::query(
+            "DELETE FROM sync_intent
+              WHERE account_id = ?
+                AND drive_label = ?
+                AND completed_at_ms IS NOT NULL
+                AND completed_at_ms < ?",
+        )
+        .bind(account_id)
+        .bind(drive_label)
+        .bind(older_than_ms)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
     }
 
     /// Aggregate counts and byte sums for one `(account_id, drive_label)`
@@ -480,32 +636,17 @@ mod tests {
 
     /// Critical invariant: completed rows are NOT dropped by compaction.
     /// They represent files the user uploaded earlier in the session and
-    /// belong to the widget's displayed totals.
-    ///
-    /// **Test fixture rationale (axiom 110 / external-library edges).**
-    /// Task 4 will add a `mark_completed` method that flips `completed_at_ms`
-    /// from `NULL` to a unix-ms timestamp. Until that lands, the only way to
-    /// reach the "row exists, completed_at_ms IS NOT NULL" state through the
-    /// public API is to forge it with a raw `UPDATE`. The unit under test
-    /// here is the compaction-on-pending-only invariant — that invariant
-    /// requires a completed row to exist for it to be meaningfully
-    /// exercised, so the direct SQL is unavoidable for now. Once Task 4
-    /// ships, this test should be refactored to use `mark_completed`
-    /// instead.
+    /// belong to the widget's displayed totals. The completed row is staged
+    /// through the public `mark_completed` ingestion path — going through
+    /// the public API is more resilient to schema changes than a raw UPDATE
+    /// would be (rust_quality_111_test_rigor).
     #[tokio::test]
     async fn record_plan_keeps_completed_rows_not_in_new_plan() {
         let pool = fresh_pool().await;
-        let repo = IntentRepo::new(pool.clone());
+        let repo = IntentRepo::new(pool);
 
         repo.record_plan("acct", "drive", &[("a.txt".into(), 100)]).await.unwrap();
-        // Stamp the row complete. Raw UPDATE used because `mark_completed`
-        // does not yet exist (see method-level comment above).
-        sqlx::query(
-            "UPDATE sync_intent SET completed_at_ms = 1700000000000 WHERE relative_path = 'a.txt'",
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
+        repo.mark_completed("acct", "drive", "a.txt", 1_700_000_000_000).await.unwrap();
 
         // Next cycle: planner no longer lists a.txt (it's done). The
         // completed row must survive both the rust-side filter (which only
@@ -541,5 +682,126 @@ mod tests {
         assert_eq!(ta.total_files, 0);
         assert_eq!(tb.total_files, 1);
         assert_eq!(tb.total_bytes, 200);
+    }
+
+    // ---------------- mark_completed ----------------
+
+    #[tokio::test]
+    async fn mark_completed_sets_completed_at_ms() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        repo.record_plan("acct", "drive", &[("a.txt".into(), 100)]).await.unwrap();
+        repo.mark_completed("acct", "drive", "a.txt", 1_700_000_000_000).await.unwrap();
+        let totals = repo.totals_for_drive("acct", "drive").await.unwrap();
+        assert_eq!(totals.completed_files, 1);
+        assert_eq!(totals.completed_bytes, 100);
+        assert_eq!(totals.total_files, 1);
+    }
+
+    #[tokio::test]
+    async fn mark_completed_is_idempotent_preserving_first_timestamp() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool.clone());
+        repo.record_plan("acct", "drive", &[("a.txt".into(), 100)]).await.unwrap();
+        repo.mark_completed("acct", "drive", "a.txt", 1_000).await.unwrap();
+        repo.mark_completed("acct", "drive", "a.txt", 2_000).await.unwrap();
+        let stored: i64 = sqlx::query_scalar(
+            "SELECT completed_at_ms FROM sync_intent WHERE relative_path = 'a.txt'",
+        ).fetch_one(&pool).await.unwrap();
+        assert_eq!(stored, 1_000, "second mark must not overwrite the first timestamp");
+    }
+
+    #[tokio::test]
+    async fn mark_completed_unknown_path_is_noop() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        // No record_plan call — the row doesn't exist.
+        repo.mark_completed("acct", "drive", "nonexistent.txt", 1_000).await.unwrap();
+        let totals = repo.totals_for_drive("acct", "drive").await.unwrap();
+        assert_eq!(totals.total_files, 0);
+    }
+
+    // ---------------- clear_drive ----------------
+
+    #[tokio::test]
+    async fn clear_drive_only_affects_that_drive() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        repo.record_plan("acct", "drive_a", &[("a.txt".into(), 100)]).await.unwrap();
+        repo.record_plan("acct", "drive_b", &[("b.txt".into(), 200)]).await.unwrap();
+        repo.clear_drive("acct", "drive_a").await.unwrap();
+        let ta = repo.totals_for_drive("acct", "drive_a").await.unwrap();
+        let tb = repo.totals_for_drive("acct", "drive_b").await.unwrap();
+        assert_eq!(ta.total_files, 0);
+        assert_eq!(tb.total_files, 1);
+        assert_eq!(tb.total_bytes, 200);
+    }
+
+    #[tokio::test]
+    async fn clear_drive_drops_both_pending_and_completed() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        repo.record_plan("acct", "drive", &[("p.txt".into(), 100), ("c.txt".into(), 200)]).await.unwrap();
+        repo.mark_completed("acct", "drive", "c.txt", 1_000).await.unwrap();
+        repo.clear_drive("acct", "drive").await.unwrap();
+        let t = repo.totals_for_drive("acct", "drive").await.unwrap();
+        assert_eq!(t.total_files, 0);
+    }
+
+    // ---------------- clear_account ----------------
+
+    #[tokio::test]
+    async fn clear_account_drops_all_rows_for_account() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        repo.record_plan("acct1", "drive_a", &[("a.txt".into(), 100)]).await.unwrap();
+        repo.record_plan("acct1", "drive_b", &[("b.txt".into(), 200)]).await.unwrap();
+        repo.record_plan("acct2", "drive_a", &[("c.txt".into(), 300)]).await.unwrap();
+
+        repo.clear_account("acct1").await.unwrap();
+
+        let t1a = repo.totals_for_drive("acct1", "drive_a").await.unwrap();
+        let t1b = repo.totals_for_drive("acct1", "drive_b").await.unwrap();
+        let t2a = repo.totals_for_drive("acct2", "drive_a").await.unwrap();
+        assert_eq!(t1a.total_files, 0);
+        assert_eq!(t1b.total_files, 0);
+        assert_eq!(t2a.total_files, 1, "other account's rows must survive");
+        assert_eq!(t2a.total_bytes, 300);
+    }
+
+    // ---------------- prune_settled ----------------
+
+    #[tokio::test]
+    async fn prune_settled_drops_only_completed_rows_older_than_threshold() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        repo.record_plan("acct", "drive", &[
+            ("old_completed.txt".into(), 100),
+            ("new_completed.txt".into(), 200),
+            ("pending.txt".into(), 300),
+        ]).await.unwrap();
+        repo.mark_completed("acct", "drive", "old_completed.txt", 500).await.unwrap();
+        repo.mark_completed("acct", "drive", "new_completed.txt", 5_000).await.unwrap();
+
+        // Prune anything completed before t=1_000.
+        let deleted = repo.prune_settled("acct", "drive", 1_000).await.unwrap();
+        assert_eq!(deleted, 1, "exactly one row (old_completed) qualifies");
+
+        let totals = repo.totals_for_drive("acct", "drive").await.unwrap();
+        assert_eq!(totals.total_files, 2, "new_completed + pending survive");
+        assert_eq!(totals.completed_files, 1);
+    }
+
+    #[tokio::test]
+    async fn prune_settled_returns_zero_when_nothing_to_prune() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        repo.record_plan("acct", "drive", &[("a.txt".into(), 100)]).await.unwrap();
+        // Pending row, never completed.
+        let deleted = repo.prune_settled("acct", "drive", 9_999_999).await.unwrap();
+        assert_eq!(deleted, 0);
+
+        let totals = repo.totals_for_drive("acct", "drive").await.unwrap();
+        assert_eq!(totals.total_files, 1, "pending row preserved");
     }
 }

--- a/src-tauri/src/sync/intent.rs
+++ b/src-tauri/src/sync/intent.rs
@@ -427,10 +427,14 @@ impl IntentRepo {
         &self,
         account_id: &str,
     ) -> Result<IntentTotals, IntentError> {
-        // One index scan over (account_id, completed_at_ms) — same covering
-        // index used by `totals_for_drive`. The `WHERE` filters by
-        // account_id only; the drive_label column is left unrestricted so
-        // SQLite walks every (account_id, *) entry.
+        // The `WHERE` filters by account_id only (drive_label left
+        // unrestricted), so SQLite seeks on the leftmost prefix of
+        // idx_sync_intent_drive (account_id, …) and walks every
+        // (account_id, *) entry. NOT a covering scan: size_bytes is not
+        // in the index, so SUM() costs a rowid lookup per matched row.
+        // Acceptable because the per-account row count is bounded (one
+        // row per queued file) and this runs off the hot path — one
+        // detached query per snapshot emit, never per chunk-tick.
         let row: (i64, i64, i64, i64) = sqlx::query_as(
             "SELECT
                 COUNT(*)                                                                AS total_files,
@@ -471,9 +475,11 @@ impl IntentRepo {
         account_id: &str,
         drive_label: &str,
     ) -> Result<IntentTotals, IntentError> {
-        // Each aggregate runs in a single index scan over
-        // (account_id, drive_label, completed_at_ms) — the covering index
-        // declared alongside the table.
+        // Each aggregate runs as one index scan over the full
+        // idx_sync_intent_drive key (account_id, drive_label,
+        // completed_at_ms). NOT covering: size_bytes is not in the
+        // index, so SUM() costs a rowid lookup per matched row —
+        // bounded by the per-drive queued-file count, so acceptable.
         let row: (i64, i64, i64, i64) = sqlx::query_as(
             "SELECT
                 COUNT(*)                                                                AS total_files,

--- a/src-tauri/src/sync/intent.rs
+++ b/src-tauri/src/sync/intent.rs
@@ -19,7 +19,22 @@
 //! across tasks. All methods are `&self`; SQLite serializes writes inside the
 //! pool, so callers don't need an external mutex.
 
+use std::collections::HashSet;
+
 use sqlx::sqlite::SqlitePool;
+
+/// Maximum number of `relative_path` values bound into a single
+/// `DELETE … WHERE relative_path IN (?, ?, …)` statement.
+///
+/// SQLite's compile-time `SQLITE_MAX_VARIABLE_NUMBER` defaults to 999 on
+/// versions <3.32 and 32_766 thereafter (source:
+/// https://www.sqlite.org/limits.html §11). A single oversized `IN` list
+/// returns `SQLITE_TOOBIG` at prepare time, not at execute, so the only
+/// safe pattern is to chunk. We pick the conservative floor of 999 and
+/// reserve headroom for the two fixed binds (`account_id`, `drive_label`)
+/// — 500 leaves comfortable slack and keeps the prepared-statement cache
+/// from exploding into a unique entry per pending-set size.
+const DELETE_CHUNK_SIZE: usize = 500;
 
 /// Repository handle backed by the `sync_intent` SQLite table.
 ///
@@ -70,67 +85,143 @@ impl IntentRepo {
         Self { pool }
     }
 
-    /// Upsert pending intent rows for the files the planner reports as
-    /// pending uploads.
+    /// Record the planner's current view of pending uploads for one drive:
+    /// **compact** stale pending rows that are no longer in the plan, then
+    /// **upsert** the rows that are.
     ///
-    /// **Semantics on conflict.** When a row already exists for
-    /// `(account_id, drive_label, relative_path)`, only `size_bytes` is
-    /// refreshed (the file may have grown between plan cycles). The original
-    /// `added_at_ms` is preserved so the manifest remains a durable
-    /// "since-when" record, and `completed_at_ms` is left untouched so an
-    /// already-completed row is NOT reverted to pending. The latter matters
-    /// because the planner's view of "still needs uploading" can disagree
-    /// briefly with the file-synced callback during sync teardown — Task 3
-    /// handles the explicit "no longer in plan" compaction.
+    /// # Why compaction lives here
     ///
-    /// **Empty input.** An empty `plan_uploads` slice returns `Ok(())`
-    /// without touching the database — the caller's planner can be wired
-    /// unconditionally without a guard.
+    /// The widget shows progress as `completed_files / total_files`. If the
+    /// planner stops listing `b.txt` because the user renamed it to `c.txt`,
+    /// deleted it before it uploaded, or added it to the exclusion rules,
+    /// the stale `b.txt` row inflates `total_files` forever and progress can
+    /// never hit 100%. The cheapest fix is reconciliation: every time the
+    /// planner reports a plan, we drop any pending row whose path is missing
+    /// from the new plan. Completed rows (`completed_at_ms IS NOT NULL`) are
+    /// preserved on purpose — they represent files the user has already
+    /// uploaded earlier in the session and belong to the displayed totals.
     ///
-    /// `added_at_ms` for new rows is computed inside SQLite via
-    /// `CAST((julianday('now') - 2440587.5) * 86400000.0 AS INTEGER)`, which
-    /// yields **true millisecond-granularity** Unix time. The earlier
-    /// `strftime('%s','now') * 1000` form rendered as the column's `_ms`
-    /// suffix promised but only delivered second precision (always `…000`);
-    /// the julianday math fixes that contract mismatch and avoids any
-    /// `unixepoch('now','subsec')` version dependency (julianday has been
-    /// in SQLite since 3.0; subsec arrived in 3.42). The value is monotonic
-    /// with the transaction commit order on the DB connection and immune
-    /// to client clock skew between the caller and SQLite.
+    /// # Semantics on conflict (upsert half)
+    ///
+    /// When a row already exists for `(account_id, drive_label,
+    /// relative_path)`, only `size_bytes` is refreshed (the file may have
+    /// grown between plan cycles). The original `added_at_ms` is preserved
+    /// so the manifest remains a durable "since-when" record, and
+    /// `completed_at_ms` is left untouched so an already-completed row is
+    /// NOT reverted to pending. `added_at_ms` for new rows uses
+    /// `CAST((julianday('now') - 2440587.5) * 86400000.0 AS INTEGER)` —
+    /// true millisecond-granularity Unix time (source:
+    /// https://www.sqlite.org/lang_datefunc.html). 2440587.5 is the Julian
+    /// Day Number of the Unix epoch (1970-01-01 00:00:00 UTC);
+    /// multiplying the fractional-day delta by 86_400_000 ms/day yields
+    /// exact ms-precision time. The CAST truncates the sub-ms remainder to
+    /// an i64.
+    ///
+    /// # Empty input semantics
+    ///
+    /// An empty `plan_uploads` slice does NOT short-circuit. It runs the
+    /// compaction half, which deletes every pending row for the
+    /// `(account_id, drive_label)` pair. That's how "the planner sees
+    /// nothing left to upload" gets reflected in the manifest. Completed
+    /// rows still survive.
+    ///
+    /// # Atomicity
+    ///
+    /// Compaction and upsert run in a single transaction. On any error the
+    /// whole call rolls back — the table cannot end up half-compacted /
+    /// half-upserted.
+    ///
+    /// # Defense in depth
+    ///
+    /// The completed-row guard is enforced in two independent places:
+    ///   1. The SELECT that drives the rust-side filter only fetches rows
+    ///      with `completed_at_ms IS NULL`.
+    ///   2. The DELETE statement repeats `AND completed_at_ms IS NULL` in
+    ///      its `WHERE` clause.
+    ///
+    /// Even if a future refactor accidentally puts a completed `relative_path`
+    /// into `to_delete`, the SQL guard still blocks the row from being
+    /// dropped. Belt and braces — losing a completed row corrupts the
+    /// widget's notion of "what the user already uploaded".
     ///
     /// # Errors
     /// Returns [`IntentError::Db`] if any SQLite operation fails (including
-    /// transaction commit). On failure the transaction is rolled back —
-    /// either no rows or all rows for this call are visible.
+    /// transaction commit).
     pub async fn record_plan(
         &self,
         account_id: &str,
         drive_label: &str,
         plan_uploads: &[(String, u64)],
     ) -> Result<(), IntentError> {
-        // Short-circuit so the caller can invoke this unconditionally without
-        // paying for a transaction round-trip when the plan is empty.
-        if plan_uploads.is_empty() {
-            return Ok(());
-        }
+        // Membership check needs O(1) lookup; borrowing into the slice means
+        // no per-path String allocation. Lifetime is the function body —
+        // dropped before the transaction commits.
+        let new_plan_paths: HashSet<&str> =
+            plan_uploads.iter().map(|(p, _)| p.as_str()).collect();
 
         let mut tx = self.pool.begin().await?;
 
-        // One INSERT per row, all inside the same transaction so partial
-        // failures don't leave the manifest half-written. `excluded` in
-        // SQLite refers to the row that would have been inserted; we
-        // deliberately reference ONLY `excluded.size_bytes` so `added_at_ms`
-        // (and `completed_at_ms`) keep their existing values on conflict.
+        // --- Compaction half ---
         //
-        // `added_at_ms` uses `julianday('now')` rather than `strftime('%s')`
-        // because the latter is second-granular and would render the `_ms`
-        // suffix a lie — every value would end in `000`. 2440587.5 is the
-        // Julian Day Number of the Unix epoch (1970-01-01 00:00:00 UTC);
-        // multiplying the fractional-day difference by 86_400_000 ms/day
-        // yields exact Unix time in milliseconds. The CAST truncates the
-        // sub-millisecond remainder to a SQLite INTEGER (i64). Source:
-        // https://www.sqlite.org/lang_datefunc.html — julianday returns a
-        // REAL (IEEE-754 f64), valid range 4714-11-24 BCE … 9999-12-31.
+        // Step 1: enumerate pending rows for this drive. The WHERE clause
+        // filters out completed rows at the DB layer so we never even
+        // materialize them into `currently_pending` — defense layer 1.
+        let currently_pending: Vec<(String,)> = sqlx::query_as(
+            "SELECT relative_path
+               FROM sync_intent
+              WHERE account_id = ?
+                AND drive_label = ?
+                AND completed_at_ms IS NULL",
+        )
+        .bind(account_id)
+        .bind(drive_label)
+        .fetch_all(&mut *tx)
+        .await?;
+
+        // Step 2: paths to delete = (currently pending) - (new plan set).
+        // Collected into a Vec because we need to drive a `?,?,…` IN-list,
+        // and the chunked DELETE statement needs to iterate twice (once for
+        // SQL construction, once for binding).
+        let to_delete: Vec<String> = currently_pending
+            .into_iter()
+            .filter_map(|(path,)| (!new_plan_paths.contains(path.as_str())).then_some(path))
+            .collect();
+
+        // Step 3: chunked DELETE. SQLite's bind-parameter limit
+        // (`SQLITE_MAX_VARIABLE_NUMBER`, conservatively 999) means a single
+        // statement with a giant `IN(?, ?, …)` returns SQLITE_TOOBIG at
+        // prepare time. Chunking at `DELETE_CHUNK_SIZE` keeps every prepared
+        // statement well below the floor and is the documented safe pattern.
+        // The `completed_at_ms IS NULL` guard is repeated here — defense
+        // layer 2.
+        for chunk in to_delete.chunks(DELETE_CHUNK_SIZE) {
+            // SQL placeholders: build "?, ?, ?" from the chunk length so the
+            // statement matches the bind count exactly. `chunk` is never
+            // empty inside this loop (chunks() yields only non-empty slices
+            // from a non-empty source), so `placeholders` is never "".
+            let placeholders = std::iter::repeat_n("?", chunk.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "DELETE FROM sync_intent
+                  WHERE account_id = ?
+                    AND drive_label = ?
+                    AND completed_at_ms IS NULL
+                    AND relative_path IN ({placeholders})",
+            );
+            let mut q = sqlx::query(&sql).bind(account_id).bind(drive_label);
+            for path in chunk {
+                q = q.bind(path);
+            }
+            q.execute(&mut *tx).await?;
+        }
+
+        // --- Upsert half ---
+        //
+        // One INSERT per row, same transaction. `excluded` is SQLite's name
+        // for the row that would have been inserted; we deliberately
+        // reference ONLY `excluded.size_bytes` so `added_at_ms` and
+        // `completed_at_ms` keep their existing values on conflict.
         for (rel_path, size_bytes) in plan_uploads {
             sqlx::query(
                 "INSERT INTO sync_intent
@@ -362,5 +453,93 @@ mod tests {
         assert_eq!(t1a.total_bytes, 100);
         assert_eq!(t1b.total_bytes, 200);
         assert_eq!(t2a.total_bytes, 300);
+    }
+
+    /// Compaction edge case 1: rename. The planner used to list `b.txt` but
+    /// no longer does (hcfs-client's `extract_renames` paired the
+    /// `b.txt` delete with the `c.txt` upload). The stale `b.txt` row must
+    /// vanish so widget progress isn't permanently inflated by a path that
+    /// no longer exists.
+    #[tokio::test]
+    async fn record_plan_drops_pending_rows_not_in_new_plan() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+        repo.record_plan("acct", "drive", &[("a.txt".into(), 100), ("b.txt".into(), 200)])
+            .await
+            .unwrap();
+
+        // Simulate: user renamed b.txt -> c.txt. The planner now reports a and c only.
+        repo.record_plan("acct", "drive", &[("a.txt".into(), 100), ("c.txt".into(), 50)])
+            .await
+            .unwrap();
+
+        let totals = repo.totals_for_drive("acct", "drive").await.unwrap();
+        assert_eq!(totals.total_files, 2, "b.txt should be dropped, c.txt added");
+        assert_eq!(totals.total_bytes, 150);
+    }
+
+    /// Critical invariant: completed rows are NOT dropped by compaction.
+    /// They represent files the user uploaded earlier in the session and
+    /// belong to the widget's displayed totals.
+    ///
+    /// **Test fixture rationale (axiom 110 / external-library edges).**
+    /// Task 4 will add a `mark_completed` method that flips `completed_at_ms`
+    /// from `NULL` to a unix-ms timestamp. Until that lands, the only way to
+    /// reach the "row exists, completed_at_ms IS NOT NULL" state through the
+    /// public API is to forge it with a raw `UPDATE`. The unit under test
+    /// here is the compaction-on-pending-only invariant — that invariant
+    /// requires a completed row to exist for it to be meaningfully
+    /// exercised, so the direct SQL is unavoidable for now. Once Task 4
+    /// ships, this test should be refactored to use `mark_completed`
+    /// instead.
+    #[tokio::test]
+    async fn record_plan_keeps_completed_rows_not_in_new_plan() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool.clone());
+
+        repo.record_plan("acct", "drive", &[("a.txt".into(), 100)]).await.unwrap();
+        // Stamp the row complete. Raw UPDATE used because `mark_completed`
+        // does not yet exist (see method-level comment above).
+        sqlx::query(
+            "UPDATE sync_intent SET completed_at_ms = 1700000000000 WHERE relative_path = 'a.txt'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Next cycle: planner no longer lists a.txt (it's done). The
+        // completed row must survive both the rust-side filter (which only
+        // selects pending rows) and the DB-side guard (`AND completed_at_ms
+        // IS NULL` in the DELETE).
+        repo.record_plan("acct", "drive", &[]).await.unwrap();
+
+        let totals = repo.totals_for_drive("acct", "drive").await.unwrap();
+        assert_eq!(totals.total_files, 1);
+        assert_eq!(totals.completed_files, 1);
+        assert_eq!(totals.total_bytes, 100);
+        assert_eq!(totals.completed_bytes, 100);
+    }
+
+    /// Compaction is scoped to one `(account_id, drive_label)`. An empty
+    /// plan for `drive_a` must not touch `drive_b`'s rows — even though the
+    /// new short-circuit-free implementation runs a transaction every call.
+    /// This is the regression test that pins down the empty-input semantic
+    /// change.
+    #[tokio::test]
+    async fn record_plan_compaction_is_drive_scoped() {
+        let pool = fresh_pool().await;
+        let repo = IntentRepo::new(pool);
+
+        repo.record_plan("acct", "drive_a", &[("x.txt".into(), 100)]).await.unwrap();
+        repo.record_plan("acct", "drive_b", &[("y.txt".into(), 200)]).await.unwrap();
+
+        // Re-call record_plan on drive_a with an empty list. drive_b's row MUST survive.
+        repo.record_plan("acct", "drive_a", &[]).await.unwrap();
+
+        let ta = repo.totals_for_drive("acct", "drive_a").await.unwrap();
+        let tb = repo.totals_for_drive("acct", "drive_b").await.unwrap();
+        assert_eq!(ta.total_files, 0);
+        assert_eq!(tb.total_files, 1);
+        assert_eq!(tb.total_bytes, 200);
     }
 }

--- a/src-tauri/src/sync/intent.rs
+++ b/src-tauri/src/sync/intent.rs
@@ -399,6 +399,62 @@ impl IntentRepo {
         Ok(result.rows_affected())
     }
 
+    /// Aggregate counts and byte sums across EVERY drive for one account.
+    ///
+    /// Mirrors [`totals_for_drive`](Self::totals_for_drive) minus the
+    /// `AND drive_label = ?` predicate — one indexed SUM/COUNT pass instead
+    /// of N per-drive round-trips. The desktop's snapshot-overlay path
+    /// fires on every progress emit (~4 Hz during transfers); summing in
+    /// the DB layer keeps the hot path to a single sqlx call regardless of
+    /// how many drives the user has configured.
+    ///
+    /// **SQLite `SUM` edge case.** Same as `totals_for_drive`: `SUM` over
+    /// zero matching rows returns SQL NULL, so the byte sums are wrapped
+    /// in `COALESCE(..., 0)`. An unknown / not-yet-used `account_id`
+    /// therefore returns `IntentTotals { 0, 0, 0, 0 }` rather than an
+    /// error. Source: https://www.sqlite.org/lang_aggfunc.html#sumunc.
+    ///
+    /// # Why account-scoped, not unconditional
+    ///
+    /// Same rationale as [`clear_account`](Self::clear_account): multiple
+    /// accounts share the desktop's SQLite file (sub-accounts, account
+    /// switching). A predicate-less aggregate would silently mix another
+    /// user's totals into the active widget overlay.
+    ///
+    /// # Errors
+    /// Returns [`IntentError::Db`] on SQLite I/O failure.
+    pub async fn totals_for_account(
+        &self,
+        account_id: &str,
+    ) -> Result<IntentTotals, IntentError> {
+        // One index scan over (account_id, completed_at_ms) — same covering
+        // index used by `totals_for_drive`. The `WHERE` filters by
+        // account_id only; the drive_label column is left unrestricted so
+        // SQLite walks every (account_id, *) entry.
+        let row: (i64, i64, i64, i64) = sqlx::query_as(
+            "SELECT
+                COUNT(*)                                                                AS total_files,
+                COALESCE(SUM(size_bytes), 0)                                            AS total_bytes,
+                COUNT(CASE WHEN completed_at_ms IS NOT NULL THEN 1 END)                 AS completed_files,
+                COALESCE(SUM(CASE WHEN completed_at_ms IS NOT NULL THEN size_bytes END), 0) AS completed_bytes
+             FROM sync_intent
+             WHERE account_id = ?",
+        )
+        .bind(account_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        // Same i64 -> u64 cast safety argument as `totals_for_drive`:
+        // COUNT(*) is non-negative; SUM of u64-sourced values is
+        // non-negative; COALESCE forces NULL -> 0 before binding.
+        Ok(IntentTotals {
+            total_files: row.0 as u64,
+            total_bytes: row.1 as u64,
+            completed_files: row.2 as u64,
+            completed_bytes: row.3 as u64,
+        })
+    }
+
     /// Aggregate counts and byte sums for one `(account_id, drive_label)`
     /// pair. Returns zeros for a drive with no rows.
     ///

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -2057,6 +2057,57 @@ pub fn build_file_synced_callback(sync: Arc<SyncRunner>, label: Arc<str>) -> hcf
     })
 }
 
+/// Build the `on_file_failed` callback that flips the file's progress
+/// status to terminal `FileStatus::Error` synchronously at the failure
+/// site (does NOT emit any Tauri event — the bridge handles that via
+/// [`hcfs_client::engine::events::SyncEvent::FileFailed`]).
+///
+/// Visibility is intentionally module-private (`pub(super)` would also
+/// suffice, but neither is needed by integration tests because tests
+/// reach the same outcome through `mark_file_failed` directly — the
+/// callback is purely glue between hcfs-client's `FileFailedFn` shape and
+/// our progress tracker).
+///
+/// The split-of-responsibilities mirrors `build_file_synced_callback` and
+/// the existing bridge: bridge → Tauri event emit; this callback →
+/// progress-tracker mutation. hcfs-client guarantees both fire for the
+/// same per-file error, so we don't lose either signal.
+fn build_file_failed_callback(sync: Arc<SyncRunner>, label: Arc<str>) -> hcfs_client::sync::FileFailedFn {
+    Arc::new(move |rel_path, file_id_hex, kind, http_status| {
+        // Mirror `on_file_synced` shape: empty rel_path means the planner
+        // never recorded a path for this file (shouldn't happen, but the
+        // upstream doc on `FileFailedFn` allows it). No-op rather than
+        // mark a phantom entry.
+        if rel_path.is_empty() {
+            return;
+        }
+        debug!(
+            label = %label,
+            path = %rel_path,
+            file_id = %file_id_hex,
+            ?kind,
+            http_status = ?http_status,
+            "per-file sync failure reported by hcfs-client"
+        );
+
+        // Best-effort display string for the snapshot row's `error` field.
+        // The frontend already discriminates failure CATEGORY via the
+        // separate `hcfs_file_failed` Tauri event (typed
+        // `FileFailureKindPayload`); this string is only used as a
+        // tooltip/details fallback in the file list, so a `Debug` render
+        // is acceptable.
+        let error_msg = format!("{kind:?}");
+        if let Err(e) = crate::sync::progress::mark_file_failed(&sync, rel_path, &error_msg) {
+            warn!(
+                label = %label,
+                path = %rel_path,
+                error = %e,
+                "failed to mark file failed in progress tracker"
+            );
+        }
+    })
+}
+
 /// Wire up the hcfs-client progress callbacks for a drive.
 ///
 /// Connects the `SyncProgress` callback struct (upload/download/encrypt/decrypt
@@ -2102,6 +2153,11 @@ pub(crate) fn setup_progress_handlers(app: &AppHandle, manager: &mut DriveManage
         on_scan_progress: Some(build_scan_callback(sync.clone(), app.clone(), Arc::clone(&label))),
         on_fetch_state_progress: Some(build_fetch_callback(sync.clone(), app.clone(), Arc::clone(&label))),
         on_file_synced: Some(build_file_synced_callback(sync.clone(), Arc::clone(&label))),
+        // Phase 2 / Task 2.7: per-file failure callback fired synchronously
+        // by hcfs-client at the error site. We mutate the in-memory
+        // progress tracker here; the bridge's `SyncEvent::FileFailed` arm
+        // is the user-visible side (Tauri event emit).
+        on_file_failed: Some(build_file_failed_callback(sync.clone(), Arc::clone(&label))),
     });
 }
 

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -1891,6 +1891,47 @@ fn handle_transfer_progress(ctx: &TransferContext, bytes: u64, total: u64, path:
     debug!("{} [{}]: {}/{} bytes, path: {:?}", dir_name, ctx.label, bytes, total, path);
 }
 
+/// Fire-and-forget: persist the planner's view of pending uploads to the
+/// `sync_intent` table.
+///
+/// Called from `build_plan_ready_callback` once per sync cycle. The intent
+/// manifest is a pure UX overlay used by the sync widget to render
+/// "5 GB of 10 GB" across app restarts — it is NOT load-bearing for sync
+/// correctness. Failures (no logged-in user, missing pool, SQLite error)
+/// are logged and dropped; the next plan-ready call will replay the same
+/// uploads.
+///
+/// Ownership: all captures are owned (`AppHandle` is `Clone` and cheap;
+/// `label` and `plan_uploads` are moved in). The spawned future is
+/// `'static`, satisfying `tokio::spawn`'s `Send + 'static` bound.
+fn spawn_record_intent_plan(app: AppHandle, label: String, plan_uploads: Vec<(String, u64)>) {
+    tokio::spawn(async move {
+        use tauri::Manager;
+        let state: tauri::State<'_, crate::app_state::AppState> = app.state();
+        let account_id = match state.current_account_id() {
+            Ok(id) => id,
+            Err(e) => {
+                // Not logged in (or auth mutex poisoned). The widget overlay
+                // is a UX nicety, not load-bearing — drop rather than emit a
+                // noisy error. Next plan-ready after login replays uploads.
+                debug!(label = %label, error = %e, "skipping intent record_plan: no active account");
+                return;
+            }
+        };
+        let pool = match state.pool() {
+            Ok(p) => p.clone(),
+            Err(e) => {
+                warn!(label = %label, error = %e, "skipping intent record_plan: pool unavailable");
+                return;
+            }
+        };
+        let repo = crate::sync::intent::IntentRepo::new(pool);
+        if let Err(e) = repo.record_plan(&account_id, &label, &plan_uploads).await {
+            warn!(label = %label, error = %e, "intent record_plan failed");
+        }
+    });
+}
+
 /// Build the `on_sync_plan_ready` callback that merges the sync plan into the
 /// progress session and emits the `SYNC_PLAN_READY` event.
 fn build_plan_ready_callback(app: &AppHandle, label: Arc<str>, sync: &Arc<SyncRunner>) -> hcfs_client::sync::SyncPlanReadyFn {
@@ -1898,6 +1939,15 @@ fn build_plan_ready_callback(app: &AppHandle, label: Arc<str>, sync: &Arc<SyncRu
     let sync = sync.clone();
     Arc::new(move |uploads, downloads, local_deletes, remote_deletes, renames| {
         sync.touch_progress_time();
+        // Persist the planner's view to the desktop-side intent manifest.
+        // Runs UNCONDITIONALLY — above the `total == 0` early-return —
+        // because an empty plan must still flush stale pending rows (see
+        // `IntentRepo::record_plan`'s "Empty input semantics" docstring).
+        // Logic is delegated to `spawn_record_intent_plan` so this closure
+        // stays under the project's 100-line per-function ceiling.
+        let plan_uploads: Vec<(String, u64)> = uploads.iter().map(|f| (f.path.clone(), f.size_bytes)).collect();
+        spawn_record_intent_plan(app.clone(), label.to_string(), plan_uploads);
+
         let total = uploads.len() + downloads.len() + local_deletes.len() + remote_deletes.len() + renames.len();
         if total == 0 {
             return;

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -1904,7 +1904,7 @@ fn handle_transfer_progress(ctx: &TransferContext, bytes: u64, total: u64, path:
 /// Ownership: all captures are owned (`AppHandle` is `Clone` and cheap;
 /// `label` and `plan_uploads` are moved in). The spawned future is
 /// `'static`, satisfying `tokio::spawn`'s `Send + 'static` bound.
-fn spawn_record_intent_plan(app: AppHandle, label: String, plan_uploads: Vec<(String, u64)>) {
+fn spawn_record_intent_plan<R: tauri::Runtime>(app: AppHandle<R>, label: String, plan_uploads: Vec<(String, u64)>) {
     tokio::spawn(async move {
         use tauri::Manager;
         let state: tauri::State<'_, crate::app_state::AppState> = app.state();
@@ -1932,9 +1932,60 @@ fn spawn_record_intent_plan(app: AppHandle, label: String, plan_uploads: Vec<(St
     });
 }
 
+/// Fire-and-forget: mark a single file as completed in the desktop-side
+/// `sync_intent` manifest.
+///
+/// Called from inside `build_file_synced_callback` only when hcfs-client's
+/// per-file callback reports `action == "uploaded"`. Downloads, deletes,
+/// and conflict events do NOT touch the intent manifest — the manifest
+/// counts user-initiated uploads, which is the only category the
+/// "X of Y uploaded across restarts" widget overlay needs.
+///
+/// Spawned because `FileSyncedFn` is a sync `Fn(...)` and
+/// [`crate::sync::intent::IntentRepo::mark_completed`] is async. The
+/// manifest is a pure UX overlay, NOT load-bearing for sync correctness,
+/// so on auth / pool / SQL failure we log and drop. Idempotence is
+/// enforced at the SQL layer (`AND completed_at_ms IS NULL`), so a
+/// duplicate fire — e.g. hcfs-client retrying a callback after a
+/// transient widget event drop — preserves the first completion
+/// timestamp.
+///
+/// Ownership: every capture is owned. `AppHandle<R>` is `Clone` and cheap
+/// (internally `Arc`); `label` and `rel_path` are moved in. The spawned
+/// future is `'static`, satisfying `tokio::spawn`'s `Send + 'static`
+/// bound.
+fn spawn_mark_intent_completed<R: tauri::Runtime>(app: AppHandle<R>, label: String, rel_path: String) {
+    tokio::spawn(async move {
+        use tauri::Manager;
+        let state: tauri::State<'_, crate::app_state::AppState> = app.state();
+        let account_id = match state.current_account_id() {
+            Ok(id) => id,
+            Err(e) => {
+                // Not logged in (or auth mutex poisoned). Treat like the
+                // plan-ready path: drop quietly, the next plan-ready will
+                // replay this row as pending until it gets uploaded again.
+                debug!(label = %label, path = %rel_path, error = %e, "skipping intent mark_completed: no active account");
+                return;
+            }
+        };
+        let pool = match state.pool() {
+            Ok(p) => p.clone(),
+            Err(e) => {
+                warn!(label = %label, path = %rel_path, error = %e, "skipping intent mark_completed: pool unavailable");
+                return;
+            }
+        };
+        let repo = crate::sync::intent::IntentRepo::new(pool);
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        if let Err(e) = repo.mark_completed(&account_id, &label, &rel_path, now_ms).await {
+            warn!(label = %label, path = %rel_path, error = %e, "intent mark_completed failed");
+        }
+    });
+}
+
 /// Build the `on_sync_plan_ready` callback that merges the sync plan into the
 /// progress session and emits the `SYNC_PLAN_READY` event.
-fn build_plan_ready_callback(app: &AppHandle, label: Arc<str>, sync: &Arc<SyncRunner>) -> hcfs_client::sync::SyncPlanReadyFn {
+fn build_plan_ready_callback<R: tauri::Runtime>(app: &AppHandle<R>, label: Arc<str>, sync: &Arc<SyncRunner>) -> hcfs_client::sync::SyncPlanReadyFn {
     let app = app.clone();
     let sync = sync.clone();
     Arc::new(move |uploads, downloads, local_deletes, remote_deletes, renames| {
@@ -2103,7 +2154,16 @@ fn build_fetch_callback(sync: Arc<SyncRunner>, app: AppHandle, label: Arc<str>) 
 /// soon as its individual AEAD verification has succeeded — instead of
 /// waiting for the entire sync cycle to finish. See
 /// [`crate::sync::progress::mark_file_synced`] for the full reasoning.
-pub fn build_file_synced_callback(sync: Arc<SyncRunner>, label: Arc<str>) -> hcfs_client::sync::FileSyncedFn {
+pub fn build_file_synced_callback<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    sync: Arc<SyncRunner>,
+    label: Arc<str>,
+) -> hcfs_client::sync::FileSyncedFn {
+    // Clone once at construction time; the closure (`Arc<dyn Fn(...)>`)
+    // captures the owned `AppHandle<R>`. Per-fire we `.clone()` again to
+    // hand an owned handle to the `'static`-bound spawn future. Both
+    // clones are cheap (`AppHandle` is internally `Arc`).
+    let app = app.clone();
     Arc::new(move |rel_path, path_hash_hex, arion_cid, action, timestamps| {
         debug!("File synced [{label}]: {rel_path} ({action}) cid={arion_cid}");
         if rel_path.is_empty() {
@@ -2203,6 +2263,26 @@ pub fn build_file_synced_callback(sync: Arc<SyncRunner>, label: Arc<str>) -> hcf
                 size_bytes,
                 label: Arc::clone(&label),
             });
+        }
+
+        // Mark the file complete in the desktop-side intent manifest so
+        // the sync widget can show "X of Y" totals across app restarts.
+        // We mark intent complete ONLY on "uploaded":
+        //   - "downloaded": pulling someone else's file, not user upload intent.
+        //   - "deleted":    deletion is out of scope for the upload manifest.
+        //   - "conflict":   when a conflict resolves via upload, hcfs-client
+        //                   already arrives here with action="uploaded" (see
+        //                   `Drive::resolve_upload_conflict`), so the
+        //                   resolution is counted; the bare "conflict" event
+        //                   reports a non-upload outcome (kept-remote /
+        //                   manual-deferred) and must not advance totals.
+        //
+        // Spawned for the same async-Fn reason as `spawn_record_intent_plan`
+        // — `FileSyncedFn` is sync; `IntentRepo::mark_completed` is async.
+        // The manifest is a pure UX overlay, NOT load-bearing for sync
+        // correctness, so failures inside the spawn log and drop.
+        if action == "uploaded" {
+            spawn_mark_intent_completed(app.clone(), label.to_string(), rel_path.to_string());
         }
 
         // hcfs's `FileSyncedFn` callback passes `path_hash_hex` as a hex
@@ -2338,7 +2418,7 @@ pub(crate) fn setup_progress_handlers(app: &AppHandle, manager: &mut DriveManage
         )),
         on_scan_progress: Some(build_scan_callback(sync.clone(), app.clone(), Arc::clone(&label))),
         on_fetch_state_progress: Some(build_fetch_callback(sync.clone(), app.clone(), Arc::clone(&label))),
-        on_file_synced: Some(build_file_synced_callback(sync.clone(), Arc::clone(&label))),
+        on_file_synced: Some(build_file_synced_callback(app, sync.clone(), Arc::clone(&label))),
         // Phase 2 / Task 2.7: per-file failure callback fired synchronously
         // by hcfs-client at the error site. We mutate the in-memory
         // progress tracker here; the bridge's `SyncEvent::FileFailed` arm
@@ -2673,11 +2753,26 @@ mod tests {
         }
     }
 
+    /// Build a `tauri::test::MockRuntime` app handle for callbacks that
+    /// now take `&AppHandle<R>` (Task 6 — intent-manifest wiring). The
+    /// handle's only role in these tests is to satisfy the type system
+    /// and the closure's per-fire `app.clone()`; the spawned
+    /// `mark_intent_completed` lookup falls through the
+    /// "no `AppState` managed" branch silently because the mock app
+    /// hasn't called `manage()` on `AppState`. That's the exact
+    /// fire-and-forget contract — the surrounding cache write +
+    /// activity enqueue keep being the only behavior these tests assert
+    /// on. The `test` feature on `tauri` is enabled via dev-deps only.
+    fn mock_app_handle() -> tauri::AppHandle<tauri::test::MockRuntime> {
+        tauri::test::mock_app().handle().clone()
+    }
+
     #[tokio::test]
     async fn build_file_synced_callback_writes_timestamps_to_cache() {
         let sync = test_sync_runner();
         let label: Arc<str> = Arc::from("test-drive");
-        let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+        let app = mock_app_handle();
+        let callback = build_file_synced_callback(&app, sync.clone(), Arc::clone(&label));
 
         // 32-byte hash keyed by 'a' so the hex decode succeeds.
         let fid = [0xAAu8; 32];
@@ -2714,7 +2809,8 @@ mod tests {
         );
         sync.update_synced_paths_cache(&label, prior);
 
-        let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+        let app = mock_app_handle();
+        let callback = build_file_synced_callback(&app, sync.clone(), Arc::clone(&label));
         // Same file re-uploaded against a legacy server that omits
         // timestamps — callback receives `None`.
         callback("doc.txt", &hex::encode(fid), "cid-new", "uploaded", None);
@@ -2734,7 +2830,8 @@ mod tests {
         // just with zero timestamps. Reconcile will backfill them.
         let sync = test_sync_runner();
         let label: Arc<str> = Arc::from("fresh-legacy-drive");
-        let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+        let app = mock_app_handle();
+        let callback = build_file_synced_callback(&app, sync.clone(), Arc::clone(&label));
 
         let fid = [0xCCu8; 32];
         callback("new.txt", &hex::encode(fid), "cid-a", "uploaded", None);
@@ -2754,7 +2851,8 @@ mod tests {
         // Empty rel_path is the early-exit guard — don't touch the cache.
         let sync = test_sync_runner();
         let label: Arc<str> = Arc::from("guard-drive");
-        let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+        let app = mock_app_handle();
+        let callback = build_file_synced_callback(&app, sync.clone(), Arc::clone(&label));
 
         let fid = [0xDDu8; 32];
         let ts = make_timestamps(123, 456);

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -1236,14 +1236,30 @@ pub async fn remove_drive(app: AppHandle, label: String) -> Result<()> {
     // sleeping through the full polling interval.
     app_state.drive_removed_notify.notify_waiters();
 
-    // Delete the DB row so the drive isn't resurrected on app restart.
-    // Best-effort: if the account or pool isn't available, the in-memory
-    // cleanup above still takes effect for this session.
+    // Delete the DB row so the drive isn't resurrected on app restart, and
+    // drop the intent-manifest rows for this drive so the snapshot overlay
+    // doesn't keep showing stale "X of Y" totals for a folder the user just
+    // removed.
+    //
+    // Both calls share the same prerequisites (pool + account known) and
+    // both are best-effort — failure here doesn't break sync correctness.
+    // The intent manifest is a UX overlay; stale rows will be cleaned up by
+    // the next manifest GC pass even if this call fails. `pause_drive`
+    // deliberately does NOT clear intent because pause is reversible and the
+    // in-flight totals must survive a resume.
     let acct = app_state.current_account_id().ok();
-    if let (Ok(pool), Some(acct)) = (app_state.pool(), acct.as_deref())
-        && let Err(e) = crate::sync::paths::remove_sync_path_internal(pool, acct, &label).await
-    {
-        warn!("Failed to remove sync path for '{}' from DB: {e}", label);
+    if let (Ok(pool), Some(acct)) = (app_state.pool(), acct.as_deref()) {
+        if let Err(e) = crate::sync::paths::remove_sync_path_internal(pool, acct, &label).await {
+            warn!("Failed to remove sync path for '{}' from DB: {e}", label);
+        }
+
+        // `IntentRepo::new` takes `SqlitePool` by value; the pool is internally
+        // `Arc`-shaped so `.clone()` is just an `Arc` bump — no connection
+        // pool duplication.
+        let repo = crate::sync::intent::IntentRepo::new(pool.clone());
+        if let Err(e) = repo.clear_drive(acct, &label).await {
+            warn!("Failed to clear intent rows for drive '{}': {e}", label);
+        }
     }
 
     // Drop the on-disk sync baseline. Without this, a re-add (whether at the

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -1053,6 +1053,13 @@ pub async fn stop_sync(app: AppHandle) -> Result<()> {
     sync.discard_all_pending_activity();
     sync.clear_label_roots();
 
+    // Clear the per-label preparing overrides so a logout / account
+    // switch cannot leak a "Preparing sync…" widget into the next
+    // session. Mirrors the unconditional `upload_processing.reset`
+    // pattern — both are transient UI-affordance state that must
+    // not survive across accounts.
+    app_state.preparing.clear_all();
+
     // Emit sync stopped event so frontend can reset UI state (tray icon, sync widget)
     let _ = app.emit(crate::sync::events::SYNC_STOPPED, ());
 
@@ -1079,6 +1086,22 @@ pub async fn remove_drive(app: AppHandle, label: String) -> Result<()> {
     let sync = &app_state.sync;
 
     let (remaining, _removed_path) = remove_drive_inmemory(sync, &label).await;
+
+    // Drop the preparing override for this label so a remove during
+    // the SyncStarted → plan_ready window cannot leave a stuck
+    // "Preparing sync…" badge tied to a drive that no longer exists.
+    //
+    // Belt-and-suspenders with the `SyncError::Cancelled` arm in
+    // `tauri_bridge.rs` — that arm also clears preparing for the
+    // cancelled label, but the cancel SyncEvent is dispatched
+    // asynchronously relative to this synchronous IPC and may not
+    // have landed yet. Calling `clear` here is idempotent (second
+    // call returns `false` and skips the `emit_snapshot`), so the
+    // dual-path is cheap and covers the race where the IPC returns
+    // before the bridge has seen the cancel.
+    if app_state.preparing.clear(&label) {
+        sync.emit_snapshot(true);
+    }
 
     // Wake any waiters in remove_drive_and_wait so they can re-check without
     // sleeping through the full polling interval.

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -123,10 +123,22 @@ pub async fn add_local_sync_folder(
     let state = app.state::<crate::app_state::AppState>();
     let pool = state.pool()?;
 
-    // Enforce credit eligibility at the IPC boundary. Refuses to add a
-    // new sync folder if the user has zero marketplace credits — see
-    // `crate::billing::eligibility::thresholds::FOLDER_SYNC`.
-    crate::billing::eligibility::require_eligible(&state, &account_id, crate::billing::eligibility::InsufficientCreditsAction::FolderSync).await?;
+    // Enforce credit eligibility at the IPC boundary, priced by the
+    // recursive byte sum of the folder's CURRENT contents — those bytes
+    // are about to be uploaded by the sync engine on first init.
+    // A user setting up sync on a 100 GB folder with $0.10 of credits
+    // would silently 402 every file otherwise. The byte-sum walk
+    // ignores permission-denied subdirs so the gate under-charges
+    // rather than rejecting a legitimate "I have access to most of
+    // this" setup. See `crate::billing::eligibility::thresholds`.
+    let bytes = crate::sync::files::sum_regular_file_bytes(std::path::Path::new(&path)).await;
+    crate::billing::eligibility::require_eligible(
+        &state,
+        &account_id,
+        crate::billing::eligibility::InsufficientCreditsAction::FolderSync,
+        bytes,
+    )
+    .await?;
 
     // 1. Generate unique label — single source of truth in
     // `crate::sync::paths::generate_unique_label_internal`.

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -1740,10 +1740,16 @@ fn handle_transfer_progress(ctx: &TransferContext, bytes: u64, total: u64, path:
         }
 
         if crate::sync::logic::is_file_completion_tick(bytes, total) {
-            let action = match ctx.direction {
-                TransferDirection::Upload => SyncActivityAction::Uploaded,
-                TransferDirection::Download => SyncActivityAction::Downloaded,
-            };
+            // Byte-progress completion is "the request body finished
+            // leaving our socket" — the HTTP response status (200 / 402
+            // / 5xx) has not been parsed yet. We log + emit the
+            // transfer-complete UI event here because both are
+            // best-effort progress signals, but we deliberately do NOT
+            // enqueue a `SyncActivityItem` from this point: that would
+            // record a server-rejected upload as a successful one.
+            // The enqueue lives in `build_file_synced_callback`, which
+            // hcfs-client fires only on per-file `Ok` (server-confirmed
+            // 2xx). See docs/plans/2026-05-13-sync-402-data-integrity.md.
             info!("{} complete [{}]: {} ({} bytes)", dir_name, ctx.label, file_name, total);
             let _ = ctx.app.emit(
                 crate::sync::events::FILE_TRANSFER_COMPLETE,
@@ -1751,13 +1757,6 @@ fn handle_transfer_progress(ctx: &TransferContext, bytes: u64, total: u64, path:
                     label: ctx.label.to_string(),
                 },
             );
-            ctx.sync.add_pending_activity(SyncActivityItem {
-                file_name: std::sync::Arc::from(path_str),
-                action,
-                timestamp: chrono::Utc::now().timestamp(),
-                size_bytes: total,
-                label: Arc::clone(&ctx.label),
-            });
         }
     }
     debug!("{} [{}]: {}/{} bytes, path: {:?}", dir_name, ctx.label, bytes, total, path);
@@ -1925,7 +1924,7 @@ fn build_fetch_callback(sync: Arc<SyncRunner>, app: AppHandle, label: Arc<str>) 
 /// soon as its individual AEAD verification has succeeded — instead of
 /// waiting for the entire sync cycle to finish. See
 /// [`crate::sync::progress::mark_file_synced`] for the full reasoning.
-fn build_file_synced_callback(sync: Arc<SyncRunner>, label: Arc<str>) -> hcfs_client::sync::FileSyncedFn {
+pub fn build_file_synced_callback(sync: Arc<SyncRunner>, label: Arc<str>) -> hcfs_client::sync::FileSyncedFn {
     Arc::new(move |rel_path, path_hash_hex, arion_cid, action, timestamps| {
         debug!("File synced [{label}]: {rel_path} ({action}) cid={arion_cid}");
         if rel_path.is_empty() {
@@ -1943,6 +1942,81 @@ fn build_file_synced_callback(sync: Arc<SyncRunner>, label: Arc<str>) -> hcfs_cl
         // also finishes.
         if let Err(e) = crate::sync::progress::mark_file_synced(&sync, rel_path) {
             warn!(label = %label, path = %rel_path, error = %e, "Failed to mark file synced in progress tracker");
+        }
+
+        // Activity items must reflect SERVER-CONFIRMED success, not just
+        // "the request body finished sending". hcfs-client's per-file
+        // upload/download tasks invoke this callback only after the
+        // task returns `Ok` (2xx response parsed for uploads, full
+        // chunked download + AEAD verification for downloads), so this
+        // is the earliest point a "Uploaded" / "Downloaded" row is true.
+        //
+        // The enqueue ran inside the byte-progress completion-tick
+        // before fix `2026-05-13-sync-402-data-integrity`. That site
+        // fires when the local TCP socket has drained, so a 402 /
+        // 5xx-rejected upload would still appear as "Uploaded" in the
+        // activity log. See docs/plans/2026-05-13-sync-402-data-integrity.md.
+        //
+        // Action mapping: hcfs-client passes `action` as one of
+        // `"uploaded"` / `"downloaded"` / `"deleted"` / `"conflict"`
+        // (mirroring `SyncActivityAction::as_str()`). Unknown values
+        // produce `None`, which skips the activity enqueue entirely —
+        // recording nothing is the truthful choice when we don't know
+        // how to categorize the event. Fabricating an `Uploaded` row
+        // for a future hcfs-client variant (e.g. Phase 2's `"failed"`)
+        // is the exact category of lie this task exists to eliminate.
+        //
+        // `size_bytes` is set to `0` because `FileSyncedFn`'s current
+        // signature (`Fn(&str, &str, &str, &str, Option<&FileTimestamps>)`)
+        // does not carry the byte count — only the byte-progress
+        // callback (which we no longer trust for activity rows) had it.
+        // Consequences accepted as Phase 1 deficits:
+        //
+        //   - `SyncActivityRow.size` (populated from this field at
+        //     `src-tauri/src/sync/status.rs:74`) reports `0` for items
+        //     enqueued here. The FE hook `app/lib/hooks/useSyncActivity.ts`
+        //     exposes the value as `size: number`, but no current FE
+        //     component consumes it (verified 2026-05-13). The latent
+        //     field still ships zero-valued.
+        //
+        //   - `ActivityDedupKey = (file_name, action, label, size_bytes)`
+        //     (`hcfs_client::engine::runner::ActivityDedupKey`) loses
+        //     entropy on its last component. Path + action + label
+        //     collisions are still possible without size, but no
+        //     production caller legitimately enqueues two `Uploaded`
+        //     rows for the same `(path, label)` within a single cycle
+        //     (hcfs-client serializes per-file work).
+        //
+        // Phase 2 Task 2.3 broadens `FileSyncedFn` into a richer event
+        // variant; that task threads `size_bytes` back through here.
+        let activity_action: Option<SyncActivityAction> = match action {
+            "uploaded" => Some(SyncActivityAction::Uploaded),
+            "downloaded" => Some(SyncActivityAction::Downloaded),
+            "deleted" => Some(SyncActivityAction::Deleted),
+            "conflict" => Some(SyncActivityAction::Conflict),
+            other => {
+                warn!(
+                    label = %label,
+                    path = %rel_path,
+                    action = other,
+                    "unknown FileSyncedFn action; skipping activity-item enqueue to preserve activity-log truth"
+                );
+                None
+            }
+        };
+        // Skip ONLY the activity enqueue on unknown actions —
+        // `upsert_synced_path` below still runs because the file did
+        // sync successfully (hcfs-client only fires this callback on
+        // per-file `Ok`); we just decline to categorize the event for
+        // the activity log.
+        if let Some(activity_action) = activity_action {
+            sync.add_pending_activity(SyncActivityItem {
+                file_name: Arc::from(rel_path),
+                action: activity_action,
+                timestamp: chrono::Utc::now().timestamp(),
+                size_bytes: 0,
+                label: Arc::clone(&label),
+            });
         }
 
         // hcfs's `FileSyncedFn` callback passes `path_hash_hex` as a hex

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -1953,9 +1953,22 @@ pub fn build_file_synced_callback(sync: Arc<SyncRunner>, label: Arc<str>) -> hcf
         // `complete_pending_files`. Without this, a small decrypted file
         // gets stuck on "Decrypting" until the largest in-flight file
         // also finishes.
-        if let Err(e) = crate::sync::progress::mark_file_synced(&sync, rel_path) {
-            warn!(label = %label, path = %rel_path, error = %e, "Failed to mark file synced in progress tracker");
-        }
+        //
+        // `mark_file_synced` also returns the file's `total_bytes` from
+        // the in-memory progress tracker — that's the byte count we
+        // thread into the activity row below. `FileSyncedFn`'s upstream
+        // signature still doesn't carry the size, but the progress
+        // tracker holds it from per-chunk telemetry and the transition
+        // here reads it BEFORE flipping the row to `Completed`. The
+        // fallback (no session / no file entry / already-Completed) is
+        // `0`, matching the prior hardcoded value for those edge cases.
+        let size_bytes = match crate::sync::progress::mark_file_synced(&sync, rel_path) {
+            Ok(n) => n,
+            Err(e) => {
+                warn!(label = %label, path = %rel_path, error = %e, "Failed to mark file synced in progress tracker");
+                0
+            }
+        };
 
         // Activity items must reflect SERVER-CONFIRMED success, not just
         // "the request body finished sending". hcfs-client's per-file
@@ -1979,29 +1992,23 @@ pub fn build_file_synced_callback(sync: Arc<SyncRunner>, label: Arc<str>) -> hcf
         // for a future hcfs-client variant (e.g. Phase 2's `"failed"`)
         // is the exact category of lie this task exists to eliminate.
         //
-        // `size_bytes` is set to `0` because `FileSyncedFn`'s current
-        // signature (`Fn(&str, &str, &str, &str, Option<&FileTimestamps>)`)
-        // does not carry the byte count — only the byte-progress
-        // callback (which we no longer trust for activity rows) had it.
-        // Consequences accepted as Phase 1 deficits:
+        // `size_bytes` comes from `mark_file_synced`'s return value —
+        // the in-memory progress tracker's `file.total_bytes` read
+        // before the row transitions to Completed. The Recent-Files
+        // view (`get_recent_files` in `sync/files.rs`) reads
+        // `item.size_bytes` directly, so without this thread-through
+        // every newly-synced file would render with size 0 / "unknown".
+        // The byte-progress callback used to supply the size; we no
+        // longer trust it for activity rows (see the 402 plan), so the
+        // progress tracker is the authoritative source. The 0 fallback
+        // covers the documented edge cases of `mark_file_synced` —
+        // no session, no file entry, or the file was already Completed
+        // — where the size isn't observable from this call.
         //
-        //   - `SyncActivityRow.size` (populated from this field at
-        //     `src-tauri/src/sync/status.rs:74`) reports `0` for items
-        //     enqueued here. The FE hook `app/lib/hooks/useSyncActivity.ts`
-        //     exposes the value as `size: number`, but no current FE
-        //     component consumes it (verified 2026-05-13). The latent
-        //     field still ships zero-valued.
-        //
-        //   - `ActivityDedupKey = (file_name, action, label, size_bytes)`
-        //     (`hcfs_client::engine::runner::ActivityDedupKey`) loses
-        //     entropy on its last component. Path + action + label
-        //     collisions are still possible without size, but no
-        //     production caller legitimately enqueues two `Uploaded`
-        //     rows for the same `(path, label)` within a single cycle
-        //     (hcfs-client serializes per-file work).
-        //
-        // Phase 2 Task 2.3 broadens `FileSyncedFn` into a richer event
-        // variant; that task threads `size_bytes` back through here.
+        // `ActivityDedupKey = (file_name, action, label, size_bytes)`
+        // (`hcfs_client::engine::runner::ActivityDedupKey`) regains
+        // full entropy now that `size_bytes` is non-zero on the common
+        // path.
         let activity_action: Option<SyncActivityAction> = match action {
             "uploaded" => Some(SyncActivityAction::Uploaded),
             "downloaded" => Some(SyncActivityAction::Downloaded),
@@ -2027,7 +2034,7 @@ pub fn build_file_synced_callback(sync: Arc<SyncRunner>, label: Arc<str>) -> hcf
                 file_name: Arc::from(rel_path),
                 action: activity_action,
                 timestamp: chrono::Utc::now().timestamp(),
-                size_bytes: 0,
+                size_bytes,
                 label: Arc::clone(&label),
             });
         }

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -1919,9 +1919,16 @@ fn handle_transfer_progress(ctx: &TransferContext, bytes: u64, total: u64, path:
 ///
 /// Ownership: all captures are owned (`AppHandle` is `Clone` and cheap;
 /// `label` and `plan_uploads` are moved in). The spawned future is
-/// `'static`, satisfying `tokio::spawn`'s `Send + 'static` bound.
+/// `'static + Send`, satisfying `tauri::async_runtime::spawn`'s bound.
+///
+/// Uses `tauri::async_runtime::spawn`, NOT bare `tokio::spawn`: this runs
+/// from the hcfs `on_sync_plan_ready` callback, whose calling thread is
+/// not contractually guaranteed to be inside a Tokio runtime. Bare
+/// `tokio::spawn` panics ("there is no reactor running") off-runtime —
+/// the same crash class fixed in `tauri_bridge::spawn_snapshot_emit`.
+/// Tauri's runtime handle is global and thread-context-independent.
 fn spawn_record_intent_plan<R: tauri::Runtime>(app: AppHandle<R>, label: String, plan_uploads: Vec<(String, u64)>) {
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         use tauri::Manager;
         let state: tauri::State<'_, crate::app_state::AppState> = app.state();
         let account_id = match state.current_account_id() {
@@ -1968,10 +1975,16 @@ fn spawn_record_intent_plan<R: tauri::Runtime>(app: AppHandle<R>, label: String,
 ///
 /// Ownership: every capture is owned. `AppHandle<R>` is `Clone` and cheap
 /// (internally `Arc`); `label` and `rel_path` are moved in. The spawned
-/// future is `'static`, satisfying `tokio::spawn`'s `Send + 'static`
+/// future is `'static + Send`, satisfying `tauri::async_runtime::spawn`'s
 /// bound.
+///
+/// Uses `tauri::async_runtime::spawn`, NOT bare `tokio::spawn`: this runs
+/// from the hcfs `on_file_synced` callback, whose calling thread is not
+/// contractually guaranteed to be inside a Tokio runtime. Bare
+/// `tokio::spawn` panics ("there is no reactor running") off-runtime —
+/// the same crash class fixed in `tauri_bridge::spawn_snapshot_emit`.
 fn spawn_mark_intent_completed<R: tauri::Runtime>(app: AppHandle<R>, label: String, rel_path: String) {
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         use tauri::Manager;
         let state: tauri::State<'_, crate::app_state::AppState> = app.state();
         let account_id = match state.current_account_id() {

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -403,39 +403,56 @@ fn spawn_reconcile_timestamps(app: &AppHandle, sync: Arc<SyncRunner>, manager_ar
     tauri::async_runtime::spawn(async move {
         use hcfs_client::drive::{FailureReason, ReconcileOutcome, RetryPolicy};
 
-        // Acquire the manager lock JUST long enough to construct the
-        // `'static` retry future, then drop the guard before awaiting
-        // it. The retry budget includes up to 7s of `tokio::time::sleep`
-        // across 0s / 2s / 5s backoffs; holding the per-drive mutex
-        // across those sleeps would block concurrent sync operations
-        // and IPC paths (like `get_user_files` -> try_lock on the same
-        // mutex) for the full retry window. `reconcile_with_retry`
-        // internally clones `Drive` (a cheap Arc-sharing clone) so
-        // the future is `'static` and lock-independent.
-        let reconcile_future = {
-            let manager = manager_arc.lock().await;
-            manager.reconcile_with_retry(RetryPolicy::first_reconcile_default())
-        };
-        let outcome = reconcile_future.await;
+        // Hold the per-drive manager lock across the ENTIRE
+        // `reconcile_with_retry` await.
+        //
+        // The reviewer flagged this lock window as wasteful (up to
+        // ~7s with 0s / 2s / 5s backoffs and HTTP latency), and the
+        // hcfs-client API was changed so the returned future is
+        // `'static` precisely to allow a lock-free await. However,
+        // releasing the lock around the network call opened a
+        // concurrent file-write race: both `reconcile_with_retry`
+        // (on success) and `run_sync_cycle` (end of every cycle)
+        // persist `sync_state.json`. With the lock released, a sync
+        // cycle triggered by a user `add_files` IPC right after
+        // login could interleave its plan-and-save with the
+        // reconcile's save, dropping the upload entry from the
+        // baseline. Observed symptom: the "Adding ... to sync
+        // folder…" toast sat on the 60s `upload_processing`
+        // watchdog timeout because no first-chunk event ever fired.
+        //
+        // The cold-start reconcile is a one-shot per drive — once
+        // the cache is populated the gate stays settled for the
+        // rest of the session, so this lock window is paid at most
+        // once per drive per login. Restoring concurrency safety
+        // beats saving 7s on cold start.
+        //
+        // The hcfs-client `'static` future shape is preserved so
+        // that a future revision can move the file-write
+        // coordination into hcfs-client (e.g. an internal
+        // per-drive write mutex) and reclaim the lock-window
+        // optimization without another desktop change.
+        //
+        // Lock hygiene: `manager_arc` is a `tokio::sync::Mutex` so
+        // its guard is `Send` and safely held across `.await`
+        // points (Async Lock Hygiene axiom applies to
+        // `std::sync::Mutex` guards, not Tokio's).
+        let manager = manager_arc.lock().await;
+        let outcome = manager.reconcile_with_retry(RetryPolicy::first_reconcile_default()).await;
 
         match &outcome {
-            ReconcileOutcome::Reconciled { duration_ms } => {
-                // Re-lock briefly to load the fresh state we just
-                // persisted. This window is microseconds (file read)
-                // versus the up-to-7s window we just eliminated.
-                let state_result = manager_arc.lock().await.load_sync_state().await;
-                match state_result {
-                    Ok(state) => {
-                        let paths = build_synced_paths_from_state(&state);
-                        sync.update_synced_paths_cache(&label, paths);
-                        let _ = app.emit(crate::sync::events::ACTIVITY_UPDATED, ());
-                        info!(label = %label, duration_ms = duration_ms, "reconcile: cache refreshed");
-                    }
-                    Err(e) => {
-                        warn!(label = %label, error = %e, "reconcile: post-fetch state reload failed");
-                    }
+            ReconcileOutcome::Reconciled { duration_ms } => match manager.load_sync_state().await {
+                Ok(state) => {
+                    let paths = build_synced_paths_from_state(&state);
+                    sync.update_synced_paths_cache(&label, paths);
+                    drop(manager);
+                    let _ = app.emit(crate::sync::events::ACTIVITY_UPDATED, ());
+                    info!(label = %label, duration_ms = duration_ms, "reconcile: cache refreshed");
                 }
-            }
+                Err(e) => {
+                    warn!(label = %label, error = %e, "reconcile: post-fetch state reload failed");
+                }
+            },
             ReconcileOutcome::Fresh => {
                 debug!(label = %label, "reconcile: skipped (fresh)");
             }

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -301,6 +301,24 @@ async fn remove_drive_inmemory(sync: &SyncRunner, label: &str) -> (usize, Option
 
     sync.remove_state(label);
     sync.discard_pending_activity_for_label(label);
+    // Wipe the synced-paths timestamp cache for this label so a
+    // future re-registration under the same label starts from a
+    // clean slate (otherwise a stale entry survives across
+    // remove/re-add cycles, briefly showing the previous drive's
+    // upload dates in the UI until the first reconcile refreshes).
+    if let Ok(mut cache) = sync.synced_paths_cache.lock() {
+        cache.remove(label);
+    }
+    // Drop the producer-side first-reconcile gate so the next
+    // `register_drive` for this label installs a fresh gate. Any
+    // in-flight `wait_for_first_reconcile` from a still-running
+    // spawned reconcile task is unaffected — that task holds its
+    // own `Arc<ReconcileGate>` clone and will settle on its Arc
+    // independently. See the upstream `SyncRunner::remove_drive`
+    // comment for the full invariant.
+    if let Ok(mut gates) = sync.first_reconcile.lock() {
+        gates.remove(label);
+    }
     let _ = crate::sync::progress::remove_files_for_label(sync, label.to_string());
 
     (remaining, removed_path)
@@ -353,39 +371,120 @@ async fn register_drive(app: &AppHandle, sync: &Arc<SyncRunner>, manager: DriveM
     spawn_reconcile_timestamps(app, sync.clone(), reconcile_arc, label.to_string());
 }
 
-/// Background one-shot task: fetch the server manifest and refresh
-/// `remote_timestamps` on disk when the drive's local state is missing
-/// authoritative values. On success, reloads state from disk, rebuilds
-/// the in-memory synced-paths cache, and emits `hcfs_activity_updated`
-/// so the Files page re-queries and renders the freshly-populated
-/// "DATE UPLOADED" column. Silently fails open — drive init must stay
-/// usable even when the server is unreachable.
+/// Background task: drive a bounded-retry reconcile of the server
+/// manifest and settle the drive's first-reconcile readiness gate so
+/// consumers reading `synced_paths_cache` (e.g. `get_user_files`) can
+/// await it.
+///
+/// Compared to the prior fire-and-forget version, this:
+///
+/// - Retries transient failures (network / 5xx / timeout) up to the
+///   policy's budget (default 3 attempts at 0s / 2s / 5s) inside
+///   hcfs-client, so a brief server hiccup at cold start no longer
+///   leaves the FE looking at zero-timestamp entries until the next
+///   sync cycle.
+/// - Settles a per-label `ReconcileGate` regardless of outcome so the
+///   FE's `wait_for_first_reconcile` budget is correctly released.
+///   Without this, `get_user_files` would wait the full 6s on every
+///   cold start before reading a cache that's already fresh from
+///   disk (when reconcile is skipped).
+/// - On terminal failure (every attempt failed), emits
+///   `hcfs_metadata_stale` so the FE can show a per-drive banner.
+///   The banner self-clears when the next `ACTIVITY_UPDATED` fires
+///   for the same label (e.g. on the first successful sync cycle).
 fn spawn_reconcile_timestamps(app: &AppHandle, sync: Arc<SyncRunner>, manager_arc: Arc<TokioMutex<DriveManager>>, label: String) {
+    // Acquire the gate handle BEFORE spawning the task. This way,
+    // even if the spawn task is delayed (Tokio scheduler under
+    // load), any FE call to `wait_for_first_reconcile` already
+    // sees the gate as registered (returns Timeout, not
+    // NotRegistered) — keeping the readiness contract consistent.
+    let gate = sync.first_reconcile_gate(&label);
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        let manager = manager_arc.lock().await;
-        match manager.reconcile_remote_timestamps().await {
-            Ok(true) => match manager.load_sync_state().await {
-                Ok(state) => {
-                    let paths = build_synced_paths_from_state(&state);
-                    sync.update_synced_paths_cache(&label, paths);
-                    drop(manager);
-                    let _ = app.emit(crate::sync::events::ACTIVITY_UPDATED, ());
-                    info!(label = %label, "reconcile_remote_timestamps: cache refreshed");
+        use hcfs_client::drive::{FailureReason, ReconcileOutcome, RetryPolicy};
+
+        // Acquire the manager lock JUST long enough to construct the
+        // `'static` retry future, then drop the guard before awaiting
+        // it. The retry budget includes up to 7s of `tokio::time::sleep`
+        // across 0s / 2s / 5s backoffs; holding the per-drive mutex
+        // across those sleeps would block concurrent sync operations
+        // and IPC paths (like `get_user_files` -> try_lock on the same
+        // mutex) for the full retry window. `reconcile_with_retry`
+        // internally clones `Drive` (a cheap Arc-sharing clone) so
+        // the future is `'static` and lock-independent.
+        let reconcile_future = {
+            let manager = manager_arc.lock().await;
+            manager.reconcile_with_retry(RetryPolicy::first_reconcile_default())
+        };
+        let outcome = reconcile_future.await;
+
+        match &outcome {
+            ReconcileOutcome::Reconciled { duration_ms } => {
+                // Re-lock briefly to load the fresh state we just
+                // persisted. This window is microseconds (file read)
+                // versus the up-to-7s window we just eliminated.
+                let state_result = manager_arc.lock().await.load_sync_state().await;
+                match state_result {
+                    Ok(state) => {
+                        let paths = build_synced_paths_from_state(&state);
+                        sync.update_synced_paths_cache(&label, paths);
+                        let _ = app.emit(crate::sync::events::ACTIVITY_UPDATED, ());
+                        info!(label = %label, duration_ms = duration_ms, "reconcile: cache refreshed");
+                    }
+                    Err(e) => {
+                        warn!(label = %label, error = %e, "reconcile: post-fetch state reload failed");
+                    }
                 }
-                Err(e) => {
-                    warn!(label = %label, error = %e, "reconcile_remote_timestamps: post-fetch state reload failed");
-                }
-            },
-            Ok(false) => {
-                debug!(label = %label, "reconcile_remote_timestamps: skipped (fresh)");
             }
-            Err(e) => {
-                // Fail open — drive stays usable, the next sync cycle's
-                // own `fetch_remote_state` will pick up the slack.
-                warn!(label = %label, error = %e, "reconcile_remote_timestamps: failed");
+            ReconcileOutcome::Fresh => {
+                debug!(label = %label, "reconcile: skipped (fresh)");
+            }
+            ReconcileOutcome::Failed { reason, attempts } => {
+                let reason_str = match reason {
+                    FailureReason::Retryable { last_error } => {
+                        // `last_error` is `Arc<SyncError>`; Display
+                        // delegates through the Arc. Downstream
+                        // consumers wanting typed dispatch (e.g.
+                        // `SyncError::RateLimited`'s retry_after_secs)
+                        // can match on `last_error.as_ref()` from the
+                        // outcome variant.
+                        format!("transient error after {attempts} attempts: {last_error}")
+                    }
+                    FailureReason::Terminal { error } => {
+                        format!("non-retryable error: {error}")
+                    }
+                    // `FailureReason` is `#[non_exhaustive]` so an
+                    // hcfs-client bump can add new variants without
+                    // breaking the build. Render unknowns as a
+                    // generic transient failure — better than
+                    // hiding them entirely.
+                    _ => format!("reconcile failed after {attempts} attempts"),
+                };
+                warn!(label = %label, attempts = attempts, reason = %reason_str, "reconcile: failed, emitting metadata-stale");
+                let _ = app.emit(
+                    crate::sync::events::METADATA_STALE,
+                    crate::sync::events::MetadataStalePayload {
+                        label: label.clone(),
+                        reason: reason_str,
+                    },
+                );
+            }
+            // `ReconcileOutcome` is `#[non_exhaustive]`; tolerate
+            // unknown future variants by logging and falling
+            // through to the gate settle below (which guarantees
+            // awaiters never hang forever).
+            _ => {
+                warn!(label = %label, "reconcile: unknown outcome variant from hcfs-client (likely needs FE wiring)");
             }
         }
+
+        // Settle the gate AFTER all I/O so a consumer that wakes
+        // on the settle sees a fully-coherent cache. The gate is
+        // first-write-wins; settling here on every code path is
+        // safe and required (the readiness signal must be set even
+        // when the outcome is `Failed`, so awaiters don't hang
+        // until the timeout).
+        gate.settle(outcome);
     });
 }
 
@@ -2337,6 +2436,66 @@ mod tests {
             "should return the sync path of the removed drive"
         );
         assert!(!sync.drives.lock().await.contains_key(label), "drive should no longer be in the map");
+    }
+
+    /// Regression test for fix 3 in the date-uploaded readiness PR.
+    ///
+    /// `remove_drive_inmemory` used to leave two per-label side maps
+    /// untouched on each remove/re-add cycle: the synced-paths
+    /// timestamp cache and the first-reconcile gate registry. Both
+    /// leaks were silent (no functional bug surfaced) but they
+    /// accumulated per label until process exit AND they could
+    /// briefly surface stale upload dates after a remove-then-re-add
+    /// because the cache entry survived. This test pins the cleanup.
+    #[tokio::test]
+    async fn remove_drive_inmemory_clears_synced_paths_cache_and_first_reconcile_gate() {
+        use hcfs_client::engine::types::SyncedFileInfo;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let sync = test_sync_runner();
+        let label = "leak-test";
+
+        // Seed both side maps directly — `remove_drive_inmemory`
+        // doesn't depend on the drive actually being registered for
+        // the cleanup invariant to hold, and seeding lets the test
+        // stay focused on the cleanup itself.
+        sync.update_synced_paths_cache(
+            label,
+            HashMap::from([(
+                "file.txt".to_string(),
+                SyncedFileInfo {
+                    path_hash: [0u8; 32],
+                    arion_cid: Arc::from("cid-1"),
+                    uploaded_at: 1_700_000_000,
+                    updated_at: 1_700_000_100,
+                },
+            )]),
+        );
+        // Register the gate via the public API so we exercise the
+        // production code path that `register_drive` uses.
+        let _ = sync.first_reconcile_gate(label);
+
+        // Pre-conditions: both side maps have an entry for the label.
+        assert!(
+            sync.get_cached_synced_paths(label).is_some(),
+            "synced_paths_cache should have a pre-removal entry"
+        );
+        assert!(
+            sync.first_reconcile.lock().expect("lock").contains_key(label),
+            "first_reconcile gate map should have a pre-removal entry"
+        );
+
+        let _ = remove_drive_inmemory(&sync, label).await;
+
+        assert!(
+            sync.get_cached_synced_paths(label).is_none(),
+            "synced_paths_cache must be cleared by remove_drive_inmemory"
+        );
+        assert!(
+            !sync.first_reconcile.lock().expect("lock").contains_key(label),
+            "first_reconcile gate map must be cleared by remove_drive_inmemory"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/sync/lifecycle.rs
+++ b/src-tauri/src/sync/lifecycle.rs
@@ -1017,11 +1017,12 @@ pub async fn stop_sync(app: AppHandle) -> Result<()> {
         cache.clear();
     }
 
-    // 0c. Reset the upload-processing banner state so a logout / account
-    //     switch doesn't leave a stale "Processing N files…" banner up
-    //     for the next user. The reset is unconditional (clears even if
-    //     no upload was active) to make this path idempotent.
-    app_state.upload_processing.reset(&app);
+    // 0c. Reset the upload-processing banner state for EVERY label so a
+    //     logout / account switch doesn't leave a stale "Processing N files…"
+    //     banner up for the next user. `reset_all` is unconditional (clears
+    //     even if no upload was active) and emits one cleared payload per
+    //     previously-active label so the FE per-drive banners all clear.
+    app_state.upload_processing.reset_all(&app);
 
     // 1. Cancel every drive's cancellation token FIRST so the sync loop
     //    sees a clean shutdown signal and can persist state before exiting.
@@ -1748,7 +1749,7 @@ fn handle_transfer_progress(ctx: &TransferContext, bytes: u64, total: u64, path:
             use tauri::Manager;
             let app_state = ctx.app.state::<crate::app_state::AppState>();
             let epoch = app_state.sync_session_epoch.load(std::sync::atomic::Ordering::SeqCst);
-            app_state.upload_processing.clear_if_session_advanced(&ctx.app, epoch);
+            app_state.upload_processing.clear_if_session_advanced(&ctx.app, &ctx.label, epoch);
         }
 
         if crate::sync::logic::is_file_completion_tick(bytes, total) {

--- a/src-tauri/src/sync/mnemonic.rs
+++ b/src-tauri/src/sync/mnemonic.rs
@@ -247,6 +247,17 @@ pub async fn ensure_sync_mnemonic(state: tauri::State<'_, crate::app_state::AppS
         // sure the active AuthInfo slot has it so downstream Rust callers
         // pick it up without re-traversing the fallback chain.
         state.auth.lock()?.cache_session_mnemonic(&account_id, (*m).clone());
+        // Re-emit `hippius_auth_ready` so the FE's `tryAutoInitSync`
+        // retry ladder picks up. The FE now fires
+        // `ensure_sync_mnemonic` in parallel with `initSync` (no
+        // longer awaiting it before invoking `auto_init_sync`), so
+        // the first `auto_init_sync` attempt may land while
+        // `AuthInfo.mnemonic` is still empty. The ladder's listener
+        // is armed before attempt 1, so an emit here unblocks the
+        // next retry the moment the cache is populated. Cheap (one
+        // Tauri event), no-op for paths where the FE didn't actually
+        // race.
+        state.sync_bridge.emit_auth_ready();
         return Ok(());
     }
 
@@ -296,6 +307,12 @@ pub async fn ensure_sync_mnemonic(state: tauri::State<'_, crate::app_state::AppS
     // substrate_address so a stale cache from a previous account never
     // leaks across logins.
     state.auth.lock()?.cache_session_mnemonic(&account_id, (*generated).clone());
+
+    // Same rationale as the fast-recovery branch above — the FE
+    // races `ensure_sync_mnemonic` with `initSync`, so emit
+    // `hippius_auth_ready` once the cache is populated so the retry
+    // ladder picks up.
+    state.sync_bridge.emit_auth_ready();
 
     Ok(())
 }

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod config;
 pub mod control;
+pub mod credits_exhausted;
 pub mod device;
 pub mod drive_status;
 pub mod events;

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -13,6 +13,7 @@ pub mod failure_commands;
 pub mod failure_tracking;
 pub mod files;
 pub mod folders;
+pub mod intent;
 pub mod lifecycle;
 pub mod logic;
 pub mod migration;

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -17,6 +17,7 @@ pub mod logic;
 pub mod migration;
 pub mod mnemonic;
 pub mod paths;
+pub mod preparing;
 pub mod progress;
 pub mod region;
 pub mod relative_path_backfill;

--- a/src-tauri/src/sync/paths.rs
+++ b/src-tauri/src/sync/paths.rs
@@ -48,9 +48,7 @@ pub struct SyncPathResult {
 /// doesn't exist (e.g. during validation of a path the user just typed),
 /// preserving the prefix-matching semantics tested by the unit tests below.
 async fn validate_no_path_overlap(new_path: &Path, new_label: &str, existing: &[(String, String)]) -> Result<()> {
-    let canonical_new = tokio::fs::canonicalize(new_path)
-        .await
-        .unwrap_or_else(|_| new_path.to_path_buf());
+    let canonical_new = tokio::fs::canonicalize(new_path).await.unwrap_or_else(|_| new_path.to_path_buf());
 
     for (label, path_str) in existing {
         if label == new_label {
@@ -290,6 +288,32 @@ mod label_tests {
     }
 }
 
+/// Look up the drive label for a given local sync-root `path`.
+///
+/// Used by IPC commands in `files.rs` (`add_file`, `add_folder`,
+/// `add_files`) to resolve the FE-supplied `sync_path` into the
+/// per-label key used by `UploadProcessingState` (and any other
+/// per-drive state going forward).
+///
+/// Returns `Ok(Some(label))` when a row exists, `Ok(None)` when no
+/// row matches — callers gracefully degrade to a no-op rather than
+/// surfacing a hard error (the FE may have invoked this IPC during
+/// a brief teardown window after the drive's row was removed).
+///
+/// # Errors
+///
+/// Returns `Err` only when the SQL query itself fails (DB locked,
+/// connection lost). Missing rows are an `Ok(None)` outcome.
+pub(crate) async fn label_for_sync_path(pool: &SqlitePool, account_id: &str, sync_path: &str) -> Result<Option<String>> {
+    let owner = account_key(account_id);
+    let label: Option<String> = sqlx::query_scalar("SELECT label FROM sync_paths WHERE owner = ? AND path = ? LIMIT 1")
+        .bind(&owner)
+        .bind(sync_path)
+        .fetch_optional(pool)
+        .await?;
+    Ok(label)
+}
+
 /// Set the `is_paused` flag for a sync path in the DB.
 pub(crate) async fn set_sync_path_paused(pool: &SqlitePool, account_id: &str, label: &str, paused: bool) -> Result<()> {
     let owner = account_key(account_id);
@@ -357,7 +381,11 @@ mod tests {
     #[tokio::test]
     async fn sibling_paths_are_allowed() {
         let existing = pairs(&[("photos", "/home/user/Photos")]);
-        assert!(validate_no_path_overlap(Path::new("/home/user/Documents"), "docs", &existing).await.is_ok());
+        assert!(
+            validate_no_path_overlap(Path::new("/home/user/Documents"), "docs", &existing)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -379,7 +407,11 @@ mod tests {
     #[tokio::test]
     async fn same_label_skips_self() {
         let existing = pairs(&[("docs", "/home/user/Documents")]);
-        assert!(validate_no_path_overlap(Path::new("/home/user/Documents/Work"), "docs", &existing).await.is_ok());
+        assert!(
+            validate_no_path_overlap(Path::new("/home/user/Documents/Work"), "docs", &existing)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/sync/preparing.rs
+++ b/src-tauri/src/sync/preparing.rs
@@ -34,31 +34,79 @@
 //!   label (the real per-file widget takes over).
 //! - [`PreparingState::clear_all`] — called from `stop_sync` /
 //!   logout / reset paths.
+//! - [`PreparingState::drain_expired`] — the watchdog backstop. The
+//!   normal-path clears above assume every `SyncStarted` is eventually
+//!   followed by a terminal event (or a files-populated snapshot) for
+//!   that label. hcfs-client violates that on at least one path: if a
+//!   drive leaves the registry between `run_sync_cycle` (which emitted
+//!   `SyncStarted`) and `dispatch_sync_result`, `trigger_sync_for_drive`
+//!   early-returns (`hcfs-client engine/runner.rs`, "Drive removed
+//!   during sync") emitting NO terminal event, and a no-op cycle never
+//!   produces a files-populated snapshot either. Without a backstop the
+//!   label is stranded in the set forever and the widget/tray show
+//!   "Preparing sync…" until an unrelated later action. The watchdog
+//!   self-expires any label that has been preparing longer than
+//!   [`PREPARING_WATCHDOG_TIMEOUT`]. This mirrors the proven
+//!   [`crate::sync::upload_processing`] banner watchdog — see that
+//!   module's note on why a pure elapsed-timeout (not an
+//!   `Instant`-ordering / liveness guard) is the correct shape.
 //!
 //! ## Concurrency
 //!
 //! All methods are synchronous and lock the inner [`Mutex`] only for
-//! the duration of the operation. The TauriSyncBridge handler that
-//! invokes them is also synchronous, so the lock is never held
-//! across an `.await` (compatible with the project's async-lock
-//! hygiene axiom).
+//! the duration of the operation; the guard is always dropped before
+//! returning (the watchdog `.await`s on the returned `Vec`, never
+//! across the guard — compatible with the project's async-lock
+//! hygiene axiom). The TauriSyncBridge handlers that invoke
+//! `mark_preparing`/`clear` are synchronous.
 
-use std::collections::HashSet;
-use std::sync::{Mutex, MutexGuard};
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::sync::{Mutex, MutexGuard, Weak};
+use std::time::{Duration, Instant};
 
-/// Set of drive labels currently in the "preparing" window between
+use hcfs_client::engine::runner::SyncRunner;
+
+/// Hard cap on how long a single label may stay in the preparing set
+/// before the watchdog force-clears it. The legitimate preparing window
+/// (watcher debounce + `scan_local_files` + `fetch_remote_state`) is
+/// seconds; a cycle still preparing after a full minute has either hung
+/// or lost its terminal event (the hcfs-client "drive removed during
+/// sync" path). 60s matches the sibling
+/// [`crate::sync::upload_processing`] banner timeout so the two
+/// "stuck UI state" backstops behave identically (it uses
+/// `Duration::from_mins(1)` — same value, same idiom).
+pub const PREPARING_WATCHDOG_TIMEOUT: Duration = Duration::from_mins(1);
+
+/// How often the watchdog scans for expired labels. 10s caps observable
+/// lateness (a stuck override clears within `TIMEOUT + SCAN_INTERVAL` of
+/// the missing terminal event) while keeping the idle wakeup rate
+/// negligible. Mirrors the upload-processing scan cadence.
+pub const PREPARING_WATCHDOG_SCAN_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Per-label state held inside the map.
+///
+/// `marked_at` is stamped once, on the first `SyncStarted` of a
+/// preparing window, and is deliberately NOT refreshed by subsequent
+/// duplicate `SyncStarted`s within the same window (see
+/// [`PreparingState::mark_preparing`]). This bounds the *total*
+/// preparing lifetime even under a file-watcher retrigger storm — a
+/// re-stamp-on-duplicate design would let such a storm reset the timer
+/// forever and defeat the watchdog.
+struct PreparingInner {
+    marked_at: Instant,
+}
+
+/// Map of drive labels currently in the "preparing" window between
 /// `SyncStarted` and the first ProgressSnapshot that has files.
 ///
 /// Owned by [`crate::app_state::AppState`] behind an `Arc`, mirroring
 /// the [`crate::sync::upload_processing::UploadProcessingState`]
-/// composition pattern.
+/// composition pattern. The value carries the timestamp the watchdog
+/// needs; membership semantics are otherwise unchanged from the
+/// original set — a label is "preparing" iff it is a key here.
 pub struct PreparingState {
-    /// Membership-only set: we only care whether a label is currently
-    /// preparing, not how long it has been. Order does not matter —
-    /// callers iterate at most once per event to clear after the
-    /// session is populated. `String` keys mirror the per-drive
-    /// label type used everywhere else in the sync module.
-    inner: Mutex<HashSet<String>>,
+    inner: Mutex<HashMap<String, PreparingInner>>,
 }
 
 impl Default for PreparingState {
@@ -70,7 +118,7 @@ impl Default for PreparingState {
 impl PreparingState {
     pub fn new() -> Self {
         Self {
-            inner: Mutex::new(HashSet::new()),
+            inner: Mutex::new(HashMap::new()),
         }
     }
 
@@ -78,12 +126,32 @@ impl PreparingState {
     ///
     /// Centralises the `expect` panic message so a future addition to
     /// the API can't introduce a new wording variant. The returned
-    /// guard's lifetime is tied to `&self`; each public method should
-    /// hold it for the smallest possible scope (no `.await` in this
-    /// module, but the project axiom forbidding sync-mutex-across-await
-    /// applies if a future caller adds async code here).
-    fn lock(&self) -> MutexGuard<'_, HashSet<String>> {
+    /// guard's lifetime is tied to `&self`; each public method holds it
+    /// for the smallest possible scope (no `.await` under the guard;
+    /// the project axiom forbidding sync-mutex-across-await applies if a
+    /// future caller adds async code here).
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, PreparingInner>> {
         self.inner.lock().expect("preparing mutex poisoned")
+    }
+
+    /// Insert `label` into the preparing set, stamping `now` as its
+    /// mark time on first insert only.
+    ///
+    /// Split out from [`Self::mark_preparing`] so tests can inject a
+    /// deterministic `now` without sleeping (mirrors
+    /// `UploadProcessingState`'s `*_at` test seam). Returns `true` if
+    /// the label was newly added; `false` if it was already present —
+    /// and on the `false` path the existing `marked_at` is preserved,
+    /// NOT refreshed, so the watchdog measures from the first
+    /// `SyncStarted` of the window.
+    fn mark_at(&self, now: Instant, label: &str) -> bool {
+        match self.lock().entry(label.to_string()) {
+            Entry::Occupied(_) => false,
+            Entry::Vacant(slot) => {
+                slot.insert(PreparingInner { marked_at: now });
+                true
+            }
+        }
     }
 
     /// Insert `label` into the preparing set.
@@ -107,7 +175,7 @@ impl PreparingState {
     /// would deadlock. The `mark_then_read_does_not_deadlock_in_sequence`
     /// test below pins this invariant.
     pub fn mark_preparing(&self, label: &str) -> bool {
-        self.lock().insert(label.to_string())
+        self.mark_at(Instant::now(), label)
     }
 
     /// Remove `label` from the preparing set.
@@ -115,7 +183,7 @@ impl PreparingState {
     /// Returns `true` if the label was present (caller can use this
     /// to skip a redundant `emit_snapshot` when nothing changed).
     pub fn clear(&self, label: &str) -> bool {
-        self.lock().remove(label)
+        self.lock().remove(label).is_some()
     }
 
     /// Remove every label from the preparing set.
@@ -138,14 +206,112 @@ impl PreparingState {
         !self.lock().is_empty()
     }
 
+    /// Remove and return every label that has been preparing for at
+    /// least [`PREPARING_WATCHDOG_TIMEOUT`] as measured from `now`.
+    ///
+    /// `now` is injected (not read internally) so tests are
+    /// deterministic without sleeping — and so a single scan compares
+    /// every entry against one consistent clock reading. Labels are
+    /// returned sorted for deterministic emit/log order; the FE does
+    /// not depend on order but the inline tests do.
+    ///
+    /// `now.checked_duration_since(marked_at)` is `None` when the
+    /// monotonic clock appears to have gone backwards (`now <
+    /// marked_at`); such an entry is treated as "not yet expired"
+    /// rather than panicking or clearing a still-active preparing
+    /// state. Mirrors `UploadProcessingState::drain_expired`.
+    ///
+    /// The guard is dropped before returning, so the watchdog may
+    /// freely `.await` on the returned `Vec` (axiom Async Lock
+    /// Hygiene).
+    fn drain_expired(&self, now: Instant) -> Vec<String> {
+        let mut g = self.lock();
+        let mut stale: Vec<String> = g
+            .iter()
+            .filter_map(|(label, entry)| {
+                now.checked_duration_since(entry.marked_at)
+                    .filter(|elapsed| *elapsed >= PREPARING_WATCHDOG_TIMEOUT)
+                    .map(|_| label.clone())
+            })
+            .collect();
+        for label in &stale {
+            g.remove(label);
+        }
+        drop(g);
+        stale.sort();
+        stale
+    }
+
     /// Sorted snapshot of the current set, for tests and diagnostics.
     /// Not on the hot path — produces a fresh `Vec` per call.
     #[doc(hidden)]
     pub fn snapshot_labels(&self) -> Vec<String> {
-        let mut labels: Vec<String> = self.lock().iter().cloned().collect();
+        let mut labels: Vec<String> = self.lock().keys().cloned().collect();
         labels.sort();
         labels
     }
+}
+
+/// Spawn the background watchdog that force-clears stuck preparing
+/// labels.
+///
+/// The normal-path clears (`SyncCompleted`/`SyncError`/`SyncStopped`,
+/// files-populated `ProgressSnapshot`) assume hcfs-client always emits
+/// a terminal event after `SyncStarted`. It does not on the
+/// "drive removed during sync" early-return, and a no-op cycle never
+/// produces a files-populated snapshot — so without this backstop a
+/// file-watcher-triggered cycle can strand a label in the set and pin
+/// the widget/tray on "Preparing sync…" indefinitely (the user-
+/// reported bug). Every [`PREPARING_WATCHDOG_SCAN_INTERVAL`] this
+/// drains any label older than [`PREPARING_WATCHDOG_TIMEOUT`] and, when
+/// something was drained, forces one snapshot emit so the FE re-derives
+/// with `is_any_preparing() == false` and drops the override.
+///
+/// Holds `Weak` handles (mirroring
+/// [`crate::sync::upload_processing::spawn_watchdog`]) so the task does
+/// not keep `AppState`/`SyncRunner` alive past app shutdown — it exits
+/// when either is dropped. One emit clears the override for all drained
+/// labels at once (the override is global on `is_any_preparing`), so
+/// there is no per-label emit.
+pub fn spawn_watchdog(state: Weak<PreparingState>, sync: Weak<SyncRunner>) {
+    // `tauri::async_runtime::spawn`, not `tokio::spawn`: our caller is
+    // Tauri's `setup` closure, which is not running inside a tokio
+    // runtime context, so `tokio::spawn`/`tokio::time::sleep` would
+    // panic at boot. Tauri's `async_runtime` is tokio underneath, so
+    // the inner `sleep` is fine. Same rationale as
+    // `upload_processing::spawn_watchdog`.
+    tauri::async_runtime::spawn(async move {
+        loop {
+            tokio::time::sleep(PREPARING_WATCHDOG_SCAN_INTERVAL).await;
+            let Some(state) = state.upgrade() else {
+                tracing::debug!("preparing watchdog: state dropped, exiting");
+                break;
+            };
+            let cleared = state.drain_expired(Instant::now());
+            // Drop the strong ref before any further work so we never
+            // extend AppState's lifetime across the (cheap) emit.
+            drop(state);
+            if cleared.is_empty() {
+                continue;
+            }
+            for label in &cleared {
+                tracing::warn!(
+                    label = %label,
+                    timeout_secs = PREPARING_WATCHDOG_TIMEOUT.as_secs(),
+                    "auto-clearing stuck preparing override (no terminal sync \
+                     event arrived — likely the hcfs-client drive-removed-mid-\
+                     cycle path)",
+                );
+            }
+            // One forced emit re-runs `apply_preparing_override` with an
+            // empty set, so the widget/tray leave "Preparing sync…".
+            // `immediate=true` bypasses the snapshot throttle. If the
+            // runner is already gone the override is moot anyway.
+            if let Some(sync) = sync.upgrade() {
+                sync.emit_snapshot(true);
+            }
+        }
+    });
 }
 
 #[cfg(test)]
@@ -224,27 +390,79 @@ mod tests {
     /// then invoke `emit_snapshot`, which synchronously re-enters
     /// `on_event` and reacquires the same mutex via `clear` /
     /// `is_any_preparing`. `std::sync::Mutex` is non-reentrant, so a
-    /// refactor that extended the guard's lifetime (e.g. returning
-    /// the guard alongside the bool, or inlining the lock acquisition
-    /// into the bridge handler) would deadlock at runtime — but every
-    /// existing unit test calls the operations on separate lines, so
-    /// it wouldn't trip them.
-    ///
-    /// This test calls `mark_preparing` and the read operations in a
-    /// tight sequence on the same thread. A regression that broke the
-    /// lock release would surface as the second call blocking
-    /// indefinitely; the test harness's per-test timeout would catch
-    /// it.
+    /// refactor that extended the guard's lifetime would deadlock at
+    /// runtime.
     #[test]
     fn mark_then_read_does_not_deadlock_in_sequence() {
         let state = PreparingState::new();
         assert!(state.mark_preparing("drive-a"));
-        // Each of the following reacquires the inner mutex. If
-        // `mark_preparing` had returned with the guard still live,
-        // every line below would deadlock on the same thread.
         assert!(state.is_any_preparing());
         assert_eq!(state.snapshot_labels(), vec!["drive-a".to_string()]);
         assert!(state.clear("drive-a"));
         assert!(!state.is_any_preparing());
+    }
+
+    // ── Watchdog backstop ────────────────────────────────────────────
+
+    /// A label that has been preparing longer than the timeout is
+    /// drained and returned; the set no longer contains it. This is
+    /// the core stuck-"Preparing sync…" fix: the missing-terminal-event
+    /// path can't strand a label forever.
+    #[test]
+    fn drain_expired_removes_label_older_than_timeout() {
+        let state = PreparingState::new();
+        let t0 = Instant::now();
+        assert!(state.mark_at(t0, "drive-a"));
+        let later = t0 + PREPARING_WATCHDOG_TIMEOUT + Duration::from_secs(1);
+        assert_eq!(state.drain_expired(later), vec!["drive-a".to_string()]);
+        assert!(!state.is_any_preparing());
+    }
+
+    /// A label still within its window is left untouched — the
+    /// watchdog must not cut short a legitimately-preparing cycle.
+    #[test]
+    fn drain_expired_keeps_fresh_label() {
+        let state = PreparingState::new();
+        let t0 = Instant::now();
+        state.mark_at(t0, "drive-a");
+        let soon = t0 + Duration::from_secs(5);
+        assert!(state.drain_expired(soon).is_empty());
+        assert_eq!(state.snapshot_labels(), vec!["drive-a".to_string()]);
+    }
+
+    /// Duplicate `SyncStarted`s within a window must NOT refresh
+    /// `marked_at`. A file-watcher retrigger storm re-marking the same
+    /// label every few seconds would otherwise reset the timer forever
+    /// and defeat the watchdog. The label must still expire measured
+    /// from the FIRST mark.
+    #[test]
+    fn duplicate_mark_does_not_extend_timeout() {
+        let state = PreparingState::new();
+        let t0 = Instant::now();
+        state.mark_at(t0, "drive-a");
+        // Re-marked well into the window (simulating a watcher storm).
+        let restamp_attempt = t0 + PREPARING_WATCHDOG_TIMEOUT - Duration::from_secs(1);
+        assert!(!state.mark_at(restamp_attempt, "drive-a"));
+        // Past the timeout relative to the FIRST mark only.
+        let later = t0 + PREPARING_WATCHDOG_TIMEOUT + Duration::from_secs(1);
+        assert_eq!(state.drain_expired(later), vec!["drive-a".to_string()]);
+    }
+
+    /// Clock-skew guard: if the supplied `now` precedes `marked_at`
+    /// (`checked_duration_since` → `None`), the entry is treated as
+    /// not-yet-expired, never drained, never panics.
+    #[test]
+    fn drain_expired_ignores_entry_marked_in_the_future() {
+        let state = PreparingState::new();
+        let t0 = Instant::now();
+        state.mark_at(t0 + Duration::from_secs(120), "drive-a");
+        assert!(state.drain_expired(t0).is_empty());
+        assert_eq!(state.snapshot_labels(), vec!["drive-a".to_string()]);
+    }
+
+    #[test]
+    fn drain_expired_on_empty_returns_empty() {
+        let state = PreparingState::new();
+        assert!(state.drain_expired(Instant::now()).is_empty());
     }
 }

--- a/src-tauri/src/sync/preparing.rs
+++ b/src-tauri/src/sync/preparing.rs
@@ -1,0 +1,199 @@
+//! Per-label "preparing" state for file-watcher-triggered sync cycles.
+//!
+//! Bridges the visibility gap between `SyncEvent::SyncStarted` and the
+//! first `ProgressSnapshot` that has files in the session.
+//!
+//! ## Why this exists
+//!
+//! For IPC-initiated uploads (`add_file`/`add_files`/`add_folder`) the
+//! top-of-page [`crate::sync::upload_processing::UploadProcessingState`]
+//! banner already covers the disk-copy + encryption window. For
+//! file-watcher-initiated cycles (user drops a folder via Finder, an
+//! external editor writes into the sync dir, etc.) there is no banner
+//! by design — and the bottom-right widget is gated on
+//! `total_files > 0` in [`hcfs_client::engine::progress::snapshot::build_snapshot`],
+//! so the user sees nothing during the debounce + `scan_local_files`
+//! + `fetch_remote_state` window even though the system is doing work.
+//!
+//! This module tracks which drive labels are currently in that
+//! "preparing" window. The snapshot pipeline reads it and, when any
+//! label is present, overrides `widget_visible=true` and
+//! `widget_state="preparing"` on an otherwise-invisible snapshot.
+//!
+//! ## Lifecycle
+//!
+//! - [`PreparingState::mark_preparing`] — called from the
+//!   `SyncEvent::SyncStarted` handler when the upload-processing
+//!   banner is NOT active (i.e. this is a file-watcher cycle, not an
+//!   IPC-initiated one). The banner check avoids double-signalling
+//!   for IPC uploads — those already have their own "we're working"
+//!   indicator.
+//! - [`PreparingState::clear`] — called from `SyncCompleted`,
+//!   `SyncError`, and `SyncStopped` handlers; and from the
+//!   `ProgressSnapshot` handler when the snapshot has files for that
+//!   label (the real per-file widget takes over).
+//! - [`PreparingState::clear_all`] — called from `stop_sync` /
+//!   logout / reset paths.
+//!
+//! ## Concurrency
+//!
+//! All methods are synchronous and lock the inner [`Mutex`] only for
+//! the duration of the operation. The TauriSyncBridge handler that
+//! invokes them is also synchronous, so the lock is never held
+//! across an `.await` (compatible with the project's async-lock
+//! hygiene axiom).
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+/// Set of drive labels currently in the "preparing" window between
+/// `SyncStarted` and the first ProgressSnapshot that has files.
+///
+/// Owned by [`crate::app_state::AppState`] behind an `Arc`, mirroring
+/// the [`crate::sync::upload_processing::UploadProcessingState`]
+/// composition pattern.
+pub struct PreparingState {
+    /// Membership-only set: we only care whether a label is currently
+    /// preparing, not how long it has been. Order does not matter —
+    /// callers iterate at most once per event to clear after the
+    /// session is populated. `String` keys mirror the per-drive
+    /// label type used everywhere else in the sync module.
+    inner: Mutex<HashSet<String>>,
+}
+
+impl Default for PreparingState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PreparingState {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// Insert `label` into the preparing set.
+    ///
+    /// Returns `true` if the label was newly added; `false` if it was
+    /// already present. Callers gate an immediate `emit_snapshot` on
+    /// the `true` return so the widget appears within one tick of
+    /// `SyncStarted`, without re-emitting on every duplicate
+    /// `SyncStarted` from rapid file-watcher re-triggers within the
+    /// same preparing window.
+    pub fn mark_preparing(&self, label: &str) -> bool {
+        let mut g = self.inner.lock().expect("preparing mutex poisoned");
+        g.insert(label.to_string())
+    }
+
+    /// Remove `label` from the preparing set.
+    ///
+    /// Returns `true` if the label was present (caller can use this
+    /// to skip a redundant `emit_snapshot` when nothing changed).
+    pub fn clear(&self, label: &str) -> bool {
+        let mut g = self.inner.lock().expect("preparing mutex poisoned");
+        g.remove(label)
+    }
+
+    /// Remove every label from the preparing set.
+    ///
+    /// Returns `true` if the set was non-empty before the clear.
+    /// Called on `SyncReset` and from `stop_sync` (logout / drive
+    /// teardown), which must guarantee no preparing override leaks
+    /// across an account switch.
+    pub fn clear_all(&self) -> bool {
+        let mut g = self.inner.lock().expect("preparing mutex poisoned");
+        let had_entries = !g.is_empty();
+        g.clear();
+        had_entries
+    }
+
+    /// Returns `true` when at least one label is in the preparing
+    /// set. Read by the snapshot pipeline to decide whether to apply
+    /// the preparing override.
+    pub fn is_any_preparing(&self) -> bool {
+        !self.inner.lock().expect("preparing mutex poisoned").is_empty()
+    }
+
+    /// Sorted snapshot of the current set, for tests and diagnostics.
+    /// Not on the hot path — produces a fresh `Vec` per call.
+    #[doc(hidden)]
+    pub fn snapshot_labels(&self) -> Vec<String> {
+        let g = self.inner.lock().expect("preparing mutex poisoned");
+        let mut labels: Vec<String> = g.iter().cloned().collect();
+        labels.sort();
+        labels
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mark_preparing_returns_true_on_first_insert() {
+        let state = PreparingState::new();
+        assert!(state.mark_preparing("drive-a"));
+        assert_eq!(state.snapshot_labels(), vec!["drive-a".to_string()]);
+    }
+
+    #[test]
+    fn mark_preparing_returns_false_on_duplicate() {
+        let state = PreparingState::new();
+        state.mark_preparing("drive-a");
+        assert!(!state.mark_preparing("drive-a"));
+        assert_eq!(state.snapshot_labels(), vec!["drive-a".to_string()]);
+    }
+
+    #[test]
+    fn clear_returns_true_when_present() {
+        let state = PreparingState::new();
+        state.mark_preparing("drive-a");
+        assert!(state.clear("drive-a"));
+        assert!(state.snapshot_labels().is_empty());
+    }
+
+    #[test]
+    fn clear_returns_false_when_absent() {
+        let state = PreparingState::new();
+        assert!(!state.clear("nobody"));
+    }
+
+    #[test]
+    fn clear_all_removes_every_label() {
+        let state = PreparingState::new();
+        state.mark_preparing("drive-a");
+        state.mark_preparing("drive-b");
+        assert!(state.clear_all());
+        assert!(!state.is_any_preparing());
+    }
+
+    #[test]
+    fn clear_all_returns_false_on_empty() {
+        let state = PreparingState::new();
+        assert!(!state.clear_all());
+    }
+
+    #[test]
+    fn is_any_preparing_reflects_membership() {
+        let state = PreparingState::new();
+        assert!(!state.is_any_preparing());
+        state.mark_preparing("drive-a");
+        assert!(state.is_any_preparing());
+        state.clear("drive-a");
+        assert!(!state.is_any_preparing());
+    }
+
+    #[test]
+    fn snapshot_labels_returns_sorted_view() {
+        let state = PreparingState::new();
+        state.mark_preparing("drive-z");
+        state.mark_preparing("drive-a");
+        state.mark_preparing("drive-m");
+        assert_eq!(
+            state.snapshot_labels(),
+            vec!["drive-a".to_string(), "drive-m".to_string(), "drive-z".to_string()],
+        );
+    }
+}

--- a/src-tauri/src/sync/preparing.rs
+++ b/src-tauri/src/sync/preparing.rs
@@ -44,7 +44,7 @@
 //! hygiene axiom).
 
 use std::collections::HashSet;
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 /// Set of drive labels currently in the "preparing" window between
 /// `SyncStarted` and the first ProgressSnapshot that has files.
@@ -74,6 +74,18 @@ impl PreparingState {
         }
     }
 
+    /// Acquire the inner mutex with a single poison-message helper.
+    ///
+    /// Centralises the `expect` panic message so a future addition to
+    /// the API can't introduce a new wording variant. The returned
+    /// guard's lifetime is tied to `&self`; each public method should
+    /// hold it for the smallest possible scope (no `.await` in this
+    /// module, but the project axiom forbidding sync-mutex-across-await
+    /// applies if a future caller adds async code here).
+    fn lock(&self) -> MutexGuard<'_, HashSet<String>> {
+        self.inner.lock().expect("preparing mutex poisoned")
+    }
+
     /// Insert `label` into the preparing set.
     ///
     /// Returns `true` if the label was newly added; `false` if it was
@@ -82,9 +94,20 @@ impl PreparingState {
     /// `SyncStarted`, without re-emitting on every duplicate
     /// `SyncStarted` from rapid file-watcher re-triggers within the
     /// same preparing window.
+    ///
+    /// The `MutexGuard` is dropped at the function boundary (the
+    /// return value is `bool`, not the guard). This non-extending-the-
+    /// guard contract is load-bearing for the
+    /// [`crate::sync::tauri_bridge::TauriSyncBridge::on_event`]
+    /// `SyncStarted` arm: that arm calls this method and then invokes
+    /// `emit_snapshot`, which synchronously re-enters `on_event` with
+    /// `ProgressSnapshot` — and that re-entry reacquires this same
+    /// mutex via `clear` / `is_any_preparing`. Since `std::sync::Mutex`
+    /// is non-reentrant, holding the guard across `emit_snapshot`
+    /// would deadlock. The `mark_then_read_does_not_deadlock_in_sequence`
+    /// test below pins this invariant.
     pub fn mark_preparing(&self, label: &str) -> bool {
-        let mut g = self.inner.lock().expect("preparing mutex poisoned");
-        g.insert(label.to_string())
+        self.lock().insert(label.to_string())
     }
 
     /// Remove `label` from the preparing set.
@@ -92,8 +115,7 @@ impl PreparingState {
     /// Returns `true` if the label was present (caller can use this
     /// to skip a redundant `emit_snapshot` when nothing changed).
     pub fn clear(&self, label: &str) -> bool {
-        let mut g = self.inner.lock().expect("preparing mutex poisoned");
-        g.remove(label)
+        self.lock().remove(label)
     }
 
     /// Remove every label from the preparing set.
@@ -103,7 +125,7 @@ impl PreparingState {
     /// teardown), which must guarantee no preparing override leaks
     /// across an account switch.
     pub fn clear_all(&self) -> bool {
-        let mut g = self.inner.lock().expect("preparing mutex poisoned");
+        let mut g = self.lock();
         let had_entries = !g.is_empty();
         g.clear();
         had_entries
@@ -113,15 +135,14 @@ impl PreparingState {
     /// set. Read by the snapshot pipeline to decide whether to apply
     /// the preparing override.
     pub fn is_any_preparing(&self) -> bool {
-        !self.inner.lock().expect("preparing mutex poisoned").is_empty()
+        !self.lock().is_empty()
     }
 
     /// Sorted snapshot of the current set, for tests and diagnostics.
     /// Not on the hot path — produces a fresh `Vec` per call.
     #[doc(hidden)]
     pub fn snapshot_labels(&self) -> Vec<String> {
-        let g = self.inner.lock().expect("preparing mutex poisoned");
-        let mut labels: Vec<String> = g.iter().cloned().collect();
+        let mut labels: Vec<String> = self.lock().iter().cloned().collect();
         labels.sort();
         labels
     }
@@ -195,5 +216,35 @@ mod tests {
             state.snapshot_labels(),
             vec!["drive-a".to_string(), "drive-m".to_string(), "drive-z".to_string()],
         );
+    }
+
+    /// Re-entrancy guardrail. `PreparingState::mark_preparing` MUST
+    /// release the inner mutex before returning so the
+    /// `TauriSyncBridge::on_event` `SyncStarted` arm can call it and
+    /// then invoke `emit_snapshot`, which synchronously re-enters
+    /// `on_event` and reacquires the same mutex via `clear` /
+    /// `is_any_preparing`. `std::sync::Mutex` is non-reentrant, so a
+    /// refactor that extended the guard's lifetime (e.g. returning
+    /// the guard alongside the bool, or inlining the lock acquisition
+    /// into the bridge handler) would deadlock at runtime — but every
+    /// existing unit test calls the operations on separate lines, so
+    /// it wouldn't trip them.
+    ///
+    /// This test calls `mark_preparing` and the read operations in a
+    /// tight sequence on the same thread. A regression that broke the
+    /// lock release would surface as the second call blocking
+    /// indefinitely; the test harness's per-test timeout would catch
+    /// it.
+    #[test]
+    fn mark_then_read_does_not_deadlock_in_sequence() {
+        let state = PreparingState::new();
+        assert!(state.mark_preparing("drive-a"));
+        // Each of the following reacquires the inner mutex. If
+        // `mark_preparing` had returned with the guard still live,
+        // every line below would deadlock on the same thread.
+        assert!(state.is_any_preparing());
+        assert_eq!(state.snapshot_labels(), vec!["drive-a".to_string()]);
+        assert!(state.clear("drive-a"));
+        assert!(!state.is_any_preparing());
     }
 }

--- a/src-tauri/src/sync/progress.rs
+++ b/src-tauri/src/sync/progress.rs
@@ -257,6 +257,64 @@ pub fn mark_file_synced(sync: &SyncRunner, path: &str) -> Result<()> {
     Ok(())
 }
 
+/// Mark a single file as failed (per-file upload or download error) and
+/// emit a snapshot.
+///
+/// Called from `build_file_failed_callback` in `lifecycle.rs`, which fires
+/// from hcfs-client's per-file `on_file_failed` callback the moment the
+/// per-file task returns `Err`. This is the synchronous counterpart to
+/// [`mark_file_synced`] for the failure path: the file's progress row
+/// flips to terminal `FileStatus::Error` immediately instead of waiting
+/// for end-of-cycle `mark_pending_files_as_failed`.
+///
+/// Why this exists: cycle-level `mark_pending_files_as_failed` only sees
+/// the shortfall (`expected_uploads - actual_uploads`), so a partial
+/// failure scenario (some files 402, some succeed inside the same cycle)
+/// arrives at the FE only after the whole cycle finalises — the failure
+/// banner UX needs the signal at the failure site, not 30 seconds later.
+///
+/// Field semantics mirror hcfs-client's [`hcfs_client::engine::progress::tracker::ProgressTracker::mark_file_error`]:
+///
+/// - `file.status = FileStatus::Error` — terminal for this cycle.
+/// - `file.error = Some(error.into())` — display text for the FE row tooltip.
+/// - `file.bytes_transferred = 0`, `file.progress = 0` — reset so the
+///   progress bar doesn't show "99% then Error" (the upstream tracker
+///   resets too, see `engine/progress/tracker.rs:491-492`).
+/// - `file.completed_at = Some(now)` — terminal timestamp, sorts the row
+///   to the recent-activity tail.
+///
+/// No-op if there's no current session, no file at the given path
+/// (rename races), or the file is already in `Error` state (re-entry from
+/// a retry that also failed — keep the first error message).
+pub fn mark_file_failed(sync: &SyncRunner, path: &str, error: &str) -> Result<()> {
+    use hcfs_client::engine::progress::state::FileStatus;
+    use std::sync::Arc;
+
+    {
+        let mut state = sync.progress.lock_state();
+        let Some(session) = state.current_session.as_mut() else {
+            return Ok(());
+        };
+        let Some(file) = session.files.get_mut(path) else {
+            return Ok(());
+        };
+        if file.status == FileStatus::Error {
+            // Already terminal — preserve the first error to avoid the
+            // hcfs-client retry loop clobbering the 402 message with a
+            // subsequent generic network error.
+            return Ok(());
+        }
+        let now = chrono::Utc::now().timestamp_millis();
+        file.status = FileStatus::Error;
+        file.error = Some(Arc::from(error));
+        file.completed_at = Some(now);
+        file.bytes_transferred = 0;
+        file.progress = 0;
+    }
+    sync.emit_snapshot(true);
+    Ok(())
+}
+
 /// Compute overall progress.
 pub fn get_overall_progress(sync: &SyncRunner) -> Result<OverallProgress> {
     sync.progress.get_overall_progress().map_err(AppError::Progress)

--- a/src-tauri/src/sync/progress.rs
+++ b/src-tauri/src/sync/progress.rs
@@ -203,6 +203,13 @@ pub fn mark_file_error(sync: &SyncRunner, path: String, error: String) -> Result
 /// Mark a single file as fully synced (download/upload + AEAD verification
 /// complete) and emit a snapshot.
 ///
+/// Returns the file's `total_bytes` (the size the progress tracker
+/// observed during this cycle). Callers thread this value into per-file
+/// telemetry rows so the Recent-Files view and the dedup-key entropy
+/// don't lose the byte count just because `FileSyncedFn`'s upstream
+/// signature doesn't carry it. See [`crate::sync::lifecycle::build_file_synced_callback`]
+/// for the consumer.
+///
 /// Called from `build_file_synced_callback` in `lifecycle.rs`, which fires
 /// from hcfs-client's per-file `on_file_synced` callback. That callback is
 /// invoked from `drive/sync_flow.rs` only after the upload OR download task
@@ -221,8 +228,13 @@ pub fn mark_file_error(sync: &SyncRunner, path: String, error: String) -> Result
 /// individual file as soon as its own AEAD verification has succeeded,
 /// independent of other in-flight files.
 ///
-/// No-op if there's no current session, no file at the given path, or the
-/// file is already Completed.
+/// Returns `Ok(0)` if there's no current session, no file at the given
+/// path, or the file is already Completed. Zero is the truthful sentinel
+/// for "this call observed no size": the size is undefined in the
+/// no-session/no-file cases, and the already-Completed branch means a
+/// previous call (or `complete_pending_files`) already reported it. The
+/// caller treats zero as "unknown" and won't fabricate a row with a fake
+/// byte count.
 ///
 /// As of hcfs-client `33048ff5bc9228939b521c8a147533dcb221dfb5` (PR #110),
 /// `path_for_progress` in `drive/download.rs` always uses the full
@@ -230,21 +242,40 @@ pub fn mark_file_error(sync: &SyncRunner, path: String, error: String) -> Result
 /// callback matches the key passed to `on_file_synced`. A simple
 /// `session.files.get_mut(path)` lookup is sufficient — no basename
 /// fallback needed.
-pub fn mark_file_synced(sync: &SyncRunner, path: &str) -> Result<()> {
+///
+/// # Errors
+///
+/// Currently infallible — every branch returns `Ok(...)`. The `Result`
+/// wrapper is retained because any future addition of fallible work
+/// (e.g. a checked timestamp arithmetic the snapshot relies on) belongs
+/// inside this helper, and a non-`Result` signature would force every
+/// caller to absorb the breakage at the call site.
+pub fn mark_file_synced(sync: &SyncRunner, path: &str) -> Result<u64> {
     use hcfs_client::engine::progress::state::FileStatus;
 
-    {
+    // `total_bytes` is captured INSIDE the locked-state block (where the
+    // session/file references are valid) and returned AFTER the guard
+    // drops. `u64: Copy`, so the value moves out of the borrow region
+    // cleanly — no lifetime extension, no extra clone.
+    let observed_bytes = {
         let mut state = sync.progress.lock_state();
         let Some(session) = state.current_session.as_mut() else {
-            return Ok(());
+            return Ok(0);
         };
         let Some(file) = session.files.get_mut(path) else {
-            return Ok(());
+            return Ok(0);
         };
         if file.status == FileStatus::Completed {
-            return Ok(());
+            // Already terminal — a previous call (or end-of-cycle
+            // `complete_pending_files`) already accounted for this file.
+            // Returning 0 here means the caller's activity row gets the
+            // "unknown" sentinel; the alternative (returning
+            // `file.total_bytes` again) would risk double-counting if a
+            // future caller multiplies the value across re-entries.
+            return Ok(0);
         }
         let now = chrono::Utc::now().timestamp_millis();
+        let bytes = file.total_bytes;
         file.status = FileStatus::Completed;
         file.progress = 100;
         file.completed_at = Some(now);
@@ -252,9 +283,10 @@ pub fn mark_file_synced(sync: &SyncRunner, path: &str) -> Result<()> {
             file.bytes_transferred = file.total_bytes;
             file.bytes_encrypted = file.total_bytes;
         }
-    }
+        bytes
+    };
     sync.emit_snapshot(true);
-    Ok(())
+    Ok(observed_bytes)
 }
 
 /// Mark a single file as failed (per-file upload or download error) and
@@ -992,5 +1024,82 @@ mod tests {
         assert_eq!(result[1].action, FileAction::LocalDelete);
         assert_eq!(result[2].action, FileAction::Download);
         assert_eq!(result[3].action, FileAction::Upload);
+    }
+
+    // ── mark_file_synced return-value contract ──────────────────────
+    //
+    // These tests pin `mark_file_synced`'s `Result<u64>` shape so a
+    // future refactor cannot quietly drop the size signal — that signal
+    // is what `build_file_synced_callback` threads into
+    // `SyncActivityItem.size_bytes` so the Recent-Files view shows a
+    // real byte count instead of "unknown". The four cases mirror the
+    // four documented branches in the helper's contract.
+
+    #[test]
+    fn mark_file_synced_returns_total_bytes_on_success() {
+        // Common path: an `Uploading` entry transitions to `Completed`
+        // and the caller gets back the size the progress tracker
+        // observed during the cycle. This is the byte count the
+        // activity row needs to be non-zero.
+        let sync = test_runner();
+        seed_session(
+            &sync,
+            vec![make_file("a.bin", "default", FileStatus::Uploading, None, 8_192, FileAction::Upload)],
+        );
+
+        let observed = mark_file_synced(&sync, "a.bin").expect("infallible");
+        assert_eq!(observed, 8_192);
+
+        // Side-effect check: the row really did transition to Completed.
+        let state = sync.progress.lock_state();
+        let session = state.current_session.as_ref().expect("session was seeded");
+        let file = session.files.get("a.bin").expect("file present");
+        assert_eq!(file.status, FileStatus::Completed);
+        assert_eq!(file.progress, 100);
+    }
+
+    #[test]
+    fn mark_file_synced_returns_zero_when_no_session() {
+        // Edge case 1: no session at all. The activity-row caller
+        // treats this as "size unknown" and emits 0.
+        let sync = test_runner();
+        // Deliberately skip `seed_session` so `current_session` is None.
+
+        let observed = mark_file_synced(&sync, "missing.bin").expect("infallible");
+        assert_eq!(observed, 0);
+    }
+
+    #[test]
+    fn mark_file_synced_returns_zero_when_file_not_in_session() {
+        // Edge case 2: session exists, but the requested path isn't in
+        // it (rename race, or hcfs-client fired for a path we never
+        // tracked). Same 0 fallback.
+        let sync = test_runner();
+        seed_session(
+            &sync,
+            vec![make_file("present.bin", "default", FileStatus::Uploading, None, 99, FileAction::Upload)],
+        );
+
+        let observed = mark_file_synced(&sync, "absent.bin").expect("infallible");
+        assert_eq!(observed, 0);
+    }
+
+    #[test]
+    fn mark_file_synced_returns_zero_when_already_completed() {
+        // Edge case 3: the file was already marked Completed by a
+        // previous call (or by end-of-cycle `complete_pending_files`).
+        // Returning the size again would risk double-counting in any
+        // caller that aggregated `size_bytes` across re-entries; the
+        // contract is "this call observed nothing new" → 0.
+        let sync = test_runner();
+        seed_session(
+            &sync,
+            // `make_file` with `completed_at = Some(...)` sets the
+            // status to whatever we pass — explicitly Completed here.
+            vec![make_file("done.bin", "default", FileStatus::Completed, Some(1), 256, FileAction::Upload)],
+        );
+
+        let observed = mark_file_synced(&sync, "done.bin").expect("infallible");
+        assert_eq!(observed, 0);
     }
 }

--- a/src-tauri/src/sync/progress.rs
+++ b/src-tauri/src/sync/progress.rs
@@ -347,7 +347,7 @@ pub fn collect_cycle_files_for_label(sync: &SyncRunner, label: &str, max_files: 
 }
 
 /// Get a full snapshot with retry state injected.
-pub fn get_snapshot(sync: &SyncRunner) -> Result<SyncSnapshot> {
+pub fn get_snapshot(sync: &SyncRunner, preparing: &crate::sync::preparing::PreparingState) -> Result<SyncSnapshot> {
     let mut snapshot = sync.progress.build_snapshot();
     let retry_at = sync.retry_at.load(std::sync::atomic::Ordering::Relaxed);
     if retry_at > 0 {
@@ -358,7 +358,7 @@ pub fn get_snapshot(sync: &SyncRunner) -> Result<SyncSnapshot> {
         snapshot.retry_in_secs = (retry_at - now).max(0) as u64;
     }
     snapshot.last_error = sync.last_error.lock().ok().and_then(|g| g.clone());
-    prepare_snapshot_for_emit(&mut snapshot);
+    prepare_snapshot_for_emit(&mut snapshot, preparing);
     Ok(snapshot)
 }
 
@@ -368,9 +368,48 @@ pub fn get_snapshot(sync: &SyncRunner) -> Result<SyncSnapshot> {
 /// (every live update). Keeping a single funnel guarantees the two paths
 /// can't drift — a stalled-completion snapshot seen at mount must look
 /// identical to one observed mid-session.
-pub(crate) fn prepare_snapshot_for_emit(snapshot: &mut SyncSnapshot) {
+///
+/// Order of operations matters. `fixup_stalled_completion` may flip
+/// the snapshot into a visible "completed" state; we run it first so
+/// the preparing override does not paper over a real completion.
+/// `apply_preparing_override` runs second and only takes effect when
+/// the snapshot is still invisible (no real session yet). `cap_snapshot_files`
+/// runs last to truncate the file list — order-independent relative
+/// to the previous two.
+pub(crate) fn prepare_snapshot_for_emit(snapshot: &mut SyncSnapshot, preparing: &crate::sync::preparing::PreparingState) {
     fixup_stalled_completion(snapshot);
+    apply_preparing_override(snapshot, preparing);
     cap_snapshot_files(snapshot);
+}
+
+/// Surface a "preparing" widget state when any drive is between
+/// `SyncStarted` and its first session-populated snapshot.
+///
+/// Only takes effect when the snapshot is otherwise invisible — never
+/// demotes an already-visible widget. Sets `widget_state` to
+/// `"preparing"` — a fourth variant added on top of the
+/// `"active" | "completed" | "idle"` set that hcfs-client's
+/// `build_snapshot` produces (see `hcfs-client/src/engine/progress/snapshot.rs`).
+/// The frontend widget and tray treat the new value as the
+/// preparing-state branch in their badge/title/icon switches without
+/// having to inspect the preparing set directly.
+///
+/// We deliberately leave `effective_in_progress` / `total_files` /
+/// `overall_percent` at their original (zero/false) values: the
+/// dialog's badge logic already has a "Preparing sync…" fallback
+/// branch for the (not-error, not-completed, not-in-progress) case
+/// (see `app/(pages)/SyncStatusDialog.tsx`), and flipping
+/// `effective_in_progress=true` here would force it into the
+/// `"0 of 0 files synced"` branch instead.
+fn apply_preparing_override(snapshot: &mut SyncSnapshot, preparing: &crate::sync::preparing::PreparingState) {
+    if snapshot.widget_visible {
+        return;
+    }
+    if !preparing.is_any_preparing() {
+        return;
+    }
+    snapshot.widget_visible = true;
+    snapshot.widget_state = "preparing".to_string();
 }
 
 /// Detect and correct a stalled completion state.
@@ -433,7 +472,7 @@ pub fn sp_clear_all_data(state: tauri::State<'_, crate::app_state::AppState>) ->
 
 #[tauri::command]
 pub fn sp_get_snapshot(state: tauri::State<'_, crate::app_state::AppState>) -> Result<SyncSnapshot> {
-    get_snapshot(&state.sync)
+    get_snapshot(&state.sync, &state.preparing)
 }
 
 /// Dismiss the sync status widget for the current session.
@@ -572,7 +611,8 @@ mod tests {
         snap.widget_state = "active".to_string();
         snap.status_variant = "progress".to_string();
 
-        prepare_snapshot_for_emit(&mut snap);
+        let preparing = crate::sync::preparing::PreparingState::new();
+        prepare_snapshot_for_emit(&mut snap, &preparing);
 
         assert!(!snap.effective_in_progress, "stall should flip effective_in_progress to false");
         assert!(snap.effective_completed, "stall should flip effective_completed to true");
@@ -604,9 +644,73 @@ mod tests {
             })
             .collect();
 
-        prepare_snapshot_for_emit(&mut snap);
+        let preparing = crate::sync::preparing::PreparingState::new();
+        prepare_snapshot_for_emit(&mut snap, &preparing);
 
         assert_eq!(snap.files.len(), MAX_EVENT_FILES);
+    }
+
+    /// When a drive is marked preparing AND the snapshot would otherwise
+    /// be invisible (no active session yet), the override sets
+    /// `widget_visible=true` and `widget_state="preparing"` so the
+    /// bottom-right widget and tray show feedback during the
+    /// SyncStarted → first-snapshot gap.
+    #[test]
+    fn preparing_override_makes_invisible_snapshot_visible() {
+        let mut snap = base_snapshot();
+        // Empty snapshot, widget would otherwise be hidden.
+        assert!(!snap.widget_visible);
+
+        let preparing = crate::sync::preparing::PreparingState::new();
+        preparing.mark_preparing("drive-a");
+
+        prepare_snapshot_for_emit(&mut snap, &preparing);
+
+        assert!(snap.widget_visible, "preparing should force widget_visible=true");
+        assert_eq!(snap.widget_state, "preparing");
+        // `effective_in_progress` deliberately stays false so the
+        // dialog's "Preparing sync…" fallback branch renders instead
+        // of "0 of 0 files synced". See `apply_preparing_override`'s
+        // doc comment for the rationale.
+        assert!(!snap.effective_in_progress);
+        assert_eq!(snap.total_files, 0);
+    }
+
+    /// Override is a no-op when no drive is preparing. Snapshots whose
+    /// session is genuinely empty (e.g. between sync cycles, with no
+    /// pending work) must stay hidden.
+    #[test]
+    fn preparing_override_is_noop_when_set_empty() {
+        let mut snap = base_snapshot();
+        let preparing = crate::sync::preparing::PreparingState::new();
+
+        prepare_snapshot_for_emit(&mut snap, &preparing);
+
+        assert!(!snap.widget_visible);
+        assert_eq!(snap.widget_state, "idle");
+    }
+
+    /// The override must never demote an already-visible widget. An
+    /// active sync mid-cycle has `widget_visible=true` from
+    /// `build_snapshot`; the preparing helper should leave it alone
+    /// (otherwise it would clobber the real `widget_state="active"`
+    /// label with `"preparing"` in the gap between a SyncStarted for
+    /// drive B and B's plan_ready, while drive A is still uploading).
+    #[test]
+    fn preparing_override_does_not_demote_visible_snapshot() {
+        let mut snap = base_snapshot();
+        snap.widget_visible = true;
+        snap.widget_state = "active".to_string();
+        snap.is_active = true;
+        snap.total_files = 5;
+
+        let preparing = crate::sync::preparing::PreparingState::new();
+        preparing.mark_preparing("drive-b");
+
+        prepare_snapshot_for_emit(&mut snap, &preparing);
+
+        assert!(snap.widget_visible);
+        assert_eq!(snap.widget_state, "active");
     }
 
     #[test]

--- a/src-tauri/src/sync/progress.rs
+++ b/src-tauri/src/sync/progress.rs
@@ -228,13 +228,16 @@ pub fn mark_file_error(sync: &SyncRunner, path: String, error: String) -> Result
 /// individual file as soon as its own AEAD verification has succeeded,
 /// independent of other in-flight files.
 ///
-/// Returns `Ok(0)` if there's no current session, no file at the given
-/// path, or the file is already Completed. Zero is the truthful sentinel
-/// for "this call observed no size": the size is undefined in the
-/// no-session/no-file cases, and the already-Completed branch means a
-/// previous call (or `complete_pending_files`) already reported it. The
-/// caller treats zero as "unknown" and won't fabricate a row with a fake
-/// byte count.
+/// Returns `Ok(0)` only when there's no current session or no file
+/// at the given path — i.e. the call observed no entry to read a
+/// size from. For the already-Completed branch we return
+/// `file.total_bytes` (the value the per-chunk callback recorded
+/// during this cycle) rather than 0, because in practice every
+/// successful upload reaches this branch (hcfs-client's
+/// `update_file_progress` flips `Completed` on the final chunk
+/// BEFORE `on_file_synced` fires). Returning 0 there caused every
+/// Recent-Files row to render its size as "Unknown" — see the
+/// regression test `mark_file_synced_returns_total_bytes_when_already_completed`.
 ///
 /// As of hcfs-client `33048ff5bc9228939b521c8a147533dcb221dfb5` (PR #110),
 /// `path_for_progress` in `drive/download.rs` always uses the full
@@ -266,13 +269,39 @@ pub fn mark_file_synced(sync: &SyncRunner, path: &str) -> Result<u64> {
             return Ok(0);
         };
         if file.status == FileStatus::Completed {
-            // Already terminal — a previous call (or end-of-cycle
-            // `complete_pending_files`) already accounted for this file.
-            // Returning 0 here means the caller's activity row gets the
-            // "unknown" sentinel; the alternative (returning
-            // `file.total_bytes` again) would risk double-counting if a
-            // future caller multiplies the value across re-entries.
-            return Ok(0);
+            // Already terminal. There are two ways this happens in
+            // practice:
+            //
+            //   1. End-of-cycle `complete_pending_files` ran before
+            //      our `on_file_synced` callback. Uncommon — files
+            //      almost always resolve via the per-file path first.
+            //
+            //   2. The byte-progress callback flipped `Completed` on
+            //      the FINAL upload chunk (hcfs-client
+            //      `progress/tracker.rs:325` flips status when
+            //      `bytes_transferred >= total_bytes`). This happens
+            //      for EVERY successful upload because the chunk
+            //      callback fires before `on_file_synced`.
+            //
+            // Returning 0 was the original defensive choice — the
+            // comment warned about a hypothetical caller that
+            // aggregated `size_bytes` across re-entries. No such
+            // caller exists: `build_file_synced_callback` reads the
+            // value once per activity row. The cost of the
+            // defensive 0 was real and user-visible: every Recent
+            // Files row for a successful upload rendered the size
+            // column as "Unknown" because the activity item
+            // serialized `size_bytes = 0`.
+            //
+            // Returning `file.total_bytes` here is the truthful
+            // value — the size was already observed via the
+            // per-chunk callback and stored on the entry, and the
+            // file is in a terminal state so the value won't be
+            // mutated again. The dedup-key entropy in
+            // `ActivityDedupKey = (file_name, action, label,
+            // size_bytes)` also benefits: distinct uploads of
+            // distinct files no longer collide on a shared 0.
+            return Ok(file.total_bytes);
         }
         let now = chrono::Utc::now().timestamp_millis();
         let bytes = file.total_bytes;
@@ -1085,21 +1114,30 @@ mod tests {
     }
 
     #[test]
-    fn mark_file_synced_returns_zero_when_already_completed() {
-        // Edge case 3: the file was already marked Completed by a
-        // previous call (or by end-of-cycle `complete_pending_files`).
-        // Returning the size again would risk double-counting in any
-        // caller that aggregated `size_bytes` across re-entries; the
-        // contract is "this call observed nothing new" → 0.
+    fn mark_file_synced_returns_total_bytes_when_already_completed() {
+        // Regression test for the Recent Files "Unknown" size bug.
+        //
+        // hcfs-client's `update_file_progress` flips `FileStatus` to
+        // `Completed` on the final upload chunk (tracker.rs:325)
+        // BEFORE `on_file_synced` fires for the file. The earlier
+        // implementation returned 0 from this branch as a defensive
+        // sentinel, but no caller actually aggregates across
+        // re-entries — `build_file_synced_callback` reads the value
+        // once per activity row. The 0 propagated into
+        // `SyncActivityItem.size_bytes`, then `RecentFile.size`,
+        // then rendered as "Unknown" in the Recent Files column for
+        // every successful upload.
+        //
+        // The contract is now: return `file.total_bytes` regardless
+        // of terminal status. The value was set by the per-chunk
+        // callback and is not mutated again once Completed.
         let sync = test_runner();
         seed_session(
             &sync,
-            // `make_file` with `completed_at = Some(...)` sets the
-            // status to whatever we pass — explicitly Completed here.
             vec![make_file("done.bin", "default", FileStatus::Completed, Some(1), 256, FileAction::Upload)],
         );
 
         let observed = mark_file_synced(&sync, "done.bin").expect("infallible");
-        assert_eq!(observed, 0);
+        assert_eq!(observed, 256, "must return total_bytes even when already Completed");
     }
 }

--- a/src-tauri/src/sync/tauri_bridge.rs
+++ b/src-tauri/src/sync/tauri_bridge.rs
@@ -238,7 +238,22 @@ impl SyncEventHandler for TauriSyncBridge {
                 files_deleted_remotely,
                 conflicts_resolved,
                 conflicts_skipped,
+                files_failed,
             } => {
+                // Cycle-level failure counter is observable here only for
+                // logging — the per-file detail already flowed through
+                // `SyncEvent::FileFailed` (one event per failing file) and
+                // the snapshot's `failed_files` aggregate. Surfacing it
+                // again as a Tauri event would duplicate signals the FE
+                // already consumes; a warn-level log preserves the
+                // operability signal for backend operators.
+                if files_failed > 0 {
+                    tracing::warn!(
+                        label = %label,
+                        files_failed = files_failed,
+                        "sync cycle completed with per-file failures"
+                    );
+                }
                 use tauri::Manager;
 
                 // Belt-and-suspenders snapshot emit. As of hcfs >= a26f4296,
@@ -419,6 +434,50 @@ impl SyncEventHandler for TauriSyncBridge {
             }
             SyncEvent::FileTransferComplete { label } => {
                 let _ = app.emit(events::FILE_TRANSFER_COMPLETE, events::LabelPayload { label });
+            }
+            SyncEvent::FileFailed {
+                label,
+                path,
+                file_id,
+                kind,
+                http_status,
+            } => {
+                // Per-file failure handling has two responsibilities:
+                //   (1) Surface the typed failure to the FE via a dedicated
+                //       Tauri event so the FE can drive category-specific UX
+                //       (e.g. "out of credits" banner for InsufficientBalance).
+                //       The translation to `FileFailureKindPayload` is needed
+                //       because the upstream `FileFailureKind` is NOT
+                //       `Serialize`-able (verified at
+                //       `hcfs-client/src/engine/events.rs:33`).
+                //   (2) Emit a Tauri event AND do nothing else here. The
+                //       in-memory progress mutation (file row → Error) was
+                //       already performed by `build_file_failed_callback`
+                //       (lifecycle.rs) which fired synchronously from the
+                //       same hcfs-client error site BEFORE this event arrived
+                //       at the bridge. Splitting the responsibilities — Tauri
+                //       emit here, progress mutation in the lifecycle callback
+                //       — matches the symmetric `on_file_synced` design and
+                //       keeps the bridge a pure forwarder.
+                //
+                // Deliberately NOT performed:
+                //   - `hcfs_sync_error` emit: per-file failure ≠ cycle
+                //     failure; the cycle-level channel is reserved for
+                //     auth/cancel/transport-level errors.
+                //   - Activity-item enqueue: Phase 1 Task 1.1 established
+                //     that activity rows only land on server-confirmed
+                //     success. Failures are visible via the snapshot's
+                //     Error status and the FILES_FAILED_REPEATEDLY event.
+                let _ = app.emit(
+                    events::FILE_FAILED,
+                    events::FileFailedPayload {
+                        label,
+                        path,
+                        file_id,
+                        kind: events::FileFailureKindPayload::from(&kind),
+                        http_status,
+                    },
+                );
             }
             SyncEvent::HealthChanged { health } => {
                 let _ = app.emit(events::CONNECTIVITY_CHANGED, &health);

--- a/src-tauri/src/sync/tauri_bridge.rs
+++ b/src-tauri/src/sync/tauri_bridge.rs
@@ -174,10 +174,42 @@ impl SyncEventHandler for TauriSyncBridge {
                 // UploadProcessingState clear gate knows a new cycle
                 // has started. See `crate::sync::upload_processing`
                 // for the full rationale.
+                //
+                // Then decide whether this is a file-watcher-triggered
+                // cycle that needs the "preparing" widget override —
+                // skip when the upload-processing banner is already
+                // raised (IPC-initiated uploads cover the gap with
+                // the banner instead, and showing both would be
+                // double-signalling).
                 {
                     use tauri::Manager;
                     let app_state = app.state::<crate::app_state::AppState>();
                     app_state.sync_session_epoch.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+                    let (banner_active, _) = app_state.upload_processing.snapshot();
+                    if !banner_active && app_state.preparing.mark_preparing(&label) {
+                        // Newly inserted — push a snapshot so the
+                        // widget reflects preparing within one tick
+                        // of `SyncStarted`. Subsequent SyncStarted
+                        // for the same label inside the same window
+                        // (rapid file-watcher re-triggers) return
+                        // false from `mark_preparing` and skip this
+                        // re-emit.
+                        //
+                        // `emit_snapshot` synchronously re-enters this
+                        // same `on_event` with `ProgressSnapshot`;
+                        // that path will reacquire the preparing
+                        // mutex. Safe because `PreparingState::mark_preparing`
+                        // drops its `MutexGuard` at its function
+                        // boundary (the return value is a `bool`, not
+                        // a guard), so the lock is released before
+                        // we get here. A future refactor that inlines
+                        // `mark_preparing` and accidentally extends
+                        // the guard's scope would deadlock on the
+                        // non-reentrant `std::sync::Mutex` — keep
+                        // the boundary.
+                        app_state.sync.emit_snapshot(true);
+                    }
                 }
                 cap_file_list(&mut upload_files);
                 cap_file_list(&mut download_files);
@@ -219,6 +251,11 @@ impl SyncEventHandler for TauriSyncBridge {
                 // miss the conflict-pending transition. Idempotent if the
                 // upstream emit already fired this cycle.
                 let app_state = app.state::<crate::app_state::AppState>();
+                // Clear the preparing override for this label BEFORE
+                // the snapshot emit so a cycle that completes with an
+                // empty plan (no merge_into_session) doesn't leak a
+                // stuck "Preparing sync…" widget after the cycle ends.
+                app_state.preparing.clear(&label);
                 app_state.sync.emit_snapshot(true);
 
                 // Defensive clear: if the cycle finished without ever
@@ -277,6 +314,17 @@ impl SyncEventHandler for TauriSyncBridge {
                 // at the bridge so the `hcfs_sync_error` channel only
                 // carries real failures (network, auth, rate limit, etc.).
                 if error == events::CANCELLED_MARKER {
+                    // Cancels still need to clear the preparing widget
+                    // for this label — otherwise a paused/removed drive
+                    // would leak a stuck "Preparing sync…" badge until
+                    // the next sync cycle (which may never come for a
+                    // paused drive). Banner clear is intentionally
+                    // skipped for cancels (handled by `stop_sync`).
+                    use tauri::Manager;
+                    let app_state = app.state::<crate::app_state::AppState>();
+                    if app_state.preparing.clear(&label) {
+                        app_state.sync.emit_snapshot(true);
+                    }
                     tracing::debug!(label = %label, "Silenced sync cancel (not emitted as error)");
                     return;
                 }
@@ -287,11 +335,16 @@ impl SyncEventHandler for TauriSyncBridge {
                 // `stop_sync`'s reset path. Epoch-gated so an error
                 // emitted by an in-flight cycle that started BEFORE
                 // a fresh `begin` cannot clear that begin's banner.
+                //
+                // Preparing override also cleared here: an error
+                // before plan_ready leaves nothing in the session, so
+                // the override would stay raised otherwise.
                 {
                     use tauri::Manager;
                     let app_state = app.state::<crate::app_state::AppState>();
                     let epoch = app_state.sync_session_epoch.load(std::sync::atomic::Ordering::SeqCst);
                     app_state.upload_processing.clear_if_session_advanced(&app, epoch);
+                    app_state.preparing.clear(&label);
                 }
                 let _ = app.emit(
                     events::SYNC_ERROR,
@@ -304,9 +357,19 @@ impl SyncEventHandler for TauriSyncBridge {
                 );
             }
             SyncEvent::SyncStopped { label } => {
+                use tauri::Manager;
+                let app_state = app.state::<crate::app_state::AppState>();
+                if app_state.preparing.clear(&label) {
+                    app_state.sync.emit_snapshot(true);
+                }
                 let _ = app.emit(events::SYNC_STOPPED, events::LabelPayload { label });
             }
             SyncEvent::SyncReset { account_id, message } => {
+                use tauri::Manager;
+                let app_state = app.state::<crate::app_state::AppState>();
+                if app_state.preparing.clear_all() {
+                    app_state.sync.emit_snapshot(true);
+                }
                 let _ = app.emit(events::SYNC_RESET, events::SyncResetPayload { account_id, message });
             }
             SyncEvent::PlanReady {
@@ -373,17 +436,45 @@ impl SyncEventHandler for TauriSyncBridge {
                 let _ = app.emit(events::AUTH_RELOGIN_REQUIRED, events::AuthRequiredPayload { error });
             }
             SyncEvent::ProgressSnapshot { mut snapshot } => {
-                // `prepare_snapshot_for_emit` applies BOTH the stalled-completion
-                // fixup and the file-cap. Without the fixup, hcfs-client's own
-                // file-watcher-driven `changes_pending=true` leaves `is_active`
-                // stuck at `true` indefinitely after all files are synced, so
+                use tauri::Manager;
+                let app_state = app.state::<crate::app_state::AppState>();
+
+                // Once a label has real files in the session, its
+                // "preparing" override has served its purpose — the
+                // regular per-file widget takes over. Clearing here
+                // (before the fingerprint check below) keeps the
+                // preparing set tight and prevents a stuck override
+                // surviving past the first plan_ready of a cycle.
+                //
+                // Gated on `is_any_preparing` so the common case (no
+                // drive in preparing — every snapshot after the first
+                // few seconds of a sync cycle) avoids both the
+                // `HashSet` allocation and the per-label `clear` calls.
+                // This path fires at up to 4 Hz during transfers, so
+                // skipping the alloc when there's nothing to clear is
+                // worth a one-line short-circuit.
+                if app_state.preparing.is_any_preparing() {
+                    let labels_with_files: std::collections::HashSet<&str> = snapshot.files.iter().map(|f| f.label.as_ref()).collect();
+                    for label in &labels_with_files {
+                        app_state.preparing.clear(label);
+                    }
+                }
+
+                // `prepare_snapshot_for_emit` applies the stalled-completion
+                // fixup, the preparing override (when no real session is yet
+                // visible and any label is preparing), and the file-cap.
+                // Without the stall fixup, hcfs-client's own file-watcher-
+                // driven `changes_pending=true` leaves `is_active` stuck at
+                // `true` indefinitely after all files are synced, so
                 // `widget_state`, `effective_in_progress`, `effective_completed`,
                 // and `status_variant` all still say "syncing" despite 100%
-                // progress. Only the bootstrap `sp_get_snapshot` path used to
-                // apply the fixup, which meant a session that stalled after the
-                // widget/tray had already mounted would display "Syncing: 100%"
-                // forever. See `progress::fixup_stalled_completion`.
-                prepare_snapshot_for_emit(&mut snapshot);
+                // progress. Without the preparing override, file-watcher-
+                // initiated cycles leave the widget hidden through the
+                // scan + remote-state-fetch window even though the system
+                // is actively working. See
+                // `progress::fixup_stalled_completion` and
+                // `progress::apply_preparing_override`.
+                prepare_snapshot_for_emit(&mut snapshot, &app_state.preparing);
 
                 // Skip the IPC if this snapshot is structurally identical to
                 // the last one we emitted. The throttle in

--- a/src-tauri/src/sync/tauri_bridge.rs
+++ b/src-tauri/src/sync/tauri_bridge.rs
@@ -197,8 +197,15 @@ impl SyncEventHandler for TauriSyncBridge {
                     // before the user sees it.
                     app_state.credits_exhausted.clear(&label);
 
-                    let (banner_active, _) = app_state.upload_processing.snapshot();
-                    if !banner_active && app_state.preparing.mark_preparing(&label) {
+                    // Per-label check (Task 4.1): an IPC-initiated
+                    // upload banner is only an "already signalling"
+                    // affordance for ITS OWN drive. A banner active
+                    // on drive A must not suppress the preparing
+                    // widget for drive B — the pre-Task-4.1 global
+                    // `snapshot()` did exactly that and was Bug 4
+                    // in the original 402 diagnosis.
+                    let banner_active_for_label = app_state.upload_processing.is_active_for(&label);
+                    if !banner_active_for_label && app_state.preparing.mark_preparing(&label) {
                         // Newly inserted — push a snapshot so the
                         // widget reflects preparing within one tick
                         // of `SyncStarted`. Subsequent SyncStarted
@@ -288,15 +295,17 @@ impl SyncEventHandler for TauriSyncBridge {
                 // emitting a non-zero upload tick (empty plan,
                 // already-synced batch, downloads/deletes only), the
                 // first-chunk path in `handle_transfer_progress` never
-                // ran and the banner would otherwise stay raised.
-                // `clear_if_session_advanced` is idempotent and gated
-                // on the per-cycle epoch, so the common case (real
-                // upload already cleared it) is a no-op and an
+                // ran and the banner would otherwise stay raised for
+                // this label. `clear_if_session_advanced` is idempotent
+                // and gated on the per-cycle epoch, so the common case
+                // (real upload already cleared it) is a no-op and an
                 // overlapping in-flight cycle's completion cannot
-                // prematurely clear a NEW upload's banner.
+                // prematurely clear a NEW upload's banner. Scoped to
+                // THIS label (Task 4.1) — completion on drive A must
+                // not touch drive B's banner state.
                 {
                     let epoch = app_state.sync_session_epoch.load(std::sync::atomic::Ordering::SeqCst);
-                    app_state.upload_processing.clear_if_session_advanced(&app, epoch);
+                    app_state.upload_processing.clear_if_session_advanced(&app, &label, epoch);
                 }
 
                 // Update per-file failure counters from the finalized session.
@@ -369,7 +378,10 @@ impl SyncEventHandler for TauriSyncBridge {
                     use tauri::Manager;
                     let app_state = app.state::<crate::app_state::AppState>();
                     let epoch = app_state.sync_session_epoch.load(std::sync::atomic::Ordering::SeqCst);
-                    app_state.upload_processing.clear_if_session_advanced(&app, epoch);
+                    // Scoped to THIS label (Task 4.1) — an error on
+                    // drive A must not silently clear drive B's
+                    // pending upload banner.
+                    app_state.upload_processing.clear_if_session_advanced(&app, &label, epoch);
                     app_state.preparing.clear(&label);
                     // The cycle ended in a real error; the next
                     // cycle should reset the 402 counter so its

--- a/src-tauri/src/sync/tauri_bridge.rs
+++ b/src-tauri/src/sync/tauri_bridge.rs
@@ -186,6 +186,17 @@ impl SyncEventHandler for TauriSyncBridge {
                     let app_state = app.state::<crate::app_state::AppState>();
                     app_state.sync_session_epoch.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
+                    // Fresh cycle for this label — reset the running
+                    // 402 counter so the next `InsufficientBalance`
+                    // failure starts at `file_count = 1` and the FE
+                    // banner reflects only the new cycle's failures.
+                    // Clearing here (not on SyncCompleted) is correct
+                    // because the user-visible state is "this cycle's
+                    // failures, banner sticks until next cycle";
+                    // clearing on completion would erase the banner
+                    // before the user sees it.
+                    app_state.credits_exhausted.clear(&label);
+
                     let (banner_active, _) = app_state.upload_processing.snapshot();
                     if !banner_active && app_state.preparing.mark_preparing(&label) {
                         // Newly inserted — push a snapshot so the
@@ -360,6 +371,13 @@ impl SyncEventHandler for TauriSyncBridge {
                     let epoch = app_state.sync_session_epoch.load(std::sync::atomic::Ordering::SeqCst);
                     app_state.upload_processing.clear_if_session_advanced(&app, epoch);
                     app_state.preparing.clear(&label);
+                    // The cycle ended in a real error; the next
+                    // cycle should reset the 402 counter so its
+                    // banner shows only the new cycle's failures.
+                    // Cancels do NOT clear here — they early-return
+                    // above. A pause/resume/remove flow goes through
+                    // `SyncStopped`, which has its own clear.
+                    app_state.credits_exhausted.clear(&label);
                 }
                 let _ = app.emit(
                     events::SYNC_ERROR,
@@ -377,6 +395,11 @@ impl SyncEventHandler for TauriSyncBridge {
                 if app_state.preparing.clear(&label) {
                     app_state.sync.emit_snapshot(true);
                 }
+                // The drive's cycle ended (pause / remove / logout
+                // teardown). The 402 banner's running count is a
+                // per-cycle aggregate; clear it so a future resume /
+                // re-add starts at zero. Idempotent.
+                app_state.credits_exhausted.clear(&label);
                 let _ = app.emit(events::SYNC_STOPPED, events::LabelPayload { label });
             }
             SyncEvent::SyncReset { account_id, message } => {
@@ -385,6 +408,11 @@ impl SyncEventHandler for TauriSyncBridge {
                 if app_state.preparing.clear_all() {
                     app_state.sync.emit_snapshot(true);
                 }
+                // Account switch / logout / reset. Every per-drive
+                // 402 counter must be wiped before different account
+                // data could touch it — a stale `file_count` would
+                // pollute the banner for an unrelated user.
+                app_state.credits_exhausted.clear_all();
                 let _ = app.emit(events::SYNC_RESET, events::SyncResetPayload { account_id, message });
             }
             SyncEvent::PlanReady {
@@ -463,11 +491,48 @@ impl SyncEventHandler for TauriSyncBridge {
                 // Deliberately NOT performed:
                 //   - `hcfs_sync_error` emit: per-file failure ≠ cycle
                 //     failure; the cycle-level channel is reserved for
-                //     auth/cancel/transport-level errors.
+                //     auth/cancel/transport-level errors. This is also why
+                //     no generic "Sync Failed" notification row is created
+                //     for an InsufficientBalance failure: the FE notification
+                //     handler (`useFilesNotification.ts`) only creates
+                //     "Sync Failed" rows on `hcfs_sync_error`, which per-file
+                //     failures never trigger. Suppression is architectural,
+                //     not gated on a flag.
                 //   - Activity-item enqueue: Phase 1 Task 1.1 established
                 //     that activity rows only land on server-confirmed
                 //     success. Failures are visible via the snapshot's
                 //     Error status and the FILES_FAILED_REPEATEDLY event.
+
+                // InsufficientBalance failures additionally raise the
+                // "Out of credits" banner. The branch reads the typed
+                // variant BEFORE the `kind` value is moved into the
+                // FileFailed payload below — copying `balance_cents` /
+                // `required_cents` here avoids a clone of the whole
+                // upstream enum. The counter mutation happens here
+                // (not in the lifecycle callback) because (a) the
+                // counter is a UI-level aggregate, not a progress-row
+                // mutation, and (b) the bridge is the single emit
+                // site for the banner event — keeping the counter
+                // adjacent to its only reader avoids a split-brain
+                // risk where the count and the event disagree.
+                let credits_payload = if let hcfs_client::engine::events::FileFailureKind::InsufficientBalance {
+                    balance_cents,
+                    required_cents,
+                } = &kind
+                {
+                    use tauri::Manager;
+                    let app_state = app.state::<crate::app_state::AppState>();
+                    let file_count = app_state.credits_exhausted.record_failure(&label);
+                    Some(events::CreditsExhaustedPayload {
+                        label: label.clone(),
+                        balance_cents: *balance_cents,
+                        required_cents: *required_cents,
+                        file_count,
+                    })
+                } else {
+                    None
+                };
+
                 let _ = app.emit(
                     events::FILE_FAILED,
                     events::FileFailedPayload {
@@ -478,6 +543,14 @@ impl SyncEventHandler for TauriSyncBridge {
                         http_status,
                     },
                 );
+
+                // Emit the banner event after the per-file detail so
+                // listeners that subscribe to BOTH (e.g. a future
+                // diagnostics overlay) see them in causal order:
+                // file-row updates first, then the aggregate banner.
+                if let Some(payload) = credits_payload {
+                    let _ = app.emit(events::CREDITS_EXHAUSTED, payload);
+                }
             }
             SyncEvent::HealthChanged { health } => {
                 let _ = app.emit(events::CONNECTIVITY_CHANGED, &health);

--- a/src-tauri/src/sync/tauri_bridge.rs
+++ b/src-tauri/src/sync/tauri_bridge.rs
@@ -622,47 +622,21 @@ impl SyncEventHandler for TauriSyncBridge {
                 prepare_snapshot_for_emit(&mut snapshot, &app_state.preparing);
 
                 // The intent overlay needs an async SQLite SUM/COUNT query,
-                // but `on_event` is the sync half of `SyncEventHandler`. We
-                // spawn the overlay-build + fingerprint-claim + emit
-                // together so the whole IPC tail runs off this synchronous
-                // arm.
-                //
-                // Ordering concern: with `tokio::spawn`, two close-spaced
-                // snapshots can complete their DB read in either order.
-                // The fingerprint atomic uses `swap` (not CAS), so each
-                // spawn's `try_claim` compares its own fp against whatever
-                // got written last; differing fingerprints both emit
-                // (which is the safe outcome — the FE renders the most
-                // recent message and reorder of by-fingerprint-identical
-                // emits is a harmless duplicate IPC). The previous
-                // synchronous claim-then-emit path could collapse two
-                // identical snapshots to one IPC; the spawn path collapses
-                // each snapshot's own duplicate but not a cross-snapshot
-                // race — that's acceptable because the FE re-renders
-                // either way.
-                //
-                // Why not `block_in_place + Handle::current().block_on`:
-                // that pattern (used by `shares::keystore`) panics on a
-                // single-threaded runtime and risks deadlock if any caller
-                // ever invokes `on_event` from inside an existing
-                // `block_on` frame. Spawning is unconditionally safe and
-                // the ordering trade-off is bounded.
-                let app_for_spawn = app.clone();
-                tokio::spawn(async move {
-                    let overlay = build_intent_overlay(&app_for_spawn).await;
-                    let fp = snapshot_fingerprint(&snapshot, overlay);
-                    if try_claim_snapshot_fingerprint(&LAST_EMITTED_FINGERPRINT, fp) {
-                        let wire = SyncSnapshotWire {
-                            inner: &snapshot,
-                            intent_total_files: overlay.total_files,
-                            intent_total_bytes: overlay.total_bytes,
-                            intent_completed_files: overlay.completed_files,
-                            intent_completed_bytes: overlay.completed_bytes,
-                            intent_active: overlay.active,
-                        };
-                        let _ = app_for_spawn.emit(events::PROGRESS_SNAPSHOT, &wire);
-                    }
-                });
+                // but `on_event` is the SYNCHRONOUS half of
+                // `SyncEventHandler` and hcfs-client's
+                // `SyncRunner::emit_snapshot` invokes it on whatever thread
+                // calls it — including the main GUI thread, which is NOT a
+                // Tokio runtime worker (e.g. the console-upload dedup path
+                // routes an emit through a synchronous context). A bare
+                // `tokio::spawn` here panics "there is no reactor running"
+                // on such a thread and the panic double-faults across the
+                // hcfs callback boundary into a process abort. The fire-
+                // and-forget work is therefore delegated to a helper that
+                // schedules onto Tauri's OWNED global runtime regardless of
+                // the calling thread's context — see `spawn_snapshot_emit`
+                // and the in-repo precedent at
+                // `sync::upload_processing::spawn_watchdog`.
+                spawn_snapshot_emit(app.clone(), snapshot);
             }
         }
     }
@@ -791,7 +765,57 @@ struct SyncSnapshotWire<'a> {
 /// multiple drives configured. One aggregate-summing query keeps the
 /// per-emit cost to a single indexed SQLite scan. Source: see
 /// `IntentRepo::totals_for_account`'s `# Why account-scoped` block.
-async fn build_intent_overlay(app: &AppHandle) -> SyncIntentOverlay {
+/// Fire-and-forget the intent-overlay build + fingerprint-claim + snapshot
+/// emit onto Tauri's owned global async runtime.
+///
+/// # Why this exists / why `tauri::async_runtime::spawn`
+///
+/// `on_event` is the synchronous half of `SyncEventHandler`. hcfs-client's
+/// `SyncRunner::emit_snapshot` calls it on whatever thread invokes it —
+/// `finalize_session_for_label`, `handle_sync_error`, and (the crash we are
+/// fixing) a main-thread console-upload path that is NOT inside a Tokio
+/// runtime. Bare `tokio::spawn` / `Handle::current()` panic
+/// ("there is no reactor running, must be called from the context of a
+/// Tokio 1.x runtime") on such a thread, and that panic double-faults
+/// across the hcfs callback boundary into `failed to initiate panic …
+/// aborting`. `tauri::async_runtime::spawn` schedules onto Tauri's own
+/// global runtime handle and is therefore safe from ANY thread regardless
+/// of ambient runtime context — the same reasoning documented at
+/// `sync::upload_processing::spawn_watchdog` and used by
+/// `lifecycle::spawn_record_intent_plan` / `spawn_mark_intent_completed`.
+///
+/// # Ordering / dedup contract (unchanged by the runtime-handle swap)
+///
+/// Two close-spaced snapshots can complete their DB read in either order.
+/// `try_claim_snapshot_fingerprint` uses `swap` (not CAS): differing
+/// fingerprints both emit (safe — the FE renders the most recent message;
+/// a reordered fingerprint-identical pair is a harmless duplicate IPC).
+/// The spawn collapses each snapshot's own duplicate but not a
+/// cross-snapshot race — acceptable because the FE re-renders either way.
+///
+/// Ownership: `app` is `Clone` (cheap `Arc`); `snapshot` is moved into the
+/// future and the `&snapshot` borrow inside is owned-by-future, so the
+/// future is `'static + Send`, satisfying `tauri::async_runtime::spawn`'s
+/// bound (identical to `tokio::spawn`'s).
+fn spawn_snapshot_emit<R: tauri::Runtime>(app: tauri::AppHandle<R>, snapshot: SyncSnapshot) {
+    tauri::async_runtime::spawn(async move {
+        let overlay = build_intent_overlay(&app).await;
+        let fp = snapshot_fingerprint(&snapshot, overlay);
+        if try_claim_snapshot_fingerprint(&LAST_EMITTED_FINGERPRINT, fp) {
+            let wire = SyncSnapshotWire {
+                inner: &snapshot,
+                intent_total_files: overlay.total_files,
+                intent_total_bytes: overlay.total_bytes,
+                intent_completed_files: overlay.completed_files,
+                intent_completed_bytes: overlay.completed_bytes,
+                intent_active: overlay.active,
+            };
+            let _ = app.emit(events::PROGRESS_SNAPSHOT, &wire);
+        }
+    });
+}
+
+async fn build_intent_overlay<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> SyncIntentOverlay {
     use tauri::Manager;
     let app_state = app.state::<crate::app_state::AppState>();
 
@@ -1112,5 +1136,43 @@ mod tests {
         assert!(json["intentCompletedFiles"].is_null());
         assert!(json["intentCompletedBytes"].is_null());
         assert!(json["intentActive"].is_null());
+    }
+
+    /// Regression for the production crash:
+    /// `thread 'main' panicked at tauri_bridge.rs: there is no reactor
+    /// running, must be called from the context of a Tokio 1.x runtime`
+    /// → `failed to initiate panic … aborting`.
+    ///
+    /// hcfs-client's `SyncRunner::emit_snapshot` invokes the synchronous
+    /// `SyncEventHandler::on_event` on whatever thread calls it, including
+    /// the main GUI thread (no ambient Tokio runtime). The fire-and-forget
+    /// snapshot spawn MUST therefore schedule onto Tauri's owned runtime,
+    /// not require `Handle::current()` on the caller.
+    ///
+    /// We drive `spawn_snapshot_emit` from a plain `std::thread` —
+    /// guaranteed NOT inside a Tokio runtime — and assert the CALLING
+    /// thread survives. Bare `tokio::spawn` panics synchronously on that
+    /// thread (`join()` → `Err`); `tauri::async_runtime::spawn` returns
+    /// normally (`join()` → `Ok`). The spawned future's own fate (it will
+    /// hit unmanaged `AppState` in this mock and panic on Tauri's runtime
+    /// worker) is irrelevant — that panic is captured by the dropped
+    /// `JoinHandle` and never reaches this assertion, which is exactly the
+    /// production/​test distinction: the crash is the SPAWN CALL, not the
+    /// task body.
+    #[test]
+    fn spawn_snapshot_emit_does_not_panic_off_runtime() {
+        let app = tauri::test::mock_app().handle().clone();
+        let snapshot = fixture_snapshot();
+        let outcome = std::thread::spawn(move || {
+            spawn_snapshot_emit(app, snapshot);
+        })
+        .join();
+        assert!(
+            outcome.is_ok(),
+            "spawn_snapshot_emit panicked when called from a non-Tokio \
+             thread — this is the production abort. The fire-and-forget \
+             spawn must use tauri::async_runtime::spawn (Tauri-owned \
+             runtime), not bare tokio::spawn (requires Handle::current())."
+        );
     }
 }

--- a/src-tauri/src/sync/tauri_bridge.rs
+++ b/src-tauri/src/sync/tauri_bridge.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::{AppHandle, Emitter};
 
 use super::events;
+use crate::sync::intent::IntentRepo;
 use crate::sync::progress::{SyncSnapshot, cap_file_list, prepare_snapshot_for_emit};
 
 /// Process-wide cursor holding the last-emitted snapshot fingerprint.
@@ -620,19 +621,48 @@ impl SyncEventHandler for TauriSyncBridge {
                 // `progress::apply_preparing_override`.
                 prepare_snapshot_for_emit(&mut snapshot, &app_state.preparing);
 
-                // Skip the IPC if this snapshot is structurally identical to
-                // the last one we emitted. The throttle in
-                // `progress::update_file_progress` already gates by time;
-                // this fingerprint gate covers the case where two emits land
-                // back-to-back with the same content (e.g. an
-                // `emit_snapshot(true)` after a no-op state mutation, or a
-                // state-transition emit that races with a chunk-tick emit
-                // both seeing the same headline data). Avoiding `app.emit`
-                // skips the JSON serialization + IPC tunnel.
-                let fp = snapshot_fingerprint(&snapshot);
-                if try_claim_snapshot_fingerprint(&LAST_EMITTED_FINGERPRINT, fp) {
-                    let _ = app.emit(events::PROGRESS_SNAPSHOT, &snapshot);
-                }
+                // The intent overlay needs an async SQLite SUM/COUNT query,
+                // but `on_event` is the sync half of `SyncEventHandler`. We
+                // spawn the overlay-build + fingerprint-claim + emit
+                // together so the whole IPC tail runs off this synchronous
+                // arm.
+                //
+                // Ordering concern: with `tokio::spawn`, two close-spaced
+                // snapshots can complete their DB read in either order.
+                // The fingerprint atomic uses `swap` (not CAS), so each
+                // spawn's `try_claim` compares its own fp against whatever
+                // got written last; differing fingerprints both emit
+                // (which is the safe outcome — the FE renders the most
+                // recent message and reorder of by-fingerprint-identical
+                // emits is a harmless duplicate IPC). The previous
+                // synchronous claim-then-emit path could collapse two
+                // identical snapshots to one IPC; the spawn path collapses
+                // each snapshot's own duplicate but not a cross-snapshot
+                // race — that's acceptable because the FE re-renders
+                // either way.
+                //
+                // Why not `block_in_place + Handle::current().block_on`:
+                // that pattern (used by `shares::keystore`) panics on a
+                // single-threaded runtime and risks deadlock if any caller
+                // ever invokes `on_event` from inside an existing
+                // `block_on` frame. Spawning is unconditionally safe and
+                // the ordering trade-off is bounded.
+                let app_for_spawn = app.clone();
+                tokio::spawn(async move {
+                    let overlay = build_intent_overlay(&app_for_spawn).await;
+                    let fp = snapshot_fingerprint(&snapshot, overlay);
+                    if try_claim_snapshot_fingerprint(&LAST_EMITTED_FINGERPRINT, fp) {
+                        let wire = SyncSnapshotWire {
+                            inner: &snapshot,
+                            intent_total_files: overlay.total_files,
+                            intent_total_bytes: overlay.total_bytes,
+                            intent_completed_files: overlay.completed_files,
+                            intent_completed_bytes: overlay.completed_bytes,
+                            intent_active: overlay.active,
+                        };
+                        let _ = app_for_spawn.emit(events::PROGRESS_SNAPSHOT, &wire);
+                    }
+                });
             }
         }
     }
@@ -693,14 +723,126 @@ impl SyncCallbacks for TauriSyncBridge {
     }
 }
 
-/// Compute a small content fingerprint for a `SyncSnapshot`.
+/// Desktop-side intent-manifest overlay piggybacked onto the snapshot wire.
+///
+/// All fields are `Option` so the wire wrapper can render `null` for an
+/// emit that happens before a user is logged in (or before the DB pool is
+/// installed) — the FE treats absent fields as "no overlay", which is the
+/// correct render for "we don't know yet". An all-`None` overlay is the
+/// `Default` and never participates in `intent_active`'s "X of Y" gate.
+///
+/// `Copy` so the fingerprint helper can take it by value without forcing
+/// the spawn body to manage a reference's lifetime alongside the
+/// `&snapshot` borrow it already owns. The struct is six pointer-sized
+/// `Option`s plus one `Option<bool>` — passing by value is ~40 bytes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct SyncIntentOverlay {
+    total_files: Option<u64>,
+    total_bytes: Option<u64>,
+    completed_files: Option<u64>,
+    completed_bytes: Option<u64>,
+    /// `Some(true)` iff `total_files > completed_files`. The FE gates the
+    /// "Syncing X GB of Y" line on this — `None` AND `Some(false)` both
+    /// hide the line, matching the "no work pending" UX.
+    active: Option<bool>,
+}
+
+/// Snapshot payload sent on the `sync_progress_snapshot` Tauri channel.
+///
+/// Wraps `hcfs_client::sync::SyncSnapshot` via `#[serde(flatten)]` and
+/// appends five desktop-side overlay fields representing the intent
+/// manifest's "X of Y" totals — what the user dragged in vs what's
+/// uploaded so far, which is the only progress signal that survives an
+/// app restart.
+///
+/// The borrowed `inner: &'a SyncSnapshot` keeps the wire shape allocation-
+/// free; the wrapper is consumed synchronously by `serde_json` inside
+/// `app.emit`, so the borrow never escapes the emit call.
+///
+/// All five overlay fields are `Option`: a snapshot emit that races
+/// AppState wiring (or fires before the user logs in) carries `None` for
+/// every overlay field. The FE contract is "treat None as no overlay";
+/// never coerce to zero (which would falsely render a "0 of 0" widget).
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncSnapshotWire<'a> {
+    #[serde(flatten)]
+    inner: &'a SyncSnapshot,
+    intent_total_files: Option<u64>,
+    intent_total_bytes: Option<u64>,
+    intent_completed_files: Option<u64>,
+    intent_completed_bytes: Option<u64>,
+    intent_active: Option<bool>,
+}
+
+/// Build the intent-overlay numbers for the current account, summed
+/// across every drive the user has.
+///
+/// Returns `SyncIntentOverlay::default()` (all-`None`) when there's no
+/// active account or the DB read fails — the wire wrapper renders that as
+/// missing JSON fields and the FE treats absent fields as "no overlay".
+/// We deliberately do NOT propagate `IntentError::Db` to the IPC channel:
+/// a transient DB hiccup must not drop the snapshot emit itself, because
+/// the FE depends on the hcfs progress fields for the per-file widget
+/// regardless of whether the overlay is known.
+///
+/// Why a single `totals_for_account` query (not N `totals_for_drive`):
+/// the emit fires at up to 4 Hz during transfers and the user may have
+/// multiple drives configured. One aggregate-summing query keeps the
+/// per-emit cost to a single indexed SQLite scan. Source: see
+/// `IntentRepo::totals_for_account`'s `# Why account-scoped` block.
+async fn build_intent_overlay(app: &AppHandle) -> SyncIntentOverlay {
+    use tauri::Manager;
+    let app_state = app.state::<crate::app_state::AppState>();
+
+    // Not-logged-in is a load-bearing case — the auto_init flow emits
+    // snapshots before AuthInfo is populated. Treat as "no overlay".
+    let Ok(account_id) = app_state.current_account_id() else {
+        return SyncIntentOverlay::default();
+    };
+    let pool = match app_state.pool() {
+        Ok(p) => p.clone(),
+        Err(e) => {
+            tracing::debug!(error = %e, "intent overlay: pool unavailable, emitting without overlay");
+            return SyncIntentOverlay::default();
+        }
+    };
+
+    let repo = IntentRepo::new(pool);
+    match repo.totals_for_account(&account_id).await {
+        Ok(totals) => SyncIntentOverlay {
+            total_files: Some(totals.total_files),
+            total_bytes: Some(totals.total_bytes),
+            completed_files: Some(totals.completed_files),
+            completed_bytes: Some(totals.completed_bytes),
+            // `active` flips false when the manifest is fully drained
+            // OR genuinely empty (no rows). The "fully drained" branch
+            // lets the FE hide the line as soon as totals == completed,
+            // without a separate widget-state field. An empty manifest
+            // (total = 0) maps to `false` rather than `None` because
+            // we DO know there's no overlay work — `None` is reserved
+            // for "we couldn't read the DB".
+            active: Some(totals.total_files > totals.completed_files),
+        },
+        Err(e) => {
+            tracing::warn!(error = %e, "intent overlay: totals_for_account failed");
+            SyncIntentOverlay::default()
+        }
+    }
+}
+
+/// Compute a small content fingerprint for a `SyncSnapshot` + its
+/// intent-overlay tail.
 ///
 /// Hashes every scalar field the FE renders plus a per-file
 /// (path, action, status, bytes_transferred, bytes_encrypted, total_bytes,
 /// error) tuple so any user-visible change in per-file progress flips the
-/// fingerprint. Pure ordering changes in the `files` vec also flip it by
-/// design — the FE renders rows in the order Rust sent them, so a reorder
-/// IS a visible change. `0` is reserved for the never-emitted sentinel
+/// fingerprint. The overlay's five `Option<u64>` / `Option<bool>` fields
+/// are folded in after the per-file loop so an overlay-only change (rare
+/// but possible — e.g. a `mark_completed` write while no transfer is in
+/// flight) still triggers an emit. Pure ordering changes in the `files`
+/// vec also flip the fingerprint by design — the FE renders rows in the
+/// order Rust sent them. `0` is reserved for the never-emitted sentinel
 /// and is remapped to `1` to keep it distinct from the gate's baseline.
 ///
 /// **Collision contract**: the gate uses `DefaultHasher` (SipHash-1-3,
@@ -711,11 +853,15 @@ impl SyncCallbacks for TauriSyncBridge {
 /// re-emit within ~250 ms anyway, so even a freak collision corrects
 /// itself within one frame.
 ///
-/// **Single-emitter contract**: pairs with `try_claim_snapshot_fingerprint`'s
-/// `swap` (not `compare_exchange`). Safe because `TauriSyncBridge::on_event`
-/// is dispatched serially per sync runner; concurrent callers would need
-/// CAS to be correct, but we don't have any.
-fn snapshot_fingerprint(s: &SyncSnapshot) -> u64 {
+/// **Concurrent-claim contract**: pairs with `try_claim_snapshot_fingerprint`'s
+/// `swap` (not `compare_exchange`). The emit path now runs from a
+/// `tokio::spawn` (so multiple emits can race), but `swap` returns the
+/// previous value to each racer — two racers with different fingerprints
+/// both see `prev != fp` and both emit. Two racers with identical
+/// fingerprints might both emit (one duplicate IPC, harmless) or might
+/// dedupe to one (the winning racer's `swap` matches the loser's later
+/// `prev`); both outcomes are acceptable.
+fn snapshot_fingerprint(s: &SyncSnapshot, overlay: SyncIntentOverlay) -> u64 {
     let mut h = std::collections::hash_map::DefaultHasher::new();
     s.is_active.hash(&mut h);
     s.progress_bytes.hash(&mut h);
@@ -760,6 +906,14 @@ fn snapshot_fingerprint(s: &SyncSnapshot) -> u64 {
         f.total_bytes.hash(&mut h);
         f.error.as_ref().map(AsRef::as_ref).hash(&mut h);
     }
+    // Overlay tail. `Option<T>: Hash` when `T: Hash` (verified at
+    // doc.rust-lang.org/std/option/enum.Option.html#impl-Hash-for-Option<T>),
+    // so each field hashes its presence + payload in one call.
+    overlay.total_files.hash(&mut h);
+    overlay.total_bytes.hash(&mut h);
+    overlay.completed_files.hash(&mut h);
+    overlay.completed_bytes.hash(&mut h);
+    overlay.active.hash(&mut h);
     let h = h.finish();
     if h == 0 { 1 } else { h }
 }
@@ -849,11 +1003,12 @@ mod tests {
         let mut a = fixture_snapshot();
         let mut b = fixture_snapshot();
         b.progress_bytes = 1500;
-        assert_ne!(snapshot_fingerprint(&a), snapshot_fingerprint(&b));
+        let empty = SyncIntentOverlay::default();
+        assert_ne!(snapshot_fingerprint(&a, empty), snapshot_fingerprint(&b, empty));
         // And while we're here, verify identical snapshots produce
         // identical fingerprints (the gate's whole reason for existing).
         a.progress_bytes = 1500;
-        assert_eq!(snapshot_fingerprint(&a), snapshot_fingerprint(&b));
+        assert_eq!(snapshot_fingerprint(&a, empty), snapshot_fingerprint(&b, empty));
     }
 
     /// Regression for the review-flagged `started_at` gap: a session
@@ -864,8 +1019,98 @@ mod tests {
         let mut a = fixture_snapshot();
         let mut b = fixture_snapshot();
         b.started_at = Some(1_700_000_001_000);
-        assert_ne!(snapshot_fingerprint(&a), snapshot_fingerprint(&b));
+        let empty = SyncIntentOverlay::default();
+        assert_ne!(snapshot_fingerprint(&a, empty), snapshot_fingerprint(&b, empty));
         a.started_at = b.started_at;
-        assert_eq!(snapshot_fingerprint(&a), snapshot_fingerprint(&b));
+        assert_eq!(snapshot_fingerprint(&a, empty), snapshot_fingerprint(&b, empty));
+    }
+
+    /// Regression for Task 7: an overlay-only change MUST flip the
+    /// fingerprint so an emit fires even if every hcfs-side field is
+    /// byte-identical. Without this, `mark_completed` advancing the
+    /// intent totals while no transfer is in flight (e.g. the closing
+    /// per-file callback fires right after the FE-visible snapshot
+    /// already settled) would not re-emit, and the FE's "X of Y" line
+    /// would stay frozen until the next unrelated snapshot tick.
+    #[test]
+    fn fingerprint_changes_when_overlay_changes() {
+        let a = fixture_snapshot();
+        let empty = SyncIntentOverlay::default();
+        let with_totals = SyncIntentOverlay {
+            total_files: Some(10),
+            total_bytes: Some(1_000),
+            completed_files: Some(5),
+            completed_bytes: Some(500),
+            active: Some(true),
+        };
+        assert_ne!(
+            snapshot_fingerprint(&a, empty),
+            snapshot_fingerprint(&a, with_totals),
+        );
+        // Sanity: identical overlays produce identical fingerprints.
+        assert_eq!(
+            snapshot_fingerprint(&a, with_totals),
+            snapshot_fingerprint(&a, with_totals),
+        );
+    }
+
+    /// Wire-format contract: serializing `SyncSnapshotWire` must
+    /// (a) inline the inner snapshot's camelCase fields at the top
+    ///     level (verifies `#[serde(flatten)]` did its job),
+    /// (b) include the five overlay fields in camelCase, and
+    /// (c) round-trip `Some` overlay values as the underlying scalar.
+    /// The FE depends on the exact field names — break this test and
+    /// the widget renders nothing.
+    #[test]
+    fn snapshot_wire_serializes_inner_flat_with_intent_camelcase() {
+        let inner = fixture_snapshot();
+        let wire = SyncSnapshotWire {
+            inner: &inner,
+            intent_total_files: Some(10),
+            intent_total_bytes: Some(1_000),
+            intent_completed_files: Some(5),
+            intent_completed_bytes: Some(500),
+            intent_active: Some(true),
+        };
+        let json = serde_json::to_value(&wire).expect("serialize wire");
+
+        // Overlay fields (camelCase).
+        assert_eq!(json["intentTotalFiles"], 10);
+        assert_eq!(json["intentTotalBytes"], 1_000);
+        assert_eq!(json["intentCompletedFiles"], 5);
+        assert_eq!(json["intentCompletedBytes"], 500);
+        assert_eq!(json["intentActive"], true);
+
+        // No `inner` nesting — flatten promoted the inner fields up.
+        assert!(json.get("inner").is_none(), "flatten must inline `inner`");
+
+        // Spot-check one inner snapshot field at the top level. The
+        // fixture sets `widget_state = "active"`, which serializes as
+        // camelCase `widgetState`.
+        assert_eq!(json["widgetState"], "active");
+        assert_eq!(json["isActive"], true);
+    }
+
+    /// `None` overlay fields render as JSON `null` (default serde
+    /// behavior). The FE checks for absent / `null` to mean "no
+    /// overlay" — treating `null` as zero would falsely render a
+    /// "0 of 0" widget for users who haven't been logged in yet.
+    #[test]
+    fn snapshot_wire_serializes_none_overlay_as_null() {
+        let inner = fixture_snapshot();
+        let wire = SyncSnapshotWire {
+            inner: &inner,
+            intent_total_files: None,
+            intent_total_bytes: None,
+            intent_completed_files: None,
+            intent_completed_bytes: None,
+            intent_active: None,
+        };
+        let json = serde_json::to_value(&wire).expect("serialize wire");
+        assert!(json["intentTotalFiles"].is_null());
+        assert!(json["intentTotalBytes"].is_null());
+        assert!(json["intentCompletedFiles"].is_null());
+        assert!(json["intentCompletedBytes"].is_null());
+        assert!(json["intentActive"].is_null());
     }
 }

--- a/src-tauri/src/sync/upload_processing.rs
+++ b/src-tauri/src/sync/upload_processing.rs
@@ -470,7 +470,13 @@ fn emit(app: &tauri::AppHandle, label: &str, active: bool, pending_files: u64) {
 /// runs on the owned `Vec`, so no `MutexGuard` exists during the
 /// `.await` (axiom `Async Lock Hygiene`).
 pub fn spawn_watchdog(state: Weak<UploadProcessingState>, app: tauri::AppHandle) {
-    tokio::spawn(async move {
+    // `tauri::async_runtime::spawn` ensures the future runs on Tauri's
+    // own tokio runtime, which is already entered. `tokio::spawn` here
+    // panics at boot because Tauri's `setup` closure (our caller) is
+    // not running inside a tokio runtime context — `tokio::spawn` and
+    // `tokio::time::sleep` both require one. Tauri's `async_runtime`
+    // IS tokio under the hood, so the inner `sleep` is fine.
+    tauri::async_runtime::spawn(async move {
         loop {
             tokio::time::sleep(BANNER_WATCHDOG_SCAN_INTERVAL).await;
             let Some(state) = state.upgrade() else {

--- a/src-tauri/src/sync/upload_processing.rs
+++ b/src-tauri/src/sync/upload_processing.rs
@@ -1,27 +1,53 @@
-//! Tracks the "processing" window between a user-initiated upload IPC
-//! call and the first byte of upload progress for a sync cycle that
-//! began AFTER the upload was registered. The frontend renders a
-//! top-of-page banner during this window so the user sees that the
-//! system has acknowledged their click while disk copy + encryption
-//! run.
+//! Per-label tracking of the "processing" window between a
+//! user-initiated upload IPC call and the first byte of upload progress
+//! for a sync cycle that began AFTER the upload was registered.
 //!
-//! Lifecycle:
-//! - `begin(count, current_epoch)` — called from `add_file` /
+//! The frontend renders a top-of-page banner per drive while
+//! `is_active_for(label)` returns `true` for that label.
+//!
+//! ## Why per-label
+//!
+//! An earlier design held a single process-wide
+//! `UploadProcessingInner`. That conflated "this drive has an IPC
+//! banner" with "any drive has an IPC banner" — so if the user clicked
+//! Upload on drive A and then a file-watcher cycle fired on drive B,
+//! the `SyncStarted` arm of [`crate::sync::tauri_bridge::TauriSyncBridge`]
+//! would consult the global `snapshot()` and incorrectly suppress
+//! drive B's `mark_preparing` call. The user saw nothing on drive B
+//! during scan + remote-state-fetch even though that drive had no
+//! IPC banner of its own. Per-label state isolates the two drives.
+//!
+//! Mirrors the [`crate::sync::preparing::PreparingState`] and
+//! [`crate::sync::credits_exhausted::CreditsExhaustedState`]
+//! composition pattern exactly.
+//!
+//! ## Lifecycle (per label)
+//!
+//! - `begin(label, count, current_epoch)` — called from `add_file` /
 //!   `add_files` / `add_folder` after the eligibility check, before
-//!   the disk copy. Increments the pending count and, on the
-//!   activating call (when no banner is currently active), stamps
+//!   the disk copy. Increments the label's pending count and, on the
+//!   activating call (when the label has no entry), stamps
 //!   `started_at` and `stamped_epoch`. The epoch comes from
 //!   `AppState::sync_session_epoch`, which increments on every
 //!   `SyncStarted` event.
-//! - `clear_if_session_advanced(event_epoch)` — called from
+//! - `clear_if_session_advanced(label, event_epoch)` — called from
 //!   `handle_transfer_progress` (per upload chunk), `SyncCompleted`,
-//!   and `SyncError`. Clears state only when `event_epoch >
-//!   stamped_epoch`, i.e. when the event is from a sync cycle that
-//!   began AFTER the activating `begin`. This is what makes the
-//!   guard correct: events from a cycle that was already running
-//!   when the user clicked Upload do not satisfy the guard, so they
-//!   cannot prematurely clear the banner.
-//! - `reset()` — unconditional clear. Used by logout / `stop_sync`.
+//!   and `SyncError` for THAT label. Clears the label's entry only
+//!   when `event_epoch > stamped_epoch`, i.e. when the event is from
+//!   a sync cycle that began AFTER the activating `begin`. Events
+//!   from a cycle that was already running when the user clicked
+//!   Upload do not satisfy the guard, so they cannot prematurely
+//!   clear the banner.
+//! - `reset(label)` — unconditional clear for a single label.
+//!   Used by IPC error paths in `files.rs` (begin-then-fail), and by
+//!   the `add_files` "all-failed" guard.
+//! - `reset_all()` — unconditional clear of every label.
+//!   Used by logout / `stop_sync` (the process-wide path that resets
+//!   every drive at once).
+//! - `is_active_for(label) -> bool` — read used by the bridge's
+//!   `SyncStarted` arm to decide whether the file-watcher "preparing"
+//!   override is needed for THIS label. Returns `true` iff the label
+//!   has an entry with `started_at = Some(_)`.
 //!
 //! ## Why epoch and not timestamp
 //!
@@ -38,10 +64,25 @@
 //! The epoch counter increments only on `SyncStarted`, so the guard
 //! correctly distinguishes "event from a cycle that started AFTER
 //! begin" from "event from a cycle that was already running."
+//!
+//! ## Concurrency
+//!
+//! The inner `std::sync::Mutex` is locked only for the duration of a
+//! single map operation. The bridge handlers that invoke these methods
+//! are synchronous (`SyncEventHandler::on_event` has no `.await`), so
+//! the sync-mutex-across-await axiom holds by construction. Each
+//! public method drops its `MutexGuard` at the function boundary —
+//! the load-bearing re-entrancy invariant from the bridge handler
+//! that calls a write method and then re-enters this module via
+//! `emit_snapshot` → `ProgressSnapshot` → reads.
 
-use std::sync::Mutex;
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
 use std::time::Instant;
 
+/// Per-label state held inside the `HashMap`. Layout is unchanged from
+/// the pre-per-label design — only the surrounding ownership shape
+/// moved from one direct field to a map entry.
 #[derive(Default)]
 struct UploadProcessingInner {
     pending_files: u64,
@@ -50,12 +91,23 @@ struct UploadProcessingInner {
     /// Used by `clear_if_session_advanced` to gate clearing on
     /// "an event from a NEWER cycle" rather than the broken
     /// wall-clock timestamp comparison. `None` exactly when
-    /// `started_at` is None.
+    /// `started_at` is `None`; the two fields move together.
     stamped_epoch: Option<u64>,
 }
 
+/// Map of drive label → "processing window" state.
+///
+/// Owned by [`crate::app_state::AppState`] behind an `Arc`, matching
+/// the [`crate::sync::preparing::PreparingState`] /
+/// [`crate::sync::credits_exhausted::CreditsExhaustedState`] pattern.
 pub struct UploadProcessingState {
-    inner: Mutex<UploadProcessingInner>,
+    /// `HashMap<String, _>` keyed by drive label. Membership in the
+    /// map ⇔ "banner active for that label". A label is removed on
+    /// `clear_if_session_advanced` (gate fires), `reset(label)`, and
+    /// `reset_all()`. The map's iteration order is unspecified, but
+    /// the bridge never iterates — every read goes through
+    /// `is_active_for(label)`, so no order-sensitivity is exposed.
+    inner: Mutex<HashMap<String, UploadProcessingInner>>,
 }
 
 impl Default for UploadProcessingState {
@@ -67,74 +119,117 @@ impl Default for UploadProcessingState {
 impl UploadProcessingState {
     pub fn new() -> Self {
         Self {
-            inner: Mutex::new(UploadProcessingInner::default()),
+            inner: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Snapshot for tests and event payload assembly.
-    #[doc(hidden)]
-    pub fn snapshot(&self) -> (bool, u64) {
-        let g = self.inner.lock().expect("upload_processing mutex poisoned");
-        (g.started_at.is_some(), g.pending_files)
+    /// Acquire the inner mutex with a single poison-message helper.
+    ///
+    /// Centralises the `expect` panic message so a future addition to
+    /// the API can't introduce a new wording variant. Poison is fatal
+    /// because the bridge is the single writer — if it panicked while
+    /// holding the guard, the per-label invariant the state encodes
+    /// is already corrupt.
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, UploadProcessingInner>> {
+        self.inner.lock().expect("upload_processing mutex poisoned")
     }
 
-    /// Increment `pending_files` by `count`. On the activating call
-    /// (when no banner is active), stamp `started_at = Some(Instant::now())`
-    /// and `stamped_epoch = Some(current_epoch)`. Emits
-    /// `hcfs_upload_processing` with `{ active: true, pending_files }`.
+    /// Returns `true` when `label` currently has an active banner.
+    ///
+    /// Used by `TauriSyncBridge::on_event` `SyncStarted` arm to decide
+    /// whether the file-watcher "preparing" widget override should be
+    /// applied for THIS label. The previous global `snapshot()` check
+    /// is what caused Bug 4 (cross-drive suppression).
+    pub fn is_active_for(&self, label: &str) -> bool {
+        self.lock().get(label).is_some_and(|i| i.started_at.is_some())
+    }
+
+    /// Test/diagnostic snapshot for a single label: `(active, pending_files)`.
+    #[doc(hidden)]
+    pub fn snapshot_for(&self, label: &str) -> (bool, u64) {
+        match self.lock().get(label) {
+            Some(i) => (i.started_at.is_some(), i.pending_files),
+            None => (false, 0),
+        }
+    }
+
+    /// Increment `pending_files` for `label` by `count`. On the
+    /// activating call (when the label has no entry), insert a fresh
+    /// entry with `started_at = Some(Instant::now())` and
+    /// `stamped_epoch = Some(current_epoch)`. Emits
+    /// `hcfs_upload_processing` with `{ label, active: true, pending_files }`.
     ///
     /// `current_epoch` is the value of
     /// `AppState::sync_session_epoch.load(Ordering::SeqCst)` at the
-    /// time of the call. Subsequent begins while active accumulate
-    /// the count but do NOT restamp epoch — the original epoch must
-    /// survive so `clear_if_session_advanced` can correctly gate on
-    /// "did a new cycle start since the FIRST begin in this window."
-    pub fn begin(&self, app: &tauri::AppHandle, count: u64, current_epoch: u64) {
+    /// time of the call. Subsequent begins for the same label while
+    /// active accumulate the count but do NOT restamp epoch — the
+    /// original epoch must survive so `clear_if_session_advanced` can
+    /// correctly gate on "did a new cycle start since the FIRST begin
+    /// in this window."
+    pub fn begin(&self, app: &tauri::AppHandle, label: &str, count: u64, current_epoch: u64) {
         let pending = {
-            let mut g = self.inner.lock().expect("upload_processing mutex poisoned");
-            g.pending_files = g.pending_files.saturating_add(count);
-            if g.started_at.is_none() {
-                g.started_at = Some(Instant::now());
-                g.stamped_epoch = Some(current_epoch);
+            let mut g = self.lock();
+            let entry = g.entry(label.to_string()).or_default();
+            entry.pending_files = entry.pending_files.saturating_add(count);
+            if entry.started_at.is_none() {
+                entry.started_at = Some(Instant::now());
+                entry.stamped_epoch = Some(current_epoch);
             }
-            g.pending_files
+            entry.pending_files
         };
-        emit(app, true, pending);
+        emit(app, label, true, pending);
     }
 
-    /// Clear state if `event_epoch > stamped_epoch`. No-op when
-    /// inactive or when the event is from a cycle that was already
-    /// running at `begin` time. Idempotent.
-    pub fn clear_if_session_advanced(&self, app: &tauri::AppHandle, event_epoch: u64) {
+    /// Clear `label`'s entry if `event_epoch > stamped_epoch`. No-op
+    /// when the label has no entry or when the event is from a cycle
+    /// that was already running at `begin` time. Idempotent.
+    pub fn clear_if_session_advanced(&self, app: &tauri::AppHandle, label: &str, event_epoch: u64) {
         let did_clear = {
-            let mut g = self.inner.lock().expect("upload_processing mutex poisoned");
-            match g.stamped_epoch {
-                Some(stamped) if event_epoch > stamped => {
-                    g.pending_files = 0;
-                    g.started_at = None;
-                    g.stamped_epoch = None;
-                    true
-                }
-                _ => false,
+            let mut g = self.lock();
+            // Inspect the entry without holding `&mut` on the map past
+            // the decision: when the gate fires we want to `remove`
+            // (not just zero the fields) so the membership invariant
+            // is preserved. `Entry::occupied` borrows the map mutably
+            // for the lifetime of the entry; we drop the borrow before
+            // calling `remove`.
+            let should_remove = matches!(g.get(label).and_then(|i| i.stamped_epoch), Some(stamped) if event_epoch > stamped);
+            if should_remove {
+                g.remove(label);
+                true
+            } else {
+                false
             }
         };
         if did_clear {
-            emit(app, false, 0);
+            emit(app, label, false, 0);
         }
     }
 
-    /// Unconditional clear used by logout / `stop_sync`.
-    pub fn reset(&self, app: &tauri::AppHandle) {
-        let did_clear = {
-            let mut g = self.inner.lock().expect("upload_processing mutex poisoned");
-            let was_active = g.started_at.is_some() || g.pending_files > 0;
-            g.pending_files = 0;
-            g.started_at = None;
-            g.stamped_epoch = None;
-            was_active
-        };
+    /// Unconditional clear for a single label. Used by IPC error
+    /// paths in `files.rs` and the `add_files` "all-failed" guard.
+    pub fn reset(&self, app: &tauri::AppHandle, label: &str) {
+        let did_clear = self.lock().remove(label).is_some();
         if did_clear {
-            emit(app, false, 0);
+            emit(app, label, false, 0);
+        }
+    }
+
+    /// Unconditional clear of every label. Used by logout /
+    /// `stop_sync` where every drive is torn down at once.
+    ///
+    /// Emits one `{ label, active: false, pending_files: 0 }` event
+    /// per previously-active label so per-drive FE banners all clear.
+    /// Sorting the drained labels keeps the emit order deterministic
+    /// for tests; the FE does not depend on order, but the inline
+    /// `reset_all_emits_per_label` test does.
+    pub fn reset_all(&self, app: &tauri::AppHandle) {
+        let mut labels: Vec<String> = {
+            let mut g = self.lock();
+            g.drain().map(|(k, _)| k).collect()
+        };
+        labels.sort();
+        for label in labels {
+            emit(app, &label, false, 0);
         }
     }
 
@@ -142,63 +237,78 @@ impl UploadProcessingState {
     /// can assert that subsequent `begin` calls during an active
     /// window do not re-stamp the original start time.
     #[cfg(test)]
-    fn started_at_for_test(&self) -> Option<std::time::Instant> {
-        self.inner.lock().expect("upload_processing mutex poisoned").started_at
+    fn started_at_for_test(&self, label: &str) -> Option<std::time::Instant> {
+        self.lock().get(label).and_then(|i| i.started_at)
     }
 
     /// Test-only accessor exposing the internal `stamped_epoch`.
     #[cfg(test)]
-    fn stamped_epoch_for_test(&self) -> Option<u64> {
-        self.inner.lock().expect("upload_processing mutex poisoned").stamped_epoch
+    fn stamped_epoch_for_test(&self, label: &str) -> Option<u64> {
+        self.lock().get(label).and_then(|i| i.stamped_epoch)
     }
 
     /// Test-only entry point that mirrors [`Self::begin`] without
     /// emitting a Tauri event.
     #[cfg(test)]
-    fn begin_for_test(&self, count: u64, current_epoch: u64) {
-        let mut g = self.inner.lock().expect("upload_processing mutex poisoned");
-        g.pending_files = g.pending_files.saturating_add(count);
-        if g.started_at.is_none() {
-            g.started_at = Some(Instant::now());
-            g.stamped_epoch = Some(current_epoch);
+    fn begin_for_test(&self, label: &str, count: u64, current_epoch: u64) {
+        let mut g = self.lock();
+        let entry = g.entry(label.to_string()).or_default();
+        entry.pending_files = entry.pending_files.saturating_add(count);
+        if entry.started_at.is_none() {
+            entry.started_at = Some(Instant::now());
+            entry.stamped_epoch = Some(current_epoch);
         }
     }
 
     /// Test-only entry point that mirrors [`Self::clear_if_session_advanced`]
     /// without emitting a Tauri event.
     #[cfg(test)]
-    fn clear_if_session_advanced_for_test(&self, event_epoch: u64) {
-        let mut g = self.inner.lock().expect("upload_processing mutex poisoned");
-        if let Some(stamped) = g.stamped_epoch {
-            if event_epoch > stamped {
-                g.pending_files = 0;
-                g.started_at = None;
-                g.stamped_epoch = None;
-            }
+    fn clear_if_session_advanced_for_test(&self, label: &str, event_epoch: u64) {
+        let mut g = self.lock();
+        let should_remove = matches!(g.get(label).and_then(|i| i.stamped_epoch), Some(stamped) if event_epoch > stamped);
+        if should_remove {
+            g.remove(label);
         }
     }
 
     /// Test-only entry point that mirrors [`Self::reset`] without
     /// emitting a Tauri event.
     #[cfg(test)]
-    fn reset_for_test(&self) {
-        let mut g = self.inner.lock().expect("upload_processing mutex poisoned");
-        g.pending_files = 0;
-        g.started_at = None;
-        g.stamped_epoch = None;
+    fn reset_for_test(&self, label: &str) {
+        self.lock().remove(label);
+    }
+
+    /// Test-only sorted view of active labels, for asserting
+    /// cross-label isolation invariants.
+    #[cfg(test)]
+    fn active_labels_for_test(&self) -> Vec<String> {
+        let mut labels: Vec<String> = self.lock().keys().cloned().collect();
+        labels.sort();
+        labels
     }
 }
 
 #[derive(serde::Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct UploadProcessingPayload {
+    /// The drive label this banner state belongs to. Frontend uses
+    /// this to route the payload to the matching drive's banner; an
+    /// older single-banner-per-process FE listener would ignore it.
+    label: String,
     active: bool,
     pending_files: u64,
 }
 
-fn emit(app: &tauri::AppHandle, active: bool, pending_files: u64) {
+fn emit(app: &tauri::AppHandle, label: &str, active: bool, pending_files: u64) {
     use tauri::Emitter;
-    let _ = app.emit(crate::sync::events::UPLOAD_PROCESSING, UploadProcessingPayload { active, pending_files });
+    let _ = app.emit(
+        crate::sync::events::UPLOAD_PROCESSING,
+        UploadProcessingPayload {
+            label: label.to_string(),
+            active,
+            pending_files,
+        },
+    );
 }
 
 #[cfg(test)]
@@ -209,33 +319,33 @@ mod tests {
     #[test]
     fn begin_then_clear_with_advanced_epoch_zeros_state() {
         let s = UploadProcessingState::new();
-        s.begin_for_test(3, 1);
-        let (active_before, count_before) = s.snapshot();
+        s.begin_for_test("drive-a", 3, 1);
+        let (active_before, count_before) = s.snapshot_for("drive-a");
         assert!(active_before);
         assert_eq!(count_before, 3);
-        assert_eq!(s.stamped_epoch_for_test(), Some(1));
+        assert_eq!(s.stamped_epoch_for_test("drive-a"), Some(1));
 
-        s.clear_if_session_advanced_for_test(2);
-        let (active_after, count_after) = s.snapshot();
+        s.clear_if_session_advanced_for_test("drive-a", 2);
+        let (active_after, count_after) = s.snapshot_for("drive-a");
         assert!(!active_after);
         assert_eq!(count_after, 0);
-        assert_eq!(s.stamped_epoch_for_test(), None);
+        assert_eq!(s.stamped_epoch_for_test("drive-a"), None);
     }
 
     #[test]
     fn clear_with_same_or_earlier_epoch_is_noop() {
         let s = UploadProcessingState::new();
-        s.begin_for_test(2, 5);
+        s.begin_for_test("drive-a", 2, 5);
         // event_epoch == stamped_epoch — must not clear (the cycle
         // was already running when begin was called).
-        s.clear_if_session_advanced_for_test(5);
-        let (active, count) = s.snapshot();
+        s.clear_if_session_advanced_for_test("drive-a", 5);
+        let (active, count) = s.snapshot_for("drive-a");
         assert!(active, "same-epoch event must not clear");
         assert_eq!(count, 2);
 
         // event_epoch < stamped_epoch — must also not clear.
-        s.clear_if_session_advanced_for_test(4);
-        let (active, count) = s.snapshot();
+        s.clear_if_session_advanced_for_test("drive-a", 4);
+        let (active, count) = s.snapshot_for("drive-a");
         assert!(active, "earlier-epoch event must not clear");
         assert_eq!(count, 2);
     }
@@ -243,9 +353,9 @@ mod tests {
     #[test]
     fn sequential_begins_accumulate() {
         let s = UploadProcessingState::new();
-        s.begin_for_test(4, 1);
-        s.begin_for_test(3, 1);
-        let (active, count) = s.snapshot();
+        s.begin_for_test("drive-a", 4, 1);
+        s.begin_for_test("drive-a", 3, 1);
+        let (active, count) = s.snapshot_for("drive-a");
         assert!(active);
         assert_eq!(count, 7);
     }
@@ -253,8 +363,8 @@ mod tests {
     #[test]
     fn clear_when_inactive_is_noop() {
         let s = UploadProcessingState::new();
-        s.clear_if_session_advanced_for_test(99);
-        let (active, count) = s.snapshot();
+        s.clear_if_session_advanced_for_test("drive-a", 99);
+        let (active, count) = s.snapshot_for("drive-a");
         assert!(!active);
         assert_eq!(count, 0);
     }
@@ -262,28 +372,28 @@ mod tests {
     #[test]
     fn reset_unconditionally_clears() {
         let s = UploadProcessingState::new();
-        s.begin_for_test(5, 7);
-        s.reset_for_test();
-        let (active, count) = s.snapshot();
+        s.begin_for_test("drive-a", 5, 7);
+        s.reset_for_test("drive-a");
+        let (active, count) = s.snapshot_for("drive-a");
         assert!(!active);
         assert_eq!(count, 0);
-        assert_eq!(s.stamped_epoch_for_test(), None);
+        assert_eq!(s.stamped_epoch_for_test("drive-a"), None);
     }
 
     #[test]
     fn second_begin_does_not_restamp_started_at_or_epoch() {
         let s = UploadProcessingState::new();
-        s.begin_for_test(1, 3);
-        let first_stamp = s.started_at_for_test();
-        let first_epoch = s.stamped_epoch_for_test();
+        s.begin_for_test("drive-a", 1, 3);
+        let first_stamp = s.started_at_for_test("drive-a");
+        let first_epoch = s.stamped_epoch_for_test("drive-a");
         assert_eq!(first_epoch, Some(3));
         assert!(first_stamp.is_some());
         std::thread::sleep(Duration::from_millis(2));
         // Second begin uses a different epoch — must not restamp
         // either field while banner is still active.
-        s.begin_for_test(1, 9);
-        let second_stamp = s.started_at_for_test();
-        let second_epoch = s.stamped_epoch_for_test();
+        s.begin_for_test("drive-a", 1, 9);
+        let second_stamp = s.started_at_for_test("drive-a");
+        let second_epoch = s.stamped_epoch_for_test("drive-a");
         assert_eq!(first_stamp, second_stamp, "must not restamp started_at while active");
         assert_eq!(first_epoch, second_epoch, "must not restamp epoch while active");
     }
@@ -295,19 +405,120 @@ mod tests {
     fn overlapping_upload_does_not_prematurely_clear() {
         let s = UploadProcessingState::new();
         // File 1 cycle is running at epoch=1. User adds file.
-        s.begin_for_test(1, 1);
+        s.begin_for_test("drive-a", 1, 1);
         // File 1's chunks fire (still epoch 1) — must not clear.
-        s.clear_if_session_advanced_for_test(1);
-        let (active, _) = s.snapshot();
+        s.clear_if_session_advanced_for_test("drive-a", 1);
+        let (active, _) = s.snapshot_for("drive-a");
         assert!(active, "in-flight cycle's chunks must not clear");
         // File 1's cycle completes (still epoch 1) — must not clear.
-        s.clear_if_session_advanced_for_test(1);
-        let (active, _) = s.snapshot();
+        s.clear_if_session_advanced_for_test("drive-a", 1);
+        let (active, _) = s.snapshot_for("drive-a");
         assert!(active, "in-flight cycle's completion must not clear");
         // File 2's cycle starts (epoch increments to 2) and fires
         // its first chunk — NOW the banner clears.
-        s.clear_if_session_advanced_for_test(2);
-        let (active, _) = s.snapshot();
+        s.clear_if_session_advanced_for_test("drive-a", 2);
+        let (active, _) = s.snapshot_for("drive-a");
         assert!(!active, "newer cycle's chunk should clear");
+    }
+
+    // -----------------------------------------------------------------
+    // Per-label invariants (Task 4.1).
+    // -----------------------------------------------------------------
+
+    /// Bug 4: an active banner on label-A must NOT make
+    /// `is_active_for(label-B)` return `true`. Pre-per-label, the
+    /// global `snapshot()` would have leaked across drives and the
+    /// `SyncStarted` handler would have suppressed the preparing
+    /// widget for drive B.
+    #[test]
+    fn is_active_for_is_per_label() {
+        let s = UploadProcessingState::new();
+        s.begin_for_test("drive-a", 1, 1);
+        assert!(s.is_active_for("drive-a"));
+        assert!(!s.is_active_for("drive-b"), "drive-a's banner must not appear active on drive-b");
+        assert!(!s.is_active_for("unknown"), "unknown label must report inactive");
+    }
+
+    /// Clearing one label's banner must leave the other label's
+    /// entry intact — the original Bug 4 fix has no value if a
+    /// drive-A clear could ripple to drive B.
+    #[test]
+    fn clear_one_label_leaves_others_intact() {
+        let s = UploadProcessingState::new();
+        s.begin_for_test("drive-a", 2, 1);
+        s.begin_for_test("drive-b", 3, 1);
+        s.reset_for_test("drive-a");
+        assert!(!s.is_active_for("drive-a"));
+        assert!(s.is_active_for("drive-b"));
+        assert_eq!(s.snapshot_for("drive-b").1, 3);
+        assert_eq!(s.active_labels_for_test(), vec!["drive-b".to_string()]);
+    }
+
+    /// Epoch gating is per-label: drive-B's epoch advance must not
+    /// clear drive-A's banner, and vice versa.
+    #[test]
+    fn epoch_advance_only_clears_matching_label() {
+        let s = UploadProcessingState::new();
+        s.begin_for_test("drive-a", 1, 5);
+        s.begin_for_test("drive-b", 1, 5);
+        // drive-B's cycle advances — must not touch drive-A.
+        s.clear_if_session_advanced_for_test("drive-b", 6);
+        assert!(s.is_active_for("drive-a"), "drive-a survives drive-b's epoch advance");
+        assert!(!s.is_active_for("drive-b"));
+        // drive-A's cycle advances — must clear drive-A.
+        s.clear_if_session_advanced_for_test("drive-a", 6);
+        assert!(!s.is_active_for("drive-a"));
+    }
+
+    /// Two labels can hold independent stamped epochs: drive-A at
+    /// epoch 3, drive-B at epoch 7, after a sequence of begins
+    /// across an epoch boundary. Validates that the second `begin`
+    /// for an already-active label still does not restamp.
+    #[test]
+    fn independent_stamped_epochs_per_label() {
+        let s = UploadProcessingState::new();
+        s.begin_for_test("drive-a", 1, 3);
+        s.begin_for_test("drive-b", 1, 7);
+        assert_eq!(s.stamped_epoch_for_test("drive-a"), Some(3));
+        assert_eq!(s.stamped_epoch_for_test("drive-b"), Some(7));
+        // Second begin on drive-a at a later epoch must not advance
+        // the epoch — the running window still belongs to the first
+        // begin's cycle.
+        s.begin_for_test("drive-a", 1, 9);
+        assert_eq!(s.stamped_epoch_for_test("drive-a"), Some(3));
+    }
+
+    /// `reset_for_test` on an absent label is a no-op (not a panic).
+    /// Idempotency matters for the IPC error paths in `files.rs`
+    /// that may call `reset` for a label whose `begin` was skipped
+    /// (e.g. zero-file folder upload).
+    #[test]
+    fn reset_for_unknown_label_is_noop() {
+        let s = UploadProcessingState::new();
+        s.reset_for_test("never-began");
+        assert!(s.active_labels_for_test().is_empty());
+        // Still valid to begin afterward.
+        s.begin_for_test("never-began", 1, 1);
+        assert!(s.is_active_for("never-began"));
+    }
+
+    /// Re-entrancy guardrail (parallels `PreparingState`).
+    ///
+    /// Every public method MUST release the inner mutex before
+    /// returning so the bridge can call them in tight sequence on
+    /// the same thread. `std::sync::Mutex` is non-reentrant — a
+    /// refactor that extended the guard's lifetime (e.g. returning
+    /// the guard alongside the value) would deadlock at runtime.
+    #[test]
+    fn write_then_read_does_not_deadlock_in_sequence() {
+        let s = UploadProcessingState::new();
+        s.begin_for_test("drive-a", 1, 1);
+        // Each of the following reacquires the inner mutex. A
+        // regression that broke the lock release would surface as
+        // the second call blocking indefinitely.
+        assert!(s.is_active_for("drive-a"));
+        assert_eq!(s.snapshot_for("drive-a"), (true, 1));
+        s.reset_for_test("drive-a");
+        assert!(!s.is_active_for("drive-a"));
     }
 }

--- a/src-tauri/src/sync/upload_processing.rs
+++ b/src-tauri/src/sync/upload_processing.rs
@@ -75,15 +75,44 @@
 //! the load-bearing re-entrancy invariant from the bridge handler
 //! that calls a write method and then re-enters this module via
 //! `emit_snapshot` → `ProgressSnapshot` → reads.
+//!
+//! ## Watchdog (Task 4.2)
+//!
+//! [`spawn_watchdog`] starts a background tokio task that periodically
+//! scans the map and clears entries whose `last_set_at` is older than
+//! [`BANNER_WATCHDOG_TIMEOUT`]. This is the time-based safety net for
+//! the case where a sync cycle never starts (e.g., the drive is
+//! queued behind another drive's per-drive mutex) — without it, the
+//! banner sat forever until app restart (original Bug 1 symptom: the
+//! "2-minute stuck toast" report). The watchdog complements, never
+//! replaces, the epoch-gated `clear_if_session_advanced` and the
+//! explicit `reset` / `reset_all` paths.
 
 use std::collections::HashMap;
-use std::sync::{Mutex, MutexGuard};
-use std::time::Instant;
+use std::sync::{Mutex, MutexGuard, Weak};
+use std::time::{Duration, Instant};
 
-/// Per-label state held inside the `HashMap`. Layout is unchanged from
-/// the pre-per-label design — only the surrounding ownership shape
-/// moved from one direct field to a map entry.
-#[derive(Default)]
+/// How long an entry may sit without a progress signal before the
+/// background watchdog clears it.
+///
+/// **Why 60s:** Long enough to absorb normal queueing (a drive can sit
+/// behind another drive's per-drive sync mutex for tens of seconds on
+/// a slow upload), short enough that a truly stuck banner does not
+/// burn minutes of user attention. The pre-watchdog behavior was
+/// "wait for app restart" — any finite timeout is a strict
+/// improvement, and 60s is the plan's recommended value.
+pub const BANNER_WATCHDOG_TIMEOUT: Duration = Duration::from_mins(1);
+
+/// How often the watchdog scans the map.
+///
+/// **Why 10s:** Lower would burn CPU walking an almost-always-empty
+/// `HashMap`; higher would let a stuck banner linger past the 60s
+/// timeout by up to the scan interval. 10s caps observable lateness
+/// at ~70s (timeout + one scan period), which is well within the
+/// "noticeable but not painful" range.
+pub const BANNER_WATCHDOG_SCAN_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Per-label state held inside the `HashMap`.
 struct UploadProcessingInner {
     pending_files: u64,
     started_at: Option<Instant>,
@@ -93,6 +122,33 @@ struct UploadProcessingInner {
     /// wall-clock timestamp comparison. `None` exactly when
     /// `started_at` is `None`; the two fields move together.
     stamped_epoch: Option<u64>,
+    /// Refreshed on `begin` and on every `clear_if_session_advanced`
+    /// call (whether or not it cleared — every event counts as a
+    /// progress signal). Read by [`UploadProcessingState::drain_expired`]
+    /// to gate the watchdog's auto-clear against the
+    /// [`BANNER_WATCHDOG_TIMEOUT`] window.
+    ///
+    /// Stored unconditionally (no `Option`) because every code path
+    /// that creates an entry initializes this field — the type encodes
+    /// that invariant rather than relying on documentation.
+    last_set_at: Instant,
+}
+
+impl UploadProcessingInner {
+    /// Construct a fresh entry with `last_set_at` stamped to `now`.
+    ///
+    /// Centralises the construction so a future field addition
+    /// can't introduce a half-initialised entry through
+    /// `HashMap::entry().or_default()` (which is exactly why this
+    /// struct intentionally does NOT derive `Default`).
+    fn new(now: Instant) -> Self {
+        Self {
+            pending_files: 0,
+            started_at: None,
+            stamped_epoch: None,
+            last_set_at: now,
+        }
+    }
 }
 
 /// Map of drive label → "processing window" state.
@@ -168,13 +224,21 @@ impl UploadProcessingState {
     /// in this window."
     pub fn begin(&self, app: &tauri::AppHandle, label: &str, count: u64, current_epoch: u64) {
         let pending = {
+            let now = Instant::now();
             let mut g = self.lock();
-            let entry = g.entry(label.to_string()).or_default();
+            let entry = g.entry(label.to_string()).or_insert_with(|| UploadProcessingInner::new(now));
             entry.pending_files = entry.pending_files.saturating_add(count);
+            // First begin in a window stamps started_at + epoch.
+            // Subsequent begins inside an already-active window must
+            // not restamp those (epoch-gating depends on the first
+            // begin's epoch surviving). last_set_at IS refreshed on
+            // every begin so the watchdog's "no progress for 60s"
+            // timer resets when the user clicks Upload again.
             if entry.started_at.is_none() {
-                entry.started_at = Some(Instant::now());
+                entry.started_at = Some(now);
                 entry.stamped_epoch = Some(current_epoch);
             }
+            entry.last_set_at = now;
             entry.pending_files
         };
         emit(app, label, true, pending);
@@ -183,20 +247,27 @@ impl UploadProcessingState {
     /// Clear `label`'s entry if `event_epoch > stamped_epoch`. No-op
     /// when the label has no entry or when the event is from a cycle
     /// that was already running at `begin` time. Idempotent.
+    ///
+    /// Side-effect: every call refreshes `last_set_at` on the
+    /// surviving entry. This is what makes the call site (per upload
+    /// chunk, `SyncCompleted`, `SyncError`) act as a "progress signal"
+    /// from the watchdog's perspective — events from the same cycle
+    /// extend the window even though the epoch gate keeps the banner
+    /// up. Without this, an in-flight cycle whose chunks keep firing
+    /// at the original epoch would have its banner cleared by the
+    /// watchdog despite progress being visible.
     pub fn clear_if_session_advanced(&self, app: &tauri::AppHandle, label: &str, event_epoch: u64) {
         let did_clear = {
+            let now = Instant::now();
             let mut g = self.lock();
-            // Inspect the entry without holding `&mut` on the map past
-            // the decision: when the gate fires we want to `remove`
-            // (not just zero the fields) so the membership invariant
-            // is preserved. `Entry::occupied` borrows the map mutably
-            // for the lifetime of the entry; we drop the borrow before
-            // calling `remove`.
             let should_remove = matches!(g.get(label).and_then(|i| i.stamped_epoch), Some(stamped) if event_epoch > stamped);
             if should_remove {
                 g.remove(label);
                 true
             } else {
+                if let Some(entry) = g.get_mut(label) {
+                    entry.last_set_at = now;
+                }
                 false
             }
         };
@@ -212,6 +283,41 @@ impl UploadProcessingState {
         if did_clear {
             emit(app, label, false, 0);
         }
+    }
+
+    /// Remove every entry whose `last_set_at` is more than
+    /// [`BANNER_WATCHDOG_TIMEOUT`] before `now`. Returns the sorted
+    /// list of cleared labels so the caller can emit one
+    /// `{ active: false, pending_files: 0 }` event per cleared banner
+    /// outside the lock.
+    ///
+    /// Pure with respect to `now` — the caller injects the timestamp
+    /// rather than reading the wall clock here. That keeps the
+    /// watchdog tests timestamp-precise without requiring
+    /// `tokio::time::pause` to also affect [`std::time::Instant::now`]
+    /// (which it does not on stable tokio).
+    ///
+    /// The `std::sync::MutexGuard` is dropped before this function
+    /// returns; callers may freely `.await` on the returned `Vec`
+    /// without holding the lock across the await point (axiom
+    /// `Async Lock Hygiene`).
+    fn drain_expired(&self, now: Instant) -> Vec<String> {
+        let mut g = self.lock();
+        let stale: Vec<String> = g
+            .iter()
+            .filter_map(|(label, entry)| {
+                now.checked_duration_since(entry.last_set_at)
+                    .filter(|elapsed| *elapsed >= BANNER_WATCHDOG_TIMEOUT)
+                    .map(|_| label.clone())
+            })
+            .collect();
+        for label in &stale {
+            g.remove(label);
+        }
+        drop(g);
+        let mut stale = stale;
+        stale.sort();
+        stale
     }
 
     /// Unconditional clear of every label. Used by logout /
@@ -251,12 +357,43 @@ impl UploadProcessingState {
     /// emitting a Tauri event.
     #[cfg(test)]
     fn begin_for_test(&self, label: &str, count: u64, current_epoch: u64) {
+        self.begin_for_test_at(Instant::now(), label, count, current_epoch);
+    }
+
+    /// Test-only entry point that mirrors [`Self::begin`] but with an
+    /// injectable `Instant` for the `last_set_at` field. Exposes the
+    /// timestamp axis to watchdog tests that must construct
+    /// known-old entries.
+    ///
+    /// Exposed as `pub` + `#[doc(hidden)]` (mirroring `snapshot_for`)
+    /// so the integration test crate in `tests/` can drive it without
+    /// needing `pub(crate)` visibility leaks. The `#[doc(hidden)]`
+    /// keeps it out of rustdoc; the name + path keep it discoverable
+    /// only to tests that already know the watchdog internals.
+    #[doc(hidden)]
+    pub fn begin_for_test_at(&self, now: Instant, label: &str, count: u64, current_epoch: u64) {
         let mut g = self.lock();
-        let entry = g.entry(label.to_string()).or_default();
+        let entry = g.entry(label.to_string()).or_insert_with(|| UploadProcessingInner::new(now));
         entry.pending_files = entry.pending_files.saturating_add(count);
         if entry.started_at.is_none() {
-            entry.started_at = Some(Instant::now());
+            entry.started_at = Some(now);
             entry.stamped_epoch = Some(current_epoch);
+        }
+        entry.last_set_at = now;
+    }
+
+    /// Test-only entry point that mirrors [`Self::clear_if_session_advanced`]
+    /// without emitting a Tauri event. Allows the watchdog tests to
+    /// drive the "progress signal refreshes last_set_at" path with a
+    /// known `Instant`.
+    #[doc(hidden)]
+    pub fn clear_if_session_advanced_for_test_at(&self, now: Instant, label: &str, event_epoch: u64) {
+        let mut g = self.lock();
+        let should_remove = matches!(g.get(label).and_then(|i| i.stamped_epoch), Some(stamped) if event_epoch > stamped);
+        if should_remove {
+            g.remove(label);
+        } else if let Some(entry) = g.get_mut(label) {
+            entry.last_set_at = now;
         }
     }
 
@@ -264,11 +401,15 @@ impl UploadProcessingState {
     /// without emitting a Tauri event.
     #[cfg(test)]
     fn clear_if_session_advanced_for_test(&self, label: &str, event_epoch: u64) {
-        let mut g = self.lock();
-        let should_remove = matches!(g.get(label).and_then(|i| i.stamped_epoch), Some(stamped) if event_epoch > stamped);
-        if should_remove {
-            g.remove(label);
-        }
+        self.clear_if_session_advanced_for_test_at(Instant::now(), label, event_epoch);
+    }
+
+    /// Test-only entry point that exposes [`Self::drain_expired`] to
+    /// the integration test crate. Same `pub` + `#[doc(hidden)]` shape
+    /// as the other watchdog helpers.
+    #[doc(hidden)]
+    pub fn drain_expired_for_test(&self, now: Instant) -> Vec<String> {
+        self.drain_expired(now)
     }
 
     /// Test-only entry point that mirrors [`Self::reset`] without
@@ -309,6 +450,46 @@ fn emit(app: &tauri::AppHandle, label: &str, active: bool, pending_files: u64) {
             pending_files,
         },
     );
+}
+
+/// Spawn the per-process upload-processing watchdog.
+///
+/// Called once at app setup (after `AppState` is constructed). The
+/// task wakes every [`BANNER_WATCHDOG_SCAN_INTERVAL`] and clears any
+/// entry whose `last_set_at` is older than [`BANNER_WATCHDOG_TIMEOUT`].
+///
+/// **Ownership:** the task holds a `Weak<UploadProcessingState>` so it
+/// does NOT keep the state alive past app shutdown. If the upgrade
+/// fails (the `Arc` was dropped), the loop exits cleanly. The
+/// `AppHandle` is `Clone` and cheap; one clone per spawn is fine.
+///
+/// **Concurrency:** the loop awaits a `tokio::time::sleep` between
+/// scans. The `std::sync::Mutex` inside `UploadProcessingState` is
+/// locked only by [`UploadProcessingState::drain_expired`], which
+/// drops its guard before returning a `Vec<String>`. The emit loop
+/// runs on the owned `Vec`, so no `MutexGuard` exists during the
+/// `.await` (axiom `Async Lock Hygiene`).
+pub fn spawn_watchdog(state: Weak<UploadProcessingState>, app: tauri::AppHandle) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(BANNER_WATCHDOG_SCAN_INTERVAL).await;
+            let Some(state) = state.upgrade() else {
+                // AppState has been dropped; nothing left to watch.
+                tracing::debug!("upload_processing watchdog: state dropped, exiting");
+                break;
+            };
+            let cleared = state.drain_expired(Instant::now());
+            for label in cleared {
+                tracing::warn!(
+                    target: "hippius_desktop::sync::upload_processing",
+                    label = %label,
+                    timeout_secs = BANNER_WATCHDOG_TIMEOUT.as_secs(),
+                    "auto-clearing stale upload-processing banner",
+                );
+                emit(&app, &label, false, 0);
+            }
+        }
+    });
 }
 
 #[cfg(test)]

--- a/src-tauri/src/utils/schema.rs
+++ b/src-tauri/src/utils/schema.rs
@@ -15,8 +15,9 @@ use tracing::{debug, info, warn};
 const EXPECTED_TABLES: &[&str] = &[
     // Declarative TABLE_SCHEMAS block (1 table)
     "sub_accounts",
-    // Imperative CREATE TABLE statements (16 tables)
+    // Imperative CREATE TABLE statements (17 tables)
     "sync_paths",
+    "sync_intent",
     "wss_endpoint",
     "security_scoped_bookmarks",
     "auth_session",
@@ -239,6 +240,45 @@ pub async fn ensure_table_schema(pool: &SqlitePool) -> Result<(), sqlx::Error> {
             info!("sync_paths constraint migration completed");
         }
     }
+
+    // sync_intent — persistent upload-intent manifest for the sync widget.
+    //
+    // The sync widget previously reset progress on app restart after a partial
+    // bulk upload (drag 10 GB → close at 5 GB → reopen shows "0 / 5 GB" instead
+    // of "5 / 10 GB") because the in-memory snapshot was the only source of
+    // truth. This table is the durable shadow: every queued file is recorded
+    // here when its plan lands, and `completed_at_ms` is set when the file
+    // finishes uploading. The composite primary key `(account_id, drive_label,
+    // relative_path)` makes "same file enqueued twice for the same drive"
+    // unrepresentable at the storage layer; subsequent tasks decide the
+    // ON CONFLICT policy when wiring `record_plan`.
+    //
+    // `completed_at_ms` is NULLABLE on purpose: NULL is the canonical "still
+    // pending" marker. The covering index `(account_id, drive_label,
+    // completed_at_ms)` keeps the per-drive "pending count" and totals queries
+    // (Task 2) off a full table scan as the table grows across long-running
+    // sync sessions. `added_at_ms` is non-NULL so age-based prune policies have
+    // a deterministic ordering key.
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS sync_intent (
+            account_id      TEXT    NOT NULL,
+            drive_label     TEXT    NOT NULL,
+            relative_path   TEXT    NOT NULL,
+            size_bytes      INTEGER NOT NULL,
+            added_at_ms     INTEGER NOT NULL,
+            completed_at_ms INTEGER,
+            PRIMARY KEY (account_id, drive_label, relative_path)
+        )",
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_sync_intent_drive
+            ON sync_intent (account_id, drive_label, completed_at_ms)",
+    )
+    .execute(&mut *tx)
+    .await?;
 
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS wss_endpoint (

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hippius",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "identifier": "hippius.com",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tests/eligibility_enforcement.rs
+++ b/src-tauri/tests/eligibility_enforcement.rs
@@ -33,6 +33,12 @@ use tokio::net::TcpListener;
 use tauri_project_lib::app_state::AppState;
 use tauri_project_lib::auth::auth_session_repo::{UpsertSession, upsert};
 use tauri_project_lib::billing::eligibility::{InsufficientCreditsAction, require_eligible};
+// Each `require_eligible` call below uses `bytes = 0` because these
+// cases assert the static-threshold layer that is the floor for every
+// upload action regardless of payload size (legacy `> 0` semantics).
+// The bytes-priced layer is covered by the dedicated regression test
+// in `tests/hippius_eligibility_pricing.rs`, which spins up the same
+// mock billing API with carefully chosen byte counts.
 use tauri_project_lib::error::{AppError, NotReadyKind};
 
 /// Shared state for the mock balance endpoint. The credit value is
@@ -150,7 +156,7 @@ async fn require_eligible_enforces_thresholds_against_mock_billing_api() {
         InsufficientCreditsAction::FolderSync,
         InsufficientCreditsAction::VmCreation,
     ] {
-        let err = require_eligible(&state, account_id, action)
+        let err = require_eligible(&state, account_id, action, 0)
             .await
             .expect_err(&format!("zero balance must reject {action:?}"));
         match err {
@@ -167,16 +173,16 @@ async fn require_eligible_enforces_thresholds_against_mock_billing_api() {
     // client. The other three actions must pass.
     // -----------------------------------------------------------------
     *mock.balance.lock().unwrap() = "5".to_string();
-    require_eligible(&state, account_id, InsufficientCreditsAction::FileUpload)
+    require_eligible(&state, account_id, InsufficientCreditsAction::FileUpload, 0)
         .await
         .expect("5 credits passes FileUpload `> 0` gate");
-    require_eligible(&state, account_id, InsufficientCreditsAction::FolderUpload)
+    require_eligible(&state, account_id, InsufficientCreditsAction::FolderUpload, 0)
         .await
         .expect("5 credits passes FolderUpload `> 0` gate");
-    require_eligible(&state, account_id, InsufficientCreditsAction::FolderSync)
+    require_eligible(&state, account_id, InsufficientCreditsAction::FolderSync, 0)
         .await
         .expect("5 credits passes FolderSync `> 0` gate");
-    let err = require_eligible(&state, account_id, InsufficientCreditsAction::VmCreation)
+    let err = require_eligible(&state, account_id, InsufficientCreditsAction::VmCreation, 0)
         .await
         .expect_err("5 credits must NOT pass VmCreation ≥10 gate");
     assert!(
@@ -200,7 +206,7 @@ async fn require_eligible_enforces_thresholds_against_mock_billing_api() {
         InsufficientCreditsAction::FolderSync,
         InsufficientCreditsAction::VmCreation,
     ] {
-        require_eligible(&state, account_id, action)
+        require_eligible(&state, account_id, action, 0)
             .await
             .unwrap_or_else(|e| panic!("100 credits must pass {action:?}, got {e:?}"));
     }
@@ -211,12 +217,12 @@ async fn require_eligible_enforces_thresholds_against_mock_billing_api() {
     // (10 passes, 9.99 fails). The `> 0` actions also have to pass.
     // -----------------------------------------------------------------
     *mock.balance.lock().unwrap() = "10".to_string();
-    require_eligible(&state, account_id, InsufficientCreditsAction::VmCreation)
+    require_eligible(&state, account_id, InsufficientCreditsAction::VmCreation, 0)
         .await
         .expect("exactly 10 credits passes the VmCreation ≥10 gate");
 
     *mock.balance.lock().unwrap() = "9.99".to_string();
-    let err = require_eligible(&state, account_id, InsufficientCreditsAction::VmCreation)
+    let err = require_eligible(&state, account_id, InsufficientCreditsAction::VmCreation, 0)
         .await
         .expect_err("9.99 credits must NOT pass the VmCreation ≥10 gate");
     assert!(

--- a/src-tauri/tests/hippius_402_e2e.rs
+++ b/src-tauri/tests/hippius_402_e2e.rs
@@ -185,12 +185,19 @@ fn end_cycle(sync: &SyncRunner) {
 /// - `sync.pending_activity` for `SyncActivityAction::Uploaded` rows
 ///   (must be empty after a 402, exactly one after a 200),
 /// - `CreditsExhaustedState::count_for` for the per-label banner count.
-#[test]
+///
+/// Runs under `#[tokio::test]` because the 200-cycle invocation of
+/// `build_file_synced_callback` with `action = "uploaded"` now fires a
+/// fire-and-forget `tokio::spawn` for the intent manifest mark
+/// (Task 6). Without a Tokio reactor `tokio::spawn` panics. The spawn
+/// falls through the "no `AppState` managed" branch, leaving the 402
+/// banner / activity assertions below unchanged.
+#[tokio::test]
 #[expect(
     clippy::too_many_lines,
     reason = "Three sequential sync cycles, each with its own setup + multi-invariant assertions, are deliberately kept in one function so the cycle ordering is readable end-to-end. Splitting into helpers would require sharing `sync`/`banner_state`/`label` across function boundaries with no abstraction win."
 )]
-fn three_cycle_402_402_200_full_chain() {
+async fn three_cycle_402_402_200_full_chain() {
     let sync = make_sync_runner();
     let label: Arc<str> = Arc::from("drive-402-e2e");
     let banner_state = CreditsExhaustedState::new();
@@ -378,7 +385,13 @@ fn three_cycle_402_402_200_full_chain() {
     // ──────────────────────────────────────────────────────────────────
     seed_one_upload(&sync, uploading_file("first.txt", &label, 2048, 2048), "cycle-3");
 
-    let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+    // `MockRuntime` AppHandle is enough — the intent-mark spawn inside
+    // the callback uses fire-and-forget semantics (no `AppState` managed
+    // here means it logs and drops, leaving the activity enqueue and
+    // cache write — the behavior this test pins — unaffected). Tauri's
+    // `test` feature is enabled via dev-deps for this binary.
+    let app = tauri::test::mock_app().handle().clone();
+    let callback = build_file_synced_callback(&app, sync.clone(), Arc::clone(&label));
     // 32-byte path hash keyed with 'a' so the hex decode succeeds —
     // matches the shape `hippius_activity_truth.rs` uses. A bad hex
     // would short-circuit the callback before `upsert_synced_path` and

--- a/src-tauri/tests/hippius_402_e2e.rs
+++ b/src-tauri/tests/hippius_402_e2e.rs
@@ -1,0 +1,486 @@
+//! End-to-end regression for the 402 -> 402 -> 200 sync flow.
+//!
+//! Phase 5 / Task 5.1 of `docs/plans/2026-05-13-sync-402-data-integrity.md`.
+//!
+//! # Why this test exists
+//!
+//! The original "phantom uploads on 402" bug was a multi-component
+//! conspiracy: a byte-progress enqueue lying about server confirmation,
+//! a planner that kept re-attempting 402'd uploads forever, a snapshot
+//! status that rendered as "Completed" instead of "Error", a bridge
+//! that didn't emit a credits-exhausted banner, and a FE that didn't
+//! know how to surface any of it. Phase 1-4 fixed each link individually
+//! and pinned each link with its own focused test:
+//!
+//! * `hippius_activity_truth.rs` — no fake `Uploaded` in the activity log
+//! * `hippius_snapshot_failure_status.rs` — snapshot row reaches FE as `"error"`
+//! * `hippius_file_failed_event.rs` — `SyncEvent::FileFailed` translates correctly
+//! * `hippius_credits_exhausted_event.rs` — per-label banner counter is correct
+//! * `hcfs-client/tests/upload_retry_policy.rs` — server-side 402-skip-set lifecycle
+//!
+//! This file ties the chain together: a scripted three-cycle scenario
+//! that simulates the *desktop's reaction* to a 402 -> 402 -> 200 server
+//! sequence, asserting each cycle's expected end-state at the public-API
+//! level. If any future refactor breaks the chain end-to-end while every
+//! per-component test still passes, this test fires.
+//!
+//! # Why Option B (orchestration via public callbacks)
+//!
+//! Option A (real wiremock + real `Drive`) would duplicate the existing
+//! `hcfs-client/tests/upload_retry_policy.rs` coverage and depend on a
+//! real Tauri runtime to capture the bridge's `app.emit` calls — neither
+//! of which adds signal beyond what hcfs-client's wiremock test and the
+//! per-component desktop tests already pin. The plan explicitly permits
+//! Option B for this reason.
+//!
+//! What this test exercises end-to-end:
+//!
+//! 1. The exact mutator sequence hcfs-client invokes against the desktop
+//!    on each per-file event (`build_file_synced_callback` for 200,
+//!    `mark_file_failed` for 402 — the latter is what
+//!    `build_file_failed_callback` calls internally).
+//! 2. The exact mutator sequence the desktop bridge runs against
+//!    `CreditsExhaustedState` on a `SyncEvent::FileFailed { kind:
+//!    InsufficientBalance }` event (the bridge code itself is one
+//!    `if let` + `app.emit`, both trivially correct given correct state).
+//! 3. The cycle-boundary contract: `SyncStarted` clears the
+//!    credits-exhausted counter so cycle 3's banner count reflects only
+//!    cycle 3, and the absence of new failures in cycle 2 leaves the
+//!    snapshot's `failed_files` aggregate at zero for new files.
+//!
+//! # What this test does NOT do
+//!
+//! - It does NOT spin up wiremock or a real `Drive`. hcfs-client's own
+//!   `upload_retry_policy.rs` already pins the server-facing 402-skip-set
+//!   lifecycle (cycle 2 skips the POST, cycle 3 re-attempts after a
+//!   zero-failure cycle clears the set). Duplicating that here would
+//!   couple this test to hcfs-server's wire shape unnecessarily.
+//! - It does NOT instantiate a real Tauri `AppHandle`. The bridge's
+//!   `app.emit` step is one line conditional on the state mutation this
+//!   test pins directly.
+//! - It does NOT assert that `hcfs_sync_error` is NOT emitted by reading
+//!   an event channel (no event channel exists in this test). Instead it
+//!   pins the structural reason no `SyncError` event fires for a per-file
+//!   402: an `InsufficientBalance` failure surfaces through
+//!   `SyncEvent::FileFailed`, never through `SyncEvent::SyncError`, and
+//!   `TauriSyncBridge::on_event` keys on the variant, not the message.
+
+use std::sync::Arc;
+
+use hcfs_client::engine::events::FileFailureKind;
+use hcfs_client::engine::progress::state::{FileAction, FileStatus, SyncFile, SyncSession};
+use hcfs_client::engine::runner::SyncRunner;
+use hcfs_client::engine::types::SyncActivityAction;
+use hcfs_client::engine::{NoopCallbacks, NoopEventHandler};
+
+use tauri_project_lib::sync::credits_exhausted::CreditsExhaustedState;
+use tauri_project_lib::sync::events::{CANCELLED_MARKER, FileFailureKindPayload};
+use tauri_project_lib::sync::lifecycle::build_file_synced_callback;
+use tauri_project_lib::sync::progress::{FileProgressStatus, mark_file_failed};
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/// Build a `SyncRunner` using only the public hcfs-client constructor.
+///
+/// Mirrors `make_sync_runner` in `hippius_activity_truth.rs` and
+/// `hippius_file_failed_event.rs`. Duplicated rather than shared via a
+/// `mod common;` re-export because each integration test crate gets its
+/// own translation unit and sharing through a `pub(crate)` shim would
+/// violate the project's "integration tests use only the public API"
+/// rule (`src-tauri/CLAUDE.md`).
+fn make_sync_runner() -> Arc<SyncRunner> {
+    Arc::new(SyncRunner::new(
+        Arc::new(NoopEventHandler),
+        Arc::new(NoopCallbacks),
+        reqwest::Client::new(),
+    ))
+}
+
+/// Build a `SyncFile` mid-upload: `status == Uploading` with `transferred`
+/// bytes accounted for. This is the shape the per-file `mark_file_failed`
+/// path sees when a 402 arrives after the request body has started
+/// streaming.
+fn uploading_file(path: &str, label: &str, total: u64, transferred: u64) -> SyncFile {
+    SyncFile {
+        id: Arc::from(path),
+        path: Arc::from(path),
+        file_name: Arc::from(path.rsplit('/').next().unwrap_or(path)),
+        label: Arc::from(label),
+        action: FileAction::Upload,
+        status: FileStatus::Uploading,
+        progress: ((transferred * 100) / total.max(1)) as u32,
+        bytes_encrypted: total,
+        bytes_transferred: transferred,
+        total_bytes: total,
+        resumed_from_bytes: None,
+        started_at: 0,
+        completed_at: None,
+        error: None,
+    }
+}
+
+/// Seed `current_session` with a single in-flight file expecting one
+/// upload. Mirrors what hcfs-client's planner does at the start of a
+/// cycle: it counts expected uploads and registers each file as
+/// `Pending` / `Uploading` before any per-file event fires.
+fn seed_one_upload(sync: &SyncRunner, file: SyncFile, session_id: &'static str) {
+    let mut state = sync.progress.lock_state();
+    let mut files = std::collections::HashMap::new();
+    files.insert(file.path.to_string(), file);
+    state.current_session = Some(SyncSession {
+        session_id: Arc::from(session_id),
+        started_at: 0,
+        completed_at: None,
+        is_active: true,
+        expected_uploads: 1,
+        expected_downloads: 0,
+        expected_local_deletes: 0,
+        expected_remote_deletes: 0,
+        files,
+    });
+}
+
+/// Tear down `current_session` so the next cycle starts from a clean
+/// slate. Mirrors what `finalize_session_for_label` does in hcfs-client
+/// at end-of-cycle (the runner moves the session into history and
+/// builds a new one on the next `SyncStarted`).
+///
+/// This is the cycle-boundary the test crosses three times. Using
+/// `lock_state` (the public progress-tracker API) is the same ingestion
+/// path the production runner uses — a refactor that removes or renames
+/// it breaks this test.
+fn end_cycle(sync: &SyncRunner) {
+    let mut state = sync.progress.lock_state();
+    state.current_session = None;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// The E2E test
+// ─────────────────────────────────────────────────────────────────────
+
+/// Three-cycle 402 -> 402 -> 200 simulation, asserting every invariant
+/// from `docs/plans/2026-05-13-sync-402-data-integrity.md` Task 5.1
+/// Step 2.
+///
+/// Each cycle:
+/// 1. Begins with `seed_one_upload` (the planner's "session is live"
+///    state for that file).
+/// 2. Runs either the failure path (`mark_file_failed` +
+///    `CreditsExhaustedState::record_failure` — what hcfs-client calls
+///    via the `on_file_failed` callback and what the bridge does on
+///    `SyncEvent::FileFailed { kind: InsufficientBalance }`) OR the
+///    success path (`build_file_synced_callback` closure invocation —
+///    what hcfs-client calls via `on_file_synced` after a 2xx).
+/// 3. Ends with `end_cycle` (the runner's `finalize_session_for_label`
+///    moves the session into history) AND, when no failures occurred
+///    in the cycle, a `CreditsExhaustedState::clear` call (the bridge's
+///    `SyncStarted`-handler resets the per-label counter on next cycle).
+///
+/// The end-of-cycle assertions inspect:
+/// - `sync.progress.build_snapshot()` for `failed_files` and per-row
+///   `status == FileProgressStatus::Error` (cycle 1) or `Completed`
+///   (cycle 3),
+/// - `sync.pending_activity` for `SyncActivityAction::Uploaded` rows
+///   (must be empty after a 402, exactly one after a 200),
+/// - `CreditsExhaustedState::count_for` for the per-label banner count.
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Three sequential sync cycles, each with its own setup + multi-invariant assertions, are deliberately kept in one function so the cycle ordering is readable end-to-end. Splitting into helpers would require sharing `sync`/`banner_state`/`label` across function boundaries with no abstraction win."
+)]
+fn three_cycle_402_402_200_full_chain() {
+    let sync = make_sync_runner();
+    let label: Arc<str> = Arc::from("drive-402-e2e");
+    let banner_state = CreditsExhaustedState::new();
+
+    // ──────────────────────────────────────────────────────────────────
+    // Cycle 1: server returns 402.
+    //
+    // Expected end state:
+    //   - snapshot row for the file has status = Error
+    //   - snapshot.failed_files == 1
+    //   - no SyncActivityAction::Uploaded item in pending_activity
+    //   - banner count for the label == 1
+    //   - NO SyncError surfaces — the file's failure flows through
+    //     SyncEvent::FileFailed, not SyncEvent::SyncError, and the
+    //     bridge keys on the variant. We pin this structurally by
+    //     asserting the failure-kind's display form does NOT match
+    //     CANCELLED_MARKER (the only string the bridge silently drops),
+    //     i.e. the failure is observable, not silently dropped.
+    // ──────────────────────────────────────────────────────────────────
+    seed_one_upload(&sync, uploading_file("first.txt", &label, 2048, 1024), "cycle-1");
+
+    // Simulate hcfs-client invoking `on_file_failed` with an
+    // `InsufficientBalance` kind. The desktop's `build_file_failed_callback`
+    // closure calls `mark_file_failed` with the kind's debug form.
+    let cycle1_kind = FileFailureKind::InsufficientBalance {
+        balance_cents: 33,
+        required_cents: 138,
+    };
+    mark_file_failed(&sync, "first.txt", &format!("{cycle1_kind:?}")).expect("cycle 1: mark_file_failed must succeed on a well-formed session");
+
+    // Simulate the bridge consuming `SyncEvent::FileFailed { kind:
+    // InsufficientBalance, .. }` — record_failure is what fires the
+    // hcfs_credits_exhausted banner emit (the actual app.emit is one
+    // `if let` away in the bridge and trivially correct given the
+    // counter post-increment value this returns).
+    let cycle1_banner_count = banner_state.record_failure(&label);
+    assert_eq!(
+        cycle1_banner_count, 1,
+        "cycle 1: first InsufficientBalance must produce banner file_count = 1"
+    );
+
+    // Pin the structural reason no `hcfs_sync_error` event fires for
+    // this 402: the failure kind's Debug form is observable (used for
+    // the snapshot row's `error` field), and it does NOT match the
+    // CANCELLED_MARKER constant that the bridge silently drops. So a
+    // sync-level error would have to come from `SyncError::Cancelled`
+    // or another variant — neither of which a 402 produces.
+    let cycle1_error_msg = format!("{cycle1_kind:?}");
+    assert_ne!(
+        cycle1_error_msg, CANCELLED_MARKER,
+        "402 failure debug-render must NOT collide with the cancel marker; \
+         otherwise the bridge would silently drop the failure"
+    );
+
+    // Translate the kind through the wire-format adapter to confirm
+    // the FE's discriminated union sees `insufficientBalance` — the
+    // exact tag the FE's banner key dispatch needs.
+    let payload = FileFailureKindPayload::from(&cycle1_kind);
+    let payload_json = serde_json::to_value(&payload).expect("FileFailureKindPayload serialises — it crosses IPC");
+    assert_eq!(
+        payload_json.get("kind").and_then(|v| v.as_str()),
+        Some("insufficientBalance"),
+        "cycle 1: wire payload must tag as `insufficientBalance` so the FE banner fires"
+    );
+
+    {
+        let snapshot = sync.progress.build_snapshot();
+        let row = snapshot
+            .files
+            .iter()
+            .find(|f| f.path.as_ref() == "first.txt")
+            .expect("cycle 1: seeded file must survive in snapshot");
+        assert_eq!(row.status, FileProgressStatus::Error, "cycle 1: snapshot row must be Error after a 402");
+        assert_eq!(
+            row.error.as_deref(),
+            Some(cycle1_error_msg.as_str()),
+            "cycle 1: snapshot row's error field must carry the failure kind"
+        );
+        assert_eq!(snapshot.failed_files, 1, "cycle 1: snapshot.failed_files aggregate must agree");
+
+        let json = serde_json::to_value(&snapshot).expect("snapshot serialises — it crosses Tauri IPC");
+        let files = json
+            .get("files")
+            .and_then(serde_json::Value::as_array)
+            .expect("snapshot.files must be a JSON array");
+        let err_row = files
+            .iter()
+            .find(|f| f.get("status").and_then(|s| s.as_str()) == Some("error"))
+            .expect("cycle 1: wire JSON must contain at least one row with status=\"error\"");
+        assert_eq!(
+            err_row.get("fileName").and_then(|n| n.as_str()),
+            Some("first.txt"),
+            "cycle 1: the error row must be the file we seeded"
+        );
+    }
+
+    let pending_after_cycle_1 = sync
+        .pending_activity
+        .lock()
+        .expect("pending_activity mutex uncontended in this test")
+        .len();
+    assert_eq!(
+        pending_after_cycle_1, 0,
+        "cycle 1: a 402 must NOT produce a fake `Uploaded` activity row; \
+         got {pending_after_cycle_1} item(s) in pending_activity"
+    );
+
+    end_cycle(&sync);
+    // NB: do NOT clear the banner counter here — the bridge clears it
+    // on the NEXT `SyncStarted` (= start of cycle 2), not at the end of
+    // cycle 1. This mirrors `record_and_build` in
+    // `hippius_credits_exhausted_event.rs`.
+
+    // ──────────────────────────────────────────────────────────────────
+    // Cycle 2: server still returns 402. After hcfs-client's
+    // strategy-A skip-set logic (`upload_retry_policy.rs` /
+    // `skip_set_clears_after_successful_cycle`), the file is NOT in
+    // `plan.uploads` this cycle — the planner filters it out because
+    // last cycle's failure left it in the in-memory skip set.
+    //
+    // From the desktop's vantage that means: no per-file events fire
+    // for `first.txt` this cycle, the bridge sees zero
+    // `FileFailed{InsufficientBalance}` events for the label, and a
+    // `SyncStarted` for the new cycle has already cleared the banner
+    // counter. The cycle ends with `files_failed == 0`, which is what
+    // tells the strategy-A skip-set to clear on the next cycle boundary.
+    //
+    // Expected end state:
+    //   - snapshot.failed_files == 0 (no new failures this cycle)
+    //   - no fresh pending_activity rows for the file
+    //   - banner count for the label == 0 (cleared by SyncStarted)
+    // ──────────────────────────────────────────────────────────────────
+
+    // SyncStarted handler clears the per-label counter. This is the
+    // exact mutation `TauriSyncBridge::on_event` performs on the
+    // `SyncStarted { label }` arm — see
+    // `hippius_credits_exhausted_event::sync_started_for_label_resets_counter`.
+    assert!(
+        banner_state.clear(&label),
+        "cycle 2: SyncStarted must clear the banner counter (returned false ⇒ no entry to clear, which means cycle 1's state was already lost — a regression)"
+    );
+    assert_eq!(banner_state.count_for(&label), 0, "cycle 2: counter must be 0 after clear");
+
+    // The planner's skip-set means hcfs-client emits zero per-file
+    // events for `first.txt` this cycle. Simulate by NOT seeding the
+    // session and NOT invoking any callbacks — this is exactly what the
+    // desktop sees when the planner's `plan.uploads` is empty.
+
+    let pending_after_cycle_2 = sync.pending_activity.lock().expect("pending_activity mutex").len();
+    assert_eq!(
+        pending_after_cycle_2, 0,
+        "cycle 2: skip-set holds — no fresh activity items must appear; got {pending_after_cycle_2}"
+    );
+
+    {
+        let snapshot = sync.progress.build_snapshot();
+        // With no current_session and no fresh events, the snapshot's
+        // `failed_files` counter reflects only the historic state of
+        // recent files. After `end_cycle` cleared the session, the
+        // aggregate must be zero — confirming the cycle 1 error row
+        // does NOT linger as a "live" failure into cycle 2.
+        assert_eq!(
+            snapshot.failed_files, 0,
+            "cycle 2: with the cycle-1 session ended and no new failures, \
+             the snapshot's live failed_files counter must be 0"
+        );
+    }
+
+    end_cycle(&sync);
+
+    // ──────────────────────────────────────────────────────────────────
+    // Cycle 3: server returns 200. The skip-set was cleared at the end
+    // of cycle 2 (files_failed == 0 → strategy-A trigger), so the
+    // planner re-includes `first.txt` in `plan.uploads`. hcfs-client
+    // runs the upload, gets a 2xx, and fires `on_file_synced` →
+    // `build_file_synced_callback`. The desktop bridge sees a
+    // `SyncEvent::FileSucceeded`-shaped event and the banner stays
+    // cleared (no `record_failure` calls).
+    //
+    // Expected end state:
+    //   - snapshot row for `first.txt` has status = Completed
+    //   - snapshot.failed_files == 0
+    //   - exactly one Uploaded item in pending_activity
+    //   - banner count for the label == 0
+    // ──────────────────────────────────────────────────────────────────
+    seed_one_upload(&sync, uploading_file("first.txt", &label, 2048, 2048), "cycle-3");
+
+    let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+    // 32-byte path hash keyed with 'a' so the hex decode succeeds —
+    // matches the shape `hippius_activity_truth.rs` uses. A bad hex
+    // would short-circuit the callback before `upsert_synced_path` and
+    // make this test silently testing a no-op.
+    let fid_hex = hex::encode([0xAAu8; 32]);
+    callback("first.txt", &fid_hex, "cid-cycle3", "uploaded", None);
+
+    {
+        let snapshot = sync.progress.build_snapshot();
+        let row = snapshot
+            .files
+            .iter()
+            .find(|f| f.path.as_ref() == "first.txt")
+            .expect("cycle 3: seeded file must survive in snapshot");
+        assert_eq!(
+            row.status,
+            FileProgressStatus::Completed,
+            "cycle 3: snapshot row must transition to Completed after the 200 — \
+             got {:?}",
+            row.status
+        );
+        assert_eq!(snapshot.failed_files, 0, "cycle 3: no failures this cycle");
+    }
+
+    let activity = sync.pending_activity.lock().expect("pending_activity mutex");
+    // `SyncActivityItem` does not implement `Debug`, so we render a
+    // human-readable summary by hand in the failure message rather than
+    // relying on `{:?}` formatting.
+    let action_summary: Vec<(String, String)> = activity
+        .iter()
+        .map(|item| (format!("{:?}", item.action), item.file_name.to_string()))
+        .collect();
+    let uploaded: Vec<_> = activity.iter().filter(|item| item.action == SyncActivityAction::Uploaded).collect();
+    assert_eq!(
+        uploaded.len(),
+        1,
+        "cycle 3: exactly one Uploaded activity row expected after the server-confirmed 200; \
+         got {} (actions = {action_summary:?})",
+        uploaded.len()
+    );
+    assert_eq!(&*uploaded[0].file_name, "first.txt", "cycle 3: the Uploaded row must be `first.txt`");
+    assert_eq!(
+        &*uploaded[0].label, "drive-402-e2e",
+        "cycle 3: the Uploaded row must carry the test drive's label"
+    );
+    drop(activity);
+
+    assert_eq!(
+        banner_state.count_for(&label),
+        0,
+        "cycle 3: banner counter must stay at 0 — no record_failure was called this cycle"
+    );
+
+    end_cycle(&sync);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Static-shape complement: the bridge's `SyncEvent::FileFailed` handler
+// MUST route InsufficientBalance failures through `record_failure`, and
+// MUST NOT emit a `hcfs_sync_error` for them. The runtime test above
+// pins the state-machine outcome; this static-shape probe pins the
+// routing decision at the source level, so a future refactor can't
+// reroute the variant without flipping this test.
+//
+// This mirrors the static-shape pattern used by
+// `byte_progress_does_not_enqueue_pending_activity` in
+// `hippius_activity_truth.rs` and
+// `lifecycle_initialize_sync_inner_spawns_backfill` in
+// `hippius_relative_path_backfill.rs`.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Pin that the bridge's `SyncEvent::FileFailed` arm uses
+/// `record_failure` (the InsufficientBalance counter) — not the
+/// SyncError emit path. If a future refactor accidentally moves the
+/// banner emit to the SyncError handler (or removes it entirely), this
+/// test catches it before the runtime invariant above does.
+#[test]
+fn bridge_routes_file_failed_to_credits_exhausted_state() {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/src/sync/tauri_bridge.rs");
+    let src = std::fs::read_to_string(path).expect("read src/sync/tauri_bridge.rs");
+
+    // The bridge handles `SyncEvent::FileFailed` and dispatches on the
+    // kind. The exact identifier the bridge uses to mutate state is
+    // `record_failure` (see `CreditsExhaustedState::record_failure`).
+    assert!(
+        src.contains("record_failure"),
+        "TauriSyncBridge must call CreditsExhaustedState::record_failure on InsufficientBalance — \
+         the banner emit depends on the post-increment count. See \
+         docs/plans/2026-05-13-sync-402-data-integrity.md Task 3.2."
+    );
+
+    // The bridge silently drops `SyncError::Cancelled` events (the
+    // CANCELLED_MARKER check). It MUST NOT drop FileFailed events the
+    // same way — a per-file 402 is an operator-visible signal, not a
+    // user cancel.
+    let drops_file_failed = src
+        .lines()
+        .filter(|line| line.contains("FileFailed"))
+        .any(|line| line.contains("return ;") || line.contains("// drop") || line.contains("CANCELLED_MARKER"));
+    assert!(
+        !drops_file_failed,
+        "FileFailed events must not be silenced via the CANCELLED_MARKER guard — \
+         that guard is for user-initiated cancels only"
+    );
+}

--- a/src-tauri/tests/hippius_activity_truth.rs
+++ b/src-tauri/tests/hippius_activity_truth.rs
@@ -1,0 +1,230 @@
+//! Activity-log truth invariants for sync.
+//!
+//! Phase 1 / Task 1.1 of `docs/plans/2026-05-13-sync-402-data-integrity.md`.
+//!
+//! # Why this suite exists
+//!
+//! The desktop used to enqueue `SyncActivityItem { action: Uploaded, .. }`
+//! from inside the byte-progress callback's completion-tick branch
+//! (`bytes == total`). That callback fires when the request body's last
+//! chunk has left the local TCP socket — *before* the HTTP response
+//! status (200 / 402 / 5xx) is parsed by `hcfs_client::client::upload`.
+//!
+//! Symptom: a 402 (Insufficient balance) response would still leave a
+//! "(uploaded)" row in the recent-activity log because the enqueue had
+//! already happened. The activity log lied to the user.
+//!
+//! Fix: the enqueue moved to `build_file_synced_callback`, which
+//! hcfs-client invokes *only* after the per-file upload (or
+//! download + AEAD-verifying decrypt) returns `Ok`. The two tests below
+//! pin both halves of that invariant from outside the crate so a future
+//! refactor cannot quietly regress either half.
+//!
+//! # What each test pins
+//!
+//! 1. `byte_progress_does_not_enqueue_pending_activity`: a *static-shape*
+//!    test that reads `src/sync/lifecycle.rs` and asserts the body of
+//!    `handle_transfer_progress` (the byte-progress site) contains zero
+//!    `add_pending_activity` calls. Static-shape tests are the
+//!    established pattern in this repo for cross-module invariants that
+//!    are easier to spot at the source level than to reproduce at
+//!    runtime — see `lifecycle_initialize_sync_inner_spawns_backfill`
+//!    in `hippius_relative_path_backfill.rs` for the canonical example.
+//!
+//! 2. `on_file_synced_enqueues_uploaded_activity`: drives the real
+//!    `build_file_synced_callback` closure end-to-end (no test-only
+//!    helpers, no `#[cfg(test)] pub`). Constructs a `SyncRunner` via
+//!    the public `hcfs_client::engine::SyncRunner::new(...)` API,
+//!    invokes the closure with realistic args, then inspects the
+//!    public `pending_activity` mutex.
+//!
+//! No live server, no real `DriveManager`, no Tauri `AppHandle`. The
+//! point is to assert the *enqueue location*, not to exercise the
+//! whole sync cycle (which hcfs-client's own tests already cover).
+
+use std::sync::Arc;
+
+use hcfs_client::engine::types::SyncActivityAction;
+use hcfs_client::engine::{NoopCallbacks, NoopEventHandler, SyncRunner};
+use tauri_project_lib::sync::lifecycle::build_file_synced_callback;
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers (test-local; nothing crosses back into the crate under test)
+// ─────────────────────────────────────────────────────────────────────
+
+/// Build a `SyncRunner` using only the public hcfs-client constructor.
+///
+/// Mirrors the in-module `test_sync_runner` helper in
+/// `src/sync/lifecycle.rs`, but defined here so this integration test
+/// does not depend on any `#[cfg(test)]`-only re-export.
+fn make_sync_runner() -> Arc<SyncRunner> {
+    Arc::new(SyncRunner::new(
+        Arc::new(NoopEventHandler),
+        Arc::new(NoopCallbacks),
+        reqwest::Client::new(),
+    ))
+}
+
+/// Read `src/sync/lifecycle.rs` and return its full source.
+///
+/// Pinned via `CARGO_MANIFEST_DIR` so the test stays runnable from any
+/// cwd (CI, `cargo test --workspace`, IDE runners, etc.).
+fn lifecycle_source() -> String {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/src/sync/lifecycle.rs");
+    std::fs::read_to_string(path).expect("read src/sync/lifecycle.rs")
+}
+
+/// Extract the balanced `{ ... }` body of a function whose signature
+/// starts with `sig_marker`. Returns `None` if the signature is
+/// absent (the caller asserts this); panics if the brace structure is
+/// malformed (a corrupt source file is a developer error, not a
+/// runtime condition this test should tolerate).
+///
+/// Naïve brace matching is sufficient for the two function bodies this
+/// test inspects — neither contains char-literal braces (`'{'`, `'}'`),
+/// raw-string braces (`r#"...{..."#`), or commented-out braces today.
+/// If this test starts failing after a refactor that introduces such
+/// tokens, swap to `syn` (or `proc-macro2`'s tokenizer) — but do not
+/// preemptively add the dependency. The precedent
+/// `lifecycle_initialize_sync_inner_spawns_backfill` in
+/// `hippius_relative_path_backfill.rs` makes the same tradeoff for the
+/// same reason: matching brace depth on real-world function bodies in
+/// this file has been load-bearing in test suites without incident, and
+/// the failure mode (a brace inside a string / comment that unbalances
+/// the count) is obvious from the resulting `panic!("unbalanced …")`.
+fn extract_fn_body<'src>(src: &'src str, sig_marker: &str) -> Option<&'src str> {
+    let sig_idx = src.find(sig_marker)?;
+    let body_start = src[sig_idx..].find('{')? + sig_idx;
+    let mut depth = 0usize;
+    for (i, ch) in src[body_start..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&src[body_start..=body_start + i]);
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unbalanced braces while scanning for `{sig_marker}` body");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+/// Static-shape invariant: the byte-progress site (`handle_transfer_progress`)
+/// MUST NOT enqueue activity items. The byte-progress callback fires when
+/// the upload request body has finished sending — before the server's
+/// HTTP response status is parsed — so an enqueue here would surface
+/// 402/5xx-rejected uploads as "Uploaded" in the activity log.
+///
+/// A symmetric assertion confirms the enqueue lives where it belongs:
+/// inside `build_file_synced_callback`, which hcfs-client invokes only
+/// on server-confirmed per-file success.
+#[test]
+fn byte_progress_does_not_enqueue_pending_activity() {
+    let src = lifecycle_source();
+
+    let transfer_body = extract_fn_body(&src, "fn handle_transfer_progress(").expect("handle_transfer_progress declaration present");
+    assert!(
+        !transfer_body.contains("add_pending_activity"),
+        "handle_transfer_progress MUST NOT call add_pending_activity — \
+         byte-progress is pre-server-confirmation and would lie about \
+         402/5xx-rejected uploads. The enqueue belongs in \
+         build_file_synced_callback. See \
+         docs/plans/2026-05-13-sync-402-data-integrity.md Task 1.1."
+    );
+
+    let synced_body = extract_fn_body(&src, "fn build_file_synced_callback(").expect("build_file_synced_callback declaration present");
+    assert!(
+        synced_body.contains("add_pending_activity"),
+        "build_file_synced_callback MUST call add_pending_activity — \
+         this is the server-confirmed enqueue site after the move."
+    );
+}
+
+/// Runtime invariant: invoking the real `build_file_synced_callback`
+/// closure with a `Uploaded`-shaped server confirmation produces exactly
+/// one `SyncActivityItem` with `action = Uploaded`, the correct
+/// `file_name`, and the correct `label`. Uses the public hcfs-client
+/// `SyncRunner::new` constructor — no test-only helpers, no
+/// `#[cfg(test)] pub` shims.
+#[test]
+fn on_file_synced_enqueues_uploaded_activity() {
+    let sync = make_sync_runner();
+    let label: Arc<str> = Arc::from("drive-a");
+    let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+
+    // 32-byte path hash keyed by 'a' so the hex decode in the callback
+    // succeeds — otherwise the callback short-circuits before the
+    // `upsert_synced_path` call and the test stops being meaningful as
+    // a regression check on the enqueue path.
+    let fid = [0xAAu8; 32];
+    let fid_hex = hex::encode(fid);
+
+    callback("folder/file.txt", &fid_hex, "cid-1", "uploaded", None);
+
+    let pending = sync.pending_activity.lock().expect("pending_activity mutex is uncontended in this test");
+    let items: Vec<_> = pending.iter().collect();
+
+    assert_eq!(items.len(), 1, "exactly one activity item expected after one server-confirmed upload");
+    let item = items[0];
+    assert_eq!(item.action, SyncActivityAction::Uploaded);
+    assert_eq!(&*item.file_name, "folder/file.txt");
+    assert_eq!(&*item.label, "drive-a");
+}
+
+/// Runtime invariant: a `Downloaded`-shaped server confirmation
+/// enqueues with `action = Downloaded`. The byte-progress site
+/// previously branched on `TransferDirection` to pick the right action;
+/// after the move, the action must come from the `action` parameter
+/// hcfs-client passes to `FileSyncedFn`.
+#[test]
+fn on_file_synced_enqueues_downloaded_activity_for_download_action() {
+    let sync = make_sync_runner();
+    let label: Arc<str> = Arc::from("drive-b");
+    let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+
+    let fid = [0xBBu8; 32];
+    callback("doc.txt", &hex::encode(fid), "cid-2", "downloaded", None);
+
+    let pending = sync.pending_activity.lock().expect("mutex");
+    let items: Vec<_> = pending.iter().collect();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].action, SyncActivityAction::Downloaded);
+    assert_eq!(&*items[0].file_name, "doc.txt");
+    assert_eq!(&*items[0].label, "drive-b");
+}
+
+/// Truth invariant: an `action` string that hcfs-client may introduce
+/// in the future (Phase 2 may add `"failed"`) MUST NOT produce a
+/// fabricated `Uploaded` row. The match arm for unknown action values
+/// maps to `None`, which skips the `add_pending_activity` call
+/// entirely. The `warn!` log still fires so the unknown variant is
+/// observable in operator logs, but the activity log itself stays
+/// truthful.
+///
+/// Pins issue I-3 from the Task 1.1 code review.
+#[test]
+fn on_file_synced_with_unknown_action_does_not_enqueue() {
+    let sync = make_sync_runner();
+    let label: Arc<str> = Arc::from("drive-test");
+    let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+
+    // Realistic-shape inputs: 32-byte hex path hash so the callback's
+    // subsequent `upsert_synced_path` decode path also succeeds. The
+    // assertion below is about the activity enqueue, but if the
+    // callback aborted earlier we would be silently testing a no-op.
+    let fid = [0xCCu8; 32];
+    callback("future/path.bin", &hex::encode(fid), "cid-future", "future-variant", None);
+
+    let pending = sync.pending_activity.lock().expect("mutex");
+    assert!(
+        pending.is_empty(),
+        "unknown action must skip the enqueue — recording nothing is the truthful choice when we cannot categorize the event; got {} item(s)",
+        pending.len()
+    );
+}

--- a/src-tauri/tests/hippius_activity_truth.rs
+++ b/src-tauri/tests/hippius_activity_truth.rs
@@ -42,8 +42,10 @@
 //! point is to assert the *enqueue location*, not to exercise the
 //! whole sync cycle (which hcfs-client's own tests already cover).
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use hcfs_client::engine::progress::state::{FileAction, FileStatus, SyncFile, SyncSession};
 use hcfs_client::engine::types::SyncActivityAction;
 use hcfs_client::engine::{NoopCallbacks, NoopEventHandler, SyncRunner};
 use tauri_project_lib::sync::lifecycle::build_file_synced_callback;
@@ -63,6 +65,49 @@ fn make_sync_runner() -> Arc<SyncRunner> {
         Arc::new(NoopCallbacks),
         reqwest::Client::new(),
     ))
+}
+
+/// Seed `current_session.files` with a single `Uploading` entry whose
+/// `total_bytes` matches the value `mark_file_synced` is expected to
+/// return when the callback fires for `path`.
+///
+/// Mirrors the in-module `seed_session` helper in
+/// `src/sync/progress.rs`, but defined here so this integration test
+/// does not depend on any `#[cfg(test)]`-only re-export.
+fn seed_one_file_session(sync: &SyncRunner, path: &str, label: &str, total_bytes: u64, action: FileAction) {
+    let file = SyncFile {
+        id: Arc::from(path),
+        path: Arc::from(path),
+        file_name: Arc::from(path.rsplit('/').next().unwrap_or(path)),
+        label: Arc::from(label),
+        action,
+        // Non-terminal status so `mark_file_synced`'s already-Completed
+        // short-circuit doesn't trigger and the callback sees the
+        // pre-transition `total_bytes`.
+        status: FileStatus::Uploading,
+        progress: 0,
+        bytes_encrypted: 0,
+        bytes_transferred: 0,
+        total_bytes,
+        resumed_from_bytes: None,
+        started_at: 0,
+        completed_at: None,
+        error: None,
+    };
+    let mut state = sync.progress.lock_state();
+    let mut files: HashMap<String, SyncFile> = HashMap::with_capacity(1);
+    files.insert(path.to_string(), file);
+    state.current_session = Some(SyncSession {
+        session_id: Arc::from("test-session"),
+        started_at: 0,
+        completed_at: None,
+        is_active: true,
+        expected_uploads: 0,
+        expected_downloads: 0,
+        expected_local_deletes: 0,
+        expected_remote_deletes: 0,
+        files,
+    });
 }
 
 /// Read `src/sync/lifecycle.rs` and return its full source.
@@ -156,6 +201,15 @@ fn byte_progress_does_not_enqueue_pending_activity() {
 fn on_file_synced_enqueues_uploaded_activity() {
     let sync = make_sync_runner();
     let label: Arc<str> = Arc::from("drive-a");
+
+    // Seed the progress tracker BEFORE building the callback so that
+    // `mark_file_synced` (called inside the closure) returns the file's
+    // `total_bytes`. Without the seed the helper returns 0 — which is
+    // technically a valid edge case, but it doesn't pin the size-
+    // propagation contract this test exists to enforce.
+    const EXPECTED_SIZE: u64 = 4_096;
+    seed_one_file_session(&sync, "folder/file.txt", "drive-a", EXPECTED_SIZE, FileAction::Upload);
+
     let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
 
     // 32-byte path hash keyed by 'a' so the hex decode in the callback
@@ -175,6 +229,10 @@ fn on_file_synced_enqueues_uploaded_activity() {
     assert_eq!(item.action, SyncActivityAction::Uploaded);
     assert_eq!(&*item.file_name, "folder/file.txt");
     assert_eq!(&*item.label, "drive-a");
+    assert_eq!(
+        item.size_bytes, EXPECTED_SIZE,
+        "size_bytes must come from the progress tracker's total_bytes so the Recent Files view doesn't show 'unknown'"
+    );
 }
 
 /// Runtime invariant: a `Downloaded`-shaped server confirmation
@@ -186,6 +244,13 @@ fn on_file_synced_enqueues_uploaded_activity() {
 fn on_file_synced_enqueues_downloaded_activity_for_download_action() {
     let sync = make_sync_runner();
     let label: Arc<str> = Arc::from("drive-b");
+
+    // Downloads also have a `total_bytes` in the progress tracker
+    // (populated during chunked decryption); pin that the same wiring
+    // works for the download path.
+    const EXPECTED_SIZE: u64 = 12_345;
+    seed_one_file_session(&sync, "doc.txt", "drive-b", EXPECTED_SIZE, FileAction::Download);
+
     let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
 
     let fid = [0xBBu8; 32];
@@ -197,6 +262,7 @@ fn on_file_synced_enqueues_downloaded_activity_for_download_action() {
     assert_eq!(items[0].action, SyncActivityAction::Downloaded);
     assert_eq!(&*items[0].file_name, "doc.txt");
     assert_eq!(&*items[0].label, "drive-b");
+    assert_eq!(items[0].size_bytes, EXPECTED_SIZE);
 }
 
 /// Truth invariant: an `action` string that hcfs-client may introduce
@@ -208,6 +274,33 @@ fn on_file_synced_enqueues_downloaded_activity_for_download_action() {
 /// truthful.
 ///
 /// Pins issue I-3 from the Task 1.1 code review.
+/// Edge case: when the progress tracker has no entry for `rel_path`
+/// (no session seeded, or a race where the file vanished from the
+/// session between the per-chunk callback and `on_file_synced`),
+/// `mark_file_synced` returns 0 and the activity row's `size_bytes`
+/// falls back to 0. This is the truthful sentinel for "size unknown"
+/// — the Recent-Files view renders it as the existing
+/// "unknown"/"--" placeholder rather than fabricating a fake count.
+/// Pins the contract that the helper never panics on a missing entry.
+#[test]
+fn on_file_synced_without_progress_entry_falls_back_to_zero_size() {
+    let sync = make_sync_runner();
+    let label: Arc<str> = Arc::from("drive-c");
+    let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+
+    // Deliberately do NOT seed `current_session`. `mark_file_synced`
+    // hits the `None` branch on `current_session.as_mut()` and returns
+    // `Ok(0)`; the callback uses that for `size_bytes`.
+    let fid = [0xEEu8; 32];
+    callback("ghost.bin", &hex::encode(fid), "cid-ghost", "uploaded", None);
+
+    let pending = sync.pending_activity.lock().expect("mutex");
+    let items: Vec<_> = pending.iter().collect();
+    assert_eq!(items.len(), 1, "row is still enqueued — the upload succeeded; only the size is unknown");
+    assert_eq!(items[0].size_bytes, 0, "no progress entry → size_bytes is the 0 sentinel, not a panic");
+    assert_eq!(items[0].action, SyncActivityAction::Uploaded);
+}
+
 #[test]
 fn on_file_synced_with_unknown_action_does_not_enqueue() {
     let sync = make_sync_runner();

--- a/src-tauri/tests/hippius_activity_truth.rs
+++ b/src-tauri/tests/hippius_activity_truth.rs
@@ -50,6 +50,18 @@ use hcfs_client::engine::types::SyncActivityAction;
 use hcfs_client::engine::{NoopCallbacks, NoopEventHandler, SyncRunner};
 use tauri_project_lib::sync::lifecycle::build_file_synced_callback;
 
+/// Build a `MockRuntime` `AppHandle` so the per-fire `app.clone()` and
+/// the fire-and-forget intent-mark spawn inside the callback compile
+/// and run without a real Tauri runtime. The spawn falls through the
+/// "no `AppState` managed" branch silently — exactly the fire-and-
+/// forget contract — leaving these tests focused on the activity
+/// enqueue and cache write, the behavior they were written to pin.
+/// The `test` feature on `tauri` is enabled only via dev-deps so this
+/// helper is unavailable in production builds.
+fn mock_app_handle() -> tauri::AppHandle<tauri::test::MockRuntime> {
+    tauri::test::mock_app().handle().clone()
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Helpers (test-local; nothing crosses back into the crate under test)
 // ─────────────────────────────────────────────────────────────────────
@@ -183,7 +195,12 @@ fn byte_progress_does_not_enqueue_pending_activity() {
          docs/plans/2026-05-13-sync-402-data-integrity.md Task 1.1."
     );
 
-    let synced_body = extract_fn_body(&src, "fn build_file_synced_callback(").expect("build_file_synced_callback declaration present");
+    // Marker omits the `(` so the substring match still works after
+    // the signature gained a `<R: tauri::Runtime>` generic parameter
+    // in Task 6 (intent manifest wiring). The brace scanner below
+    // jumps from the marker to the first `{`, so the runtime
+    // generic between the name and `(` doesn't affect body extraction.
+    let synced_body = extract_fn_body(&src, "fn build_file_synced_callback").expect("build_file_synced_callback declaration present");
     assert!(
         synced_body.contains("add_pending_activity"),
         "build_file_synced_callback MUST call add_pending_activity — \
@@ -197,8 +214,15 @@ fn byte_progress_does_not_enqueue_pending_activity() {
 /// `file_name`, and the correct `label`. Uses the public hcfs-client
 /// `SyncRunner::new` constructor — no test-only helpers, no
 /// `#[cfg(test)] pub` shims.
-#[test]
-fn on_file_synced_enqueues_uploaded_activity() {
+///
+/// Runs under `#[tokio::test]` because the closure now also fires a
+/// `tokio::spawn` (Task 6: fire-and-forget `mark_intent_completed`)
+/// on the `uploaded` action; without a Tokio reactor that spawn
+/// panics. The spawn itself is fire-and-forget and falls through the
+/// "no `AppState` managed" branch silently, so it doesn't affect the
+/// assertions below.
+#[tokio::test]
+async fn on_file_synced_enqueues_uploaded_activity() {
     let sync = make_sync_runner();
     let label: Arc<str> = Arc::from("drive-a");
 
@@ -210,7 +234,8 @@ fn on_file_synced_enqueues_uploaded_activity() {
     const EXPECTED_SIZE: u64 = 4_096;
     seed_one_file_session(&sync, "folder/file.txt", "drive-a", EXPECTED_SIZE, FileAction::Upload);
 
-    let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+    let app = mock_app_handle();
+    let callback = build_file_synced_callback(&app, sync.clone(), Arc::clone(&label));
 
     // 32-byte path hash keyed by 'a' so the hex decode in the callback
     // succeeds — otherwise the callback short-circuits before the
@@ -251,7 +276,8 @@ fn on_file_synced_enqueues_downloaded_activity_for_download_action() {
     const EXPECTED_SIZE: u64 = 12_345;
     seed_one_file_session(&sync, "doc.txt", "drive-b", EXPECTED_SIZE, FileAction::Download);
 
-    let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+    let app = mock_app_handle();
+    let callback = build_file_synced_callback(&app, sync.clone(), Arc::clone(&label));
 
     let fid = [0xBBu8; 32];
     callback("doc.txt", &hex::encode(fid), "cid-2", "downloaded", None);
@@ -282,11 +308,17 @@ fn on_file_synced_enqueues_downloaded_activity_for_download_action() {
 /// — the Recent-Files view renders it as the existing
 /// "unknown"/"--" placeholder rather than fabricating a fake count.
 /// Pins the contract that the helper never panics on a missing entry.
-#[test]
-fn on_file_synced_without_progress_entry_falls_back_to_zero_size() {
+///
+/// Runs under `#[tokio::test]` because the "uploaded" branch now
+/// spawns a fire-and-forget `mark_intent_completed` (Task 6) and a
+/// Tokio reactor is required for `tokio::spawn` not to panic. The
+/// spawn falls through silently — no `AppState` managed in this test.
+#[tokio::test]
+async fn on_file_synced_without_progress_entry_falls_back_to_zero_size() {
     let sync = make_sync_runner();
     let label: Arc<str> = Arc::from("drive-c");
-    let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+    let app = mock_app_handle();
+    let callback = build_file_synced_callback(&app, sync.clone(), Arc::clone(&label));
 
     // Deliberately do NOT seed `current_session`. `mark_file_synced`
     // hits the `None` branch on `current_session.as_mut()` and returns
@@ -305,7 +337,8 @@ fn on_file_synced_without_progress_entry_falls_back_to_zero_size() {
 fn on_file_synced_with_unknown_action_does_not_enqueue() {
     let sync = make_sync_runner();
     let label: Arc<str> = Arc::from("drive-test");
-    let callback = build_file_synced_callback(sync.clone(), Arc::clone(&label));
+    let app = mock_app_handle();
+    let callback = build_file_synced_callback(&app, sync.clone(), Arc::clone(&label));
 
     // Realistic-shape inputs: 32-byte hex path hash so the callback's
     // subsequent `upsert_synced_path` decode path also succeeds. The

--- a/src-tauri/tests/hippius_credits_exhausted_event.rs
+++ b/src-tauri/tests/hippius_credits_exhausted_event.rs
@@ -1,0 +1,244 @@
+//! Regression pins for the `hcfs_credits_exhausted` banner event —
+//! Task 3.2 of `docs/plans/2026-05-13-sync-402-data-integrity.md`.
+//!
+//! # What this suite covers
+//!
+//! Four independent invariants the bridge-side credits-exhausted
+//! plumbing must honour:
+//!
+//! 1. **First `InsufficientBalance` returns `file_count = 1`.** The
+//!    running counter starts at zero per label, increments by one per
+//!    `record_failure`, and the bridge attaches the post-increment
+//!    value to the payload.
+//!
+//! 2. **Second `InsufficientBalance` in the same cycle returns
+//!    `file_count = 2`.** Per-label running count is preserved across
+//!    consecutive failures until a cycle boundary clears it.
+//!
+//! 3. **Non-`InsufficientBalance` failures (e.g. `ServerError`) do NOT
+//!    touch the counter.** The banner is for 402s only.
+//!
+//! 4. **`SyncStarted` for a new cycle resets the counter.** A
+//!    fresh cycle starts at zero so the banner reflects only that
+//!    cycle's failures.
+//!
+//! # What this suite does NOT do
+//!
+//! - It does NOT spin up a real Tauri runtime. Like
+//!   `hippius_file_failed_event.rs`, the bridge's `app.emit` step is
+//!   exercised at the *counter mutation* level (the state the bridge
+//!   reads when building the payload) rather than through a real
+//!   `AppHandle`. The wire-shape contract for the payload struct is
+//!   pinned by the `payload_serialises_to_camel_case_json` test.
+
+use tauri_project_lib::sync::credits_exhausted::CreditsExhaustedState;
+use tauri_project_lib::sync::events::CreditsExhaustedPayload;
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/// Simulate the bridge's `FileFailed { kind: InsufficientBalance }`
+/// branch: record a failure and build the payload exactly as the bridge
+/// would. This is the unit under test — the bridge code itself is one
+/// `if let` plus an `app.emit`, both trivially correct given a correct
+/// state and payload.
+fn record_and_build(state: &CreditsExhaustedState, label: &str, balance_cents: i64, required_cents: i64) -> CreditsExhaustedPayload {
+    let file_count = state.record_failure(label);
+    CreditsExhaustedPayload {
+        label: label.to_string(),
+        balance_cents,
+        required_cents,
+        file_count,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 1 — first InsufficientBalance reports file_count = 1
+// ─────────────────────────────────────────────────────────────────────
+
+/// Acceptance criterion 5 (Task 3.2 plan): "On `FileFailed { kind:
+/// InsufficientBalance { balance_cents: 33, required_cents: 138 } }`,
+/// assert `hcfs_credits_exhausted` is emitted with `{ balance_cents:
+/// 33, required_cents: 138, file_count: 1 }`."
+#[test]
+fn first_insufficient_balance_emits_file_count_one() {
+    let state = CreditsExhaustedState::new();
+    let payload = record_and_build(&state, "drive-a", 33, 138);
+
+    assert_eq!(payload.balance_cents, 33);
+    assert_eq!(payload.required_cents, 138);
+    assert_eq!(payload.file_count, 1, "first failure in a fresh cycle must report file_count = 1");
+    assert_eq!(payload.label, "drive-a");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 2 — second InsufficientBalance in same cycle reports file_count = 2
+// ─────────────────────────────────────────────────────────────────────
+
+/// Acceptance criterion 5: "On a SECOND `FileFailed { kind:
+/// InsufficientBalance, .. }` in the same cycle, assert `file_count: 2`."
+#[test]
+fn second_insufficient_balance_in_same_cycle_increments_to_two() {
+    let state = CreditsExhaustedState::new();
+
+    let first = record_and_build(&state, "drive-a", 33, 138);
+    let second = record_and_build(&state, "drive-a", 30, 138);
+
+    assert_eq!(first.file_count, 1);
+    assert_eq!(
+        second.file_count, 2,
+        "second failure in the same cycle must increment the per-label counter"
+    );
+    // The payload carries the LATEST server-reported balance — a partial
+    // top-up between the two 402s would surface here. Asserting this pins
+    // the contract that the banner shows the most recent values, not the
+    // first ones.
+    assert_eq!(second.balance_cents, 30);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 3 — non-InsufficientBalance failures do NOT touch the counter
+// ─────────────────────────────────────────────────────────────────────
+
+/// Acceptance criterion 5: "On a `FileFailed { kind: ServerError, .. }`
+/// (not InsufficientBalance), assert NO `hcfs_credits_exhausted` event."
+///
+/// The bridge's `if let InsufficientBalance` branch is the gate; we test
+/// the gate's complement here by asserting that `record_failure` is NEVER
+/// called for non-402 failures — its absence is the absence of the event.
+#[test]
+fn non_insufficient_balance_failure_does_not_increment_counter() {
+    let state = CreditsExhaustedState::new();
+
+    // Simulate a ServerError-kind failure arriving at the bridge: the
+    // bridge does NOT call `record_failure`. Verify the counter stays
+    // at zero.
+    //
+    // (We don't call record_failure here on purpose — the bridge's
+    // `if let InsufficientBalance` branch is the gate. This test pins
+    // that "no record_failure call ⇒ counter stays zero" — i.e. no
+    // banner.)
+    assert_eq!(state.count_for("drive-a"), 0);
+
+    // To be extra-explicit: a real-world bridge-side `ServerError`
+    // arrival flows through the FILE_FAILED arm but skips the
+    // `if let InsufficientBalance` branch entirely. Recording a real
+    // 402 afterwards should still yield file_count = 1 (not 2 — the
+    // ServerError must not have leaked in).
+    let payload = record_and_build(&state, "drive-a", 33, 138);
+    assert_eq!(
+        payload.file_count, 1,
+        "a non-402 failure between resets must not contaminate the 402 counter"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 4 — SyncStarted on the same label resets the counter
+// ─────────────────────────────────────────────────────────────────────
+
+/// Acceptance criterion 5: "On `SyncStarted` for a new cycle, the
+/// counter resets." The bridge clears via `clear(&label)` on
+/// `SyncStarted` — calling `clear` directly here is the test, since
+/// it's the exact mutation the bridge performs.
+#[test]
+fn sync_started_for_label_resets_counter() {
+    let state = CreditsExhaustedState::new();
+    record_and_build(&state, "drive-a", 33, 138);
+    record_and_build(&state, "drive-a", 33, 138);
+    assert_eq!(state.count_for("drive-a"), 2);
+
+    // SyncStarted handler calls clear(label). Assert the counter is
+    // reset.
+    assert!(state.clear("drive-a"));
+    assert_eq!(state.count_for("drive-a"), 0);
+
+    // Next 402 in the new cycle re-emits with file_count = 1 (not 3).
+    let payload = record_and_build(&state, "drive-a", 33, 138);
+    assert_eq!(
+        payload.file_count, 1,
+        "fresh-cycle clear must result in next failure showing file_count = 1"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 5 — SyncStopped resets the per-label counter
+// ─────────────────────────────────────────────────────────────────────
+
+/// Bridge handler symmetry: `SyncStopped` must clear the counter for
+/// the stopped label. A subsequent resume/re-add must NOT inherit the
+/// stale count.
+#[test]
+fn sync_stopped_clears_counter_for_label() {
+    let state = CreditsExhaustedState::new();
+    record_and_build(&state, "drive-a", 33, 138);
+    record_and_build(&state, "drive-b", 50, 200);
+    assert!(state.clear("drive-a"));
+    assert_eq!(state.count_for("drive-a"), 0);
+    // Other drive's counter is unaffected — per-label scoping.
+    assert_eq!(state.count_for("drive-b"), 1);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 6 — SyncReset clears every counter
+// ─────────────────────────────────────────────────────────────────────
+
+/// Bridge handler symmetry: `SyncReset` (logout / account switch) must
+/// wipe every counter so a different user's 402 history can't leak.
+#[test]
+fn sync_reset_clears_every_counter() {
+    let state = CreditsExhaustedState::new();
+    record_and_build(&state, "drive-a", 33, 138);
+    record_and_build(&state, "drive-b", 50, 200);
+    record_and_build(&state, "drive-c", 100, 150);
+    assert!(state.clear_all());
+    assert_eq!(state.count_for("drive-a"), 0);
+    assert_eq!(state.count_for("drive-b"), 0);
+    assert_eq!(state.count_for("drive-c"), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 7 — wire format pin
+// ─────────────────────────────────────────────────────────────────────
+
+/// `CreditsExhaustedPayload` must serialise to the camelCase JSON the
+/// FE consumes. Catches a regression that drops `rename_all = "camelCase"`
+/// or renames a field.
+#[test]
+fn payload_serialises_to_camel_case_json() {
+    let payload = CreditsExhaustedPayload {
+        label: "drive-a".to_string(),
+        balance_cents: 33,
+        required_cents: 138,
+        file_count: 1,
+    };
+    let json = serde_json::to_value(&payload).expect("payload must serialise — it crosses Tauri IPC");
+
+    assert_eq!(json.get("label").and_then(|v| v.as_str()), Some("drive-a"));
+    assert_eq!(json.get("balanceCents").and_then(serde_json::Value::as_i64), Some(33));
+    assert_eq!(json.get("requiredCents").and_then(serde_json::Value::as_i64), Some(138));
+    assert_eq!(json.get("fileCount").and_then(serde_json::Value::as_u64), Some(1));
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 8 — per-label scoping under interleaving
+// ─────────────────────────────────────────────────────────────────────
+
+/// Two drives failing concurrently must each accumulate independently.
+/// This pins the "drives don't share counters" invariant in case a
+/// future refactor introduces a global counter.
+#[test]
+fn per_label_scoping_under_interleaving() {
+    let state = CreditsExhaustedState::new();
+    let a1 = record_and_build(&state, "drive-a", 33, 138);
+    let b1 = record_and_build(&state, "drive-b", 50, 200);
+    let a2 = record_and_build(&state, "drive-a", 33, 138);
+    let b2 = record_and_build(&state, "drive-b", 50, 200);
+    let a3 = record_and_build(&state, "drive-a", 33, 138);
+
+    assert_eq!(a1.file_count, 1);
+    assert_eq!(a2.file_count, 2);
+    assert_eq!(a3.file_count, 3);
+    assert_eq!(b1.file_count, 1);
+    assert_eq!(b2.file_count, 2);
+}

--- a/src-tauri/tests/hippius_credits_exhausted_event.rs
+++ b/src-tauri/tests/hippius_credits_exhausted_event.rs
@@ -43,7 +43,7 @@ use tauri_project_lib::sync::events::CreditsExhaustedPayload;
 /// would. This is the unit under test — the bridge code itself is one
 /// `if let` plus an `app.emit`, both trivially correct given a correct
 /// state and payload.
-fn record_and_build(state: &CreditsExhaustedState, label: &str, balance_cents: i64, required_cents: i64) -> CreditsExhaustedPayload {
+fn record_and_build(state: &CreditsExhaustedState, label: &str, balance_cents: u64, required_cents: u64) -> CreditsExhaustedPayload {
     let file_count = state.record_failure(label);
     CreditsExhaustedPayload {
         label: label.to_string(),

--- a/src-tauri/tests/hippius_eligibility_pricing.rs
+++ b/src-tauri/tests/hippius_eligibility_pricing.rs
@@ -1,0 +1,258 @@
+//! Integration tests for the bytes-priced layer of
+//! `crate::billing::eligibility::require_eligible` (Task 3.1 of the
+//! 2026-05-13 sync-402 plan).
+//!
+//! Companion to `tests/eligibility_enforcement.rs` (which pins the
+//! static-threshold layer at `bytes = 0`). This file pins the layer
+//! that scales with the byte count of the upload payload:
+//!
+//! - A 1-byte file with a $0.33 marketplace balance passes — the
+//!   per-byte cost is far below any positive balance, so the gate
+//!   degenerates to the legacy `> 0` floor.
+//! - A "huge" file whose priced cost exceeds the balance is REJECTED
+//!   with the structured `NotReady(InsufficientCredits)` error.
+//! - A folder whose recursive byte sum exceeds the balance is REJECTED.
+//! - A folder whose recursive byte sum fits in the balance passes.
+//! - `VmCreation` (non-upload action) is unaffected by the bytes
+//!   argument — same threshold semantics as the existing test.
+//!
+//! The mock-server / pool setup mirrors `eligibility_enforcement.rs` so
+//! the two files exercise the same contract surface against the same
+//! billing API shape; only the byte-count input changes.
+
+use axum::{Json, Router, extract::State, routing::get};
+use serde_json::json;
+use sqlx::sqlite::SqlitePool;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use tokio::net::TcpListener;
+
+use tauri_project_lib::app_state::AppState;
+use tauri_project_lib::auth::auth_session_repo::{UpsertSession, upsert};
+use tauri_project_lib::billing::eligibility::{InsufficientCreditsAction, cost_for_bytes, require_eligible};
+use tauri_project_lib::error::{AppError, NotReadyKind};
+
+/// Shared mock-balance state; identical shape to the helper in
+/// `eligibility_enforcement.rs`. Duplicated rather than extracted
+/// because integration-test binaries cannot share module code without
+/// turning either into a `pub mod` library — Rust integration tests
+/// build one binary per file by design.
+#[derive(Clone, Default)]
+struct MockBilling {
+    balance: Arc<Mutex<String>>,
+}
+
+async fn balance_handler(State(state): State<MockBilling>) -> Json<serde_json::Value> {
+    let balance = state.balance.lock().unwrap().clone();
+    Json(json!({ "balance": balance }))
+}
+
+async fn spawn_mock_server() -> (String, MockBilling) {
+    let state = MockBilling::default();
+    let app = Router::new()
+        .route("/api/billing/credits/balance/", get(balance_handler))
+        .with_state(state.clone());
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await.expect("bind mock server");
+    let addr = listener.local_addr().expect("local addr");
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("mock server");
+    });
+
+    (format!("http://{addr}"), state)
+}
+
+/// In-memory pool seeded with a placeholder auth-session row. The token
+/// value doesn't matter to the mock server, but it must be present and
+/// non-empty or `ApiClient::get` short-circuits before hitting the
+/// network. Identical to the helper in `eligibility_enforcement.rs`.
+async fn setup_pool_with_token(account_id: &str) -> SqlitePool {
+    // SAFETY: process-global env mutation, deterministic value, set
+    // before any auth_session_repo call in this test file. Mirrors the
+    // pattern in `eligibility_enforcement.rs` — prevents the test from
+    // writing test tokens to the developer's macOS keychain.
+    unsafe {
+        std::env::set_var("HIPPIUS_DISABLE_TOKEN_KEYCHAIN", "1");
+    }
+
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS auth_session (
+            owner TEXT PRIMARY KEY,
+            auth_token TEXT,
+            token_expiry INTEGER,
+            user_id INTEGER,
+            username TEXT,
+            provider TEXT,
+            substrate_address TEXT,
+            logout_time_minutes INTEGER,
+            last_login_at TEXT,
+            updated_at TEXT DEFAULT (datetime('now'))
+        )",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    upsert(
+        &pool,
+        UpsertSession {
+            substrate_address: account_id,
+            token: "test-token-not-validated",
+            token_expiry_ms: chrono::Utc::now().timestamp_millis() + 3_600_000,
+            user_id: Some(1),
+            username: "tester",
+            provider: "test",
+            logout_time_minutes: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    pool
+}
+
+/// Smallest byte count whose priced cost exceeds a given balance. Used
+/// to pick test sizes deliberately (the plan calls out "exact required
+/// cost depends on the constant; pick test sizes deliberately"). Avoids
+/// hardcoding magic constants by deriving the threshold from the same
+/// `cost_for_bytes` the production code uses.
+fn bytes_just_over(balance: f64) -> u64 {
+    // Doubled to give the test a safety margin against the float
+    // representation of `cost_for_bytes` rounding right at the boundary.
+    // The cost function is monotone non-decreasing, so any larger byte
+    // count is also "over".
+    let mut bytes: u64 = 1;
+    while cost_for_bytes(bytes) <= balance {
+        bytes = bytes.saturating_mul(2);
+        if bytes == 0 {
+            panic!("u64 overflow: no byte count produces cost > {balance}");
+        }
+    }
+    bytes
+}
+
+#[tokio::test]
+async fn require_eligible_prices_uploads_by_byte_count() {
+    let (base_url, mock) = spawn_mock_server().await;
+    // SAFETY: tests in this file are a single `#[tokio::test]` so the
+    // env var mutation can't race another test in this binary. Mirrors
+    // the pattern in `eligibility_enforcement.rs`.
+    unsafe {
+        std::env::set_var("HIPPIUS_API_BASE_URL", &base_url);
+    }
+
+    let account_id = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    let pool = setup_pool_with_token(account_id).await;
+    let state = AppState::new();
+    state.set_pool(pool);
+
+    // -----------------------------------------------------------------
+    // Case A: tiny file (1 byte) with $0.33 balance must be ELIGIBLE.
+    // The per-byte cost is far below any positive balance, so the gate
+    // falls through to the static `> 0` floor.
+    // -----------------------------------------------------------------
+    *mock.balance.lock().unwrap() = "0.33".to_string();
+    require_eligible(&state, account_id, InsufficientCreditsAction::FileUpload, 1)
+        .await
+        .expect("1-byte upload must fit in $0.33 balance");
+
+    // -----------------------------------------------------------------
+    // Case B: same balance, but a payload large enough that its priced
+    // cost EXCEEDS the balance. Must be REJECTED with the structured
+    // `NotReady(InsufficientCredits)` error.
+    //
+    // Size is derived from `bytes_just_over(0.33)` so the assertion
+    // survives any future tuning of `CREDITS_PER_BYTE_MONTHLY` —
+    // re-running the helper recomputes the boundary against the
+    // current constant. The plan example ($1.38 storage cost vs $0.33
+    // balance) maps to ~470 GB at the per-month rate; the helper picks
+    // a similar magnitude.
+    // -----------------------------------------------------------------
+    let too_many_bytes = bytes_just_over(0.33);
+    let err = require_eligible(&state, account_id, InsufficientCreditsAction::FileUpload, too_many_bytes)
+        .await
+        .expect_err("priced file upload must fail when cost exceeds balance");
+    assert!(
+        matches!(err, AppError::NotReady(NotReadyKind::InsufficientCredits)),
+        "expected NotReady(InsufficientCredits) for priced file overrun, got {err:?}",
+    );
+
+    // -----------------------------------------------------------------
+    // Case C: folder upload — same byte threshold logic, different
+    // action. Pins that the bytes-priced layer applies to every upload
+    // action variant, not just `FileUpload`.
+    // -----------------------------------------------------------------
+    let err = require_eligible(&state, account_id, InsufficientCreditsAction::FolderUpload, too_many_bytes)
+        .await
+        .expect_err("priced folder upload must fail when cost exceeds balance");
+    assert!(
+        matches!(err, AppError::NotReady(NotReadyKind::InsufficientCredits)),
+        "expected NotReady(InsufficientCredits) for priced folder overrun, got {err:?}",
+    );
+
+    // Folder within balance: the same `FolderUpload` action passes with
+    // a payload sized below the boundary. Pins that the boundary is
+    // monotone (no "gate rejects everything once balance < threshold").
+    require_eligible(&state, account_id, InsufficientCreditsAction::FolderUpload, 1024)
+        .await
+        .expect("1 KiB folder upload must fit in $0.33 balance");
+
+    // -----------------------------------------------------------------
+    // Case D: `add_local_sync_folder` action (`FolderSync`). Same
+    // bytes-priced gate.
+    // -----------------------------------------------------------------
+    let err = require_eligible(&state, account_id, InsufficientCreditsAction::FolderSync, too_many_bytes)
+        .await
+        .expect_err("priced folder-sync must fail when cost exceeds balance");
+    assert!(matches!(err, AppError::NotReady(NotReadyKind::InsufficientCredits)));
+
+    // -----------------------------------------------------------------
+    // Case E: non-upload action (VmCreation) is UNAFFECTED by the
+    // bytes argument — its threshold is the up-front extrinsic fee
+    // (10 credits), and no payload byte count should ever raise or
+    // lower that bar. Pin both directions:
+    //   E1. Balance < 10, huge bytes → still rejected (threshold loss,
+    //       NOT bytes loss). Confirms bytes don't push a sub-threshold
+    //       balance into "ineligible" via the wrong axis.
+    //   E2. Balance == 10, huge bytes → ELIGIBLE. Confirms bytes don't
+    //       artificially raise the VM gate above its static threshold.
+    // -----------------------------------------------------------------
+    *mock.balance.lock().unwrap() = "0.33".to_string();
+    let err = require_eligible(&state, account_id, InsufficientCreditsAction::VmCreation, too_many_bytes)
+        .await
+        .expect_err("VmCreation under-threshold must still reject");
+    assert!(matches!(err, AppError::NotReady(NotReadyKind::InsufficientCredits)));
+
+    *mock.balance.lock().unwrap() = "10".to_string();
+    require_eligible(&state, account_id, InsufficientCreditsAction::VmCreation, too_many_bytes)
+        .await
+        .expect("VmCreation at threshold passes regardless of bytes (chain-balance fallthrough)");
+
+    // -----------------------------------------------------------------
+    // Case F: enough balance to cover the priced layer. The same huge
+    // byte count from case B passes when the balance is above its
+    // computed cost. Confirms the gate is genuinely a comparison, not
+    // a unconditional rejection above some size.
+    // -----------------------------------------------------------------
+    let cost_for_big = cost_for_bytes(too_many_bytes);
+    // Add a safety margin so float-equality at the boundary doesn't
+    // flip the result; `required_credits >=` is `>=`, not `>`.
+    //
+    // Use fixed-point `{:.10}` rather than default `{}` to avoid the f64
+    // Display sometimes emitting scientific notation (e.g. `6e-3`) for
+    // small magnitudes — the billing balance parser on the other side
+    // expects a plain decimal string. 10 fractional digits is well
+    // beyond the precision needed for any plausible `cost_for_big * 2.0`
+    // in this test, and the value still parses back via `f64::from_str`.
+    *mock.balance.lock().unwrap() = format!("{:.10}", cost_for_big * 2.0);
+    require_eligible(&state, account_id, InsufficientCreditsAction::FileUpload, too_many_bytes)
+        .await
+        .expect("priced upload passes when balance covers cost + margin");
+
+    unsafe {
+        std::env::remove_var("HIPPIUS_API_BASE_URL");
+    }
+}

--- a/src-tauri/tests/hippius_file_failed_event.rs
+++ b/src-tauri/tests/hippius_file_failed_event.rs
@@ -1,0 +1,322 @@
+//! Regression pins for `SyncEvent::FileFailed` consumption — Task 2.7 of
+//! `docs/plans/2026-05-13-sync-402-data-integrity.md`.
+//!
+//! # What this suite covers
+//!
+//! Three independent contracts the Phase 2 desktop consumer must honour:
+//!
+//! 1. **`mark_file_failed` flips the snapshot synchronously**: when the
+//!    per-file failure callback fires (the in-process equivalent of
+//!    `SyncEvent::FileFailed` arriving via the bridge), the file's row
+//!    in the next `build_snapshot()` MUST carry
+//!    `FileProgressStatus::Error` AND `snapshot.failed_files` MUST agree
+//!    with the per-file count. No waiting for end-of-cycle finalize.
+//!
+//! 2. **Wire-format pin for `FileFailureKindPayload`**: the
+//!    desktop-owned translation enum must serialise to the tagged JSON
+//!    shape the FE consumes. Because the upstream
+//!    `hcfs_client::engine::events::FileFailureKind` does NOT derive
+//!    `Serialize`, this test guards the translation map — adding a
+//!    variant upstream without extending `From<&FileFailureKind>`
+//!    silently maps to `Other`, which this test would catch via the
+//!    `InsufficientBalance` round-trip.
+//!
+//! 3. **First-error wins**: calling `mark_file_failed` a second time
+//!    with a different error string for the same path must NOT overwrite
+//!    the first error message. Justification: hcfs-client retries
+//!    transient errors and the first 402 is the operator-actionable
+//!    signal; clobbering it with a follow-up "network timeout" hides
+//!    the real root cause.
+//!
+//! # What this suite does NOT do
+//!
+//! - It does NOT spin up a real Tauri runtime. The `on_event` arm that
+//!   emits `hcfs_file_failed` is exercised at the *progress mutation*
+//!   level (the side effect that matters for the snapshot/widget) and
+//!   at the *payload translation* level (the wire format the FE keys
+//!   on). A full Tauri-runtime integration would require the
+//!   `tauri::test` harness and a real `AppHandle` — neither is
+//!   reachable from an `integration_test` build without test-only
+//!   harness scaffolding the project deliberately avoids
+//!   (`src-tauri/CLAUDE.md`, project axiom 111: tests use only the
+//!   public API).
+
+use std::sync::Arc;
+
+use hcfs_client::engine::events::FileFailureKind;
+use hcfs_client::engine::progress::state::{FileAction, FileStatus, SyncFile, SyncSession};
+use hcfs_client::engine::runner::SyncRunner;
+use hcfs_client::engine::{NoopCallbacks, NoopEventHandler};
+
+use tauri_project_lib::sync::events::{FileFailedPayload, FileFailureKindPayload};
+use tauri_project_lib::sync::progress::{FileProgressStatus, mark_file_failed};
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers (mirrors hippius_snapshot_failure_status.rs — see that file
+// for the rationale on duplicating instead of sharing through a
+// `mod common`).
+// ─────────────────────────────────────────────────────────────────────
+
+/// Build a `SyncRunner` using only the public hcfs-client constructor.
+fn make_sync_runner() -> Arc<SyncRunner> {
+    Arc::new(SyncRunner::new(
+        Arc::new(NoopEventHandler),
+        Arc::new(NoopCallbacks),
+        reqwest::Client::new(),
+    ))
+}
+
+/// Build a `SyncFile` mid-upload: bytes are partway through, no terminal
+/// state yet. This is the shape `mark_file_failed` sees when a 402
+/// response arrives mid-stream.
+fn uploading_file(path: &str, label: &str, size: u64, transferred: u64) -> SyncFile {
+    SyncFile {
+        id: Arc::from(path),
+        path: Arc::from(path),
+        file_name: Arc::from(path.rsplit('/').next().unwrap_or(path)),
+        label: Arc::from(label),
+        action: FileAction::Upload,
+        status: FileStatus::Uploading,
+        progress: ((transferred * 100) / size.max(1)) as u32,
+        bytes_encrypted: size,
+        bytes_transferred: transferred,
+        total_bytes: size,
+        resumed_from_bytes: None,
+        started_at: 0,
+        completed_at: None,
+        error: None,
+    }
+}
+
+/// Seed the runner's `current_session` with a single in-flight file.
+fn seed_single_file(sync: &SyncRunner, file: SyncFile) {
+    let mut state = sync.progress.lock_state();
+    let mut files = std::collections::HashMap::new();
+    files.insert(file.path.to_string(), file);
+    state.current_session = Some(SyncSession {
+        session_id: Arc::from("test-session-file-failed"),
+        started_at: 0,
+        completed_at: None,
+        is_active: true,
+        expected_uploads: 1,
+        expected_downloads: 0,
+        expected_local_deletes: 0,
+        expected_remote_deletes: 0,
+        files,
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 1 — synchronous progress transition
+// ─────────────────────────────────────────────────────────────────────
+
+/// `mark_file_failed` MUST flip the file's snapshot row to
+/// `FileProgressStatus::Error` immediately (no end-of-cycle wait).
+///
+/// This pins acceptance criterion (5)/bullet 1 of Task 2.7: the
+/// snapshot's file entry has `status == FileProgressStatus::Error`
+/// immediately, before any finalize-session call.
+#[test]
+fn mark_file_failed_flips_snapshot_status_to_error_immediately() {
+    let sync = make_sync_runner();
+    let label = "drive-a";
+
+    // Mid-upload: 50% transferred, status = Uploading. A 402 arriving
+    // right now should flip the row to Error without waiting for
+    // `complete_pending_files` / `mark_pending_files_as_failed`.
+    seed_single_file(&sync, uploading_file("over-budget.bin", label, 2048, 1024));
+
+    mark_file_failed(&sync, "over-budget.bin", "insufficient_balance: 12¢ < 100¢")
+        .expect("mark_file_failed should not error on a well-formed session");
+
+    let snapshot = sync.progress.build_snapshot();
+    let row = snapshot
+        .files
+        .iter()
+        .find(|f| f.path.as_ref() == "over-budget.bin")
+        .expect("file we seeded must still be present in the snapshot");
+
+    assert_eq!(
+        row.status,
+        FileProgressStatus::Error,
+        "snapshot row for the failed file must be `Error` immediately; \
+         got {:?}",
+        row.status
+    );
+    assert_eq!(
+        row.error.as_deref(),
+        Some("insufficient_balance: 12¢ < 100¢"),
+        "the error message must be carried on the row for the FE tooltip"
+    );
+    assert_eq!(
+        row.progress_percent, 0,
+        "progress_percent reset to 0 (mirrors upstream `mark_file_error` semantics)"
+    );
+    assert_eq!(row.bytes_transferred, 0, "bytes_transferred reset to 0 so the FE doesn't show 99%→Error");
+    assert_eq!(
+        snapshot.failed_files, 1,
+        "aggregate `failed_files` counter must agree with the per-file Error count"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 2 — wire-format pin for the kind translation
+// ─────────────────────────────────────────────────────────────────────
+
+/// `FileFailureKindPayload::from(&FileFailureKind::InsufficientBalance{..})`
+/// MUST round-trip through serde to the tagged-union JSON shape the FE
+/// keys on: `{"kind":"insufficientBalance","balanceCents":12,"requiredCents":100}`.
+///
+/// Failure mode this catches: an upstream rename, a variant addition
+/// without extending the `From` impl, or a serde-attribute regression
+/// (dropping `tag = "kind"` or `rename_all = "camelCase"`) would silently
+/// break the FE's discriminated union without breaking the Rust types'
+/// `PartialEq`. The on-wire string assertion catches that.
+#[test]
+fn insufficient_balance_serialises_to_tagged_camel_case_json() {
+    let upstream = FileFailureKind::InsufficientBalance {
+        balance_cents: 12,
+        required_cents: 100,
+    };
+    let payload = FileFailureKindPayload::from(&upstream);
+
+    let json = serde_json::to_value(&payload).expect("FileFailureKindPayload must serialise; it crosses Tauri IPC");
+
+    assert_eq!(
+        json.get("kind").and_then(|k| k.as_str()),
+        Some("insufficientBalance"),
+        "tag must serialise as camelCase `insufficientBalance`; \
+         got payload JSON = {json}"
+    );
+    assert_eq!(json.get("balanceCents").and_then(serde_json::Value::as_i64), Some(12));
+    assert_eq!(json.get("requiredCents").and_then(serde_json::Value::as_i64), Some(100));
+}
+
+/// Each upstream variant must translate to a distinct, FE-stable wire shape.
+/// This is the breadth pin — Test 2 above pins InsufficientBalance depth.
+#[test]
+fn each_upstream_variant_translates_to_distinct_wire_shape() {
+    let cases = [
+        (FileFailureKind::ServerError { status: 500 }, "serverError", Some(("status", 500_i64))),
+        (FileFailureKind::Network, "network", None),
+    ];
+    for (upstream, expected_kind, extra_field) in cases {
+        let payload = FileFailureKindPayload::from(&upstream);
+        let json = serde_json::to_value(&payload).expect("serialise");
+        assert_eq!(
+            json.get("kind").and_then(|v| v.as_str()),
+            Some(expected_kind),
+            "variant {upstream:?} must serialise with kind = {expected_kind:?}"
+        );
+        if let Some((field, value)) = extra_field {
+            assert_eq!(
+                json.get(field).and_then(serde_json::Value::as_i64),
+                Some(value),
+                "variant {upstream:?} must carry {field}={value}"
+            );
+        }
+    }
+
+    // `Other(String)` translates the inner message — separate case
+    // because it owns a `String`, not a `Copy` field.
+    let other_payload = FileFailureKindPayload::from(&FileFailureKind::Other("unmapped".into()));
+    let json = serde_json::to_value(&other_payload).expect("serialise");
+    assert_eq!(json.get("kind").and_then(|v| v.as_str()), Some("other"));
+    assert_eq!(json.get("message").and_then(|v| v.as_str()), Some("unmapped"));
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 3 — first-error-wins idempotence
+// ─────────────────────────────────────────────────────────────────────
+
+/// Calling `mark_file_failed` a second time for the same path with a
+/// different error MUST NOT overwrite the first error message.
+///
+/// Why: hcfs-client may retry transient failures, and the first error
+/// (e.g. `InsufficientBalance: 12¢ < 100¢`) is the operator-actionable
+/// signal. Letting a follow-up "connection reset" message clobber it
+/// hides the real cause from the FE tooltip and the `last_error`
+/// channel. The terminal `FileStatus::Error` row is sticky for the
+/// duration of the cycle.
+#[test]
+fn second_failure_for_same_path_does_not_overwrite_first_error() {
+    let sync = make_sync_runner();
+    let label = "drive-a";
+
+    seed_single_file(&sync, uploading_file("paid.txt", label, 1024, 512));
+
+    mark_file_failed(&sync, "paid.txt", "first: insufficient_balance").expect("first call");
+    mark_file_failed(&sync, "paid.txt", "second: network_timeout").expect("second call");
+
+    let snapshot = sync.progress.build_snapshot();
+    let row = snapshot.files.iter().find(|f| f.path.as_ref() == "paid.txt").expect("row");
+    assert_eq!(
+        row.error.as_deref(),
+        Some("first: insufficient_balance"),
+        "the first failure message must win — second call is a no-op while the row is already Error"
+    );
+    assert_eq!(snapshot.failed_files, 1, "still exactly one failed file (not double-counted)");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 4 — empty path is a no-op
+// ─────────────────────────────────────────────────────────────────────
+
+/// Defensive: `mark_file_failed` with `path = ""` must not corrupt the
+/// session. Mirrors the `rel_path.is_empty()` guard in
+/// `build_file_failed_callback` and `build_file_synced_callback`.
+#[test]
+fn mark_file_failed_with_unknown_path_is_a_noop() {
+    let sync = make_sync_runner();
+    seed_single_file(&sync, uploading_file("real.bin", "drive-a", 1024, 0));
+
+    mark_file_failed(&sync, "ghost-path-not-in-session.bin", "should be ignored").expect("must not error when the path is missing — race-safe no-op");
+
+    let snapshot = sync.progress.build_snapshot();
+    assert_eq!(snapshot.failed_files, 0, "no row was flipped; failed_files must stay at 0");
+    let row = snapshot
+        .files
+        .iter()
+        .find(|f| f.path.as_ref() == "real.bin")
+        .expect("seeded row survives");
+    assert_eq!(row.status, FileProgressStatus::InProgress);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 5 — payload struct shape (end-to-end IPC contract)
+// ─────────────────────────────────────────────────────────────────────
+
+/// The `FileFailedPayload` struct as a whole must serialise with the
+/// shape the FE's event listener expects. This is the composite of the
+/// translation pin (Test 2) plus the outer-struct camelCase rename
+/// (`fileId`, `httpStatus`) the bridge emits.
+#[test]
+fn file_failed_payload_full_wire_shape() {
+    let payload = FileFailedPayload {
+        label: "drive-a".to_string(),
+        path: "over-budget.bin".to_string(),
+        file_id: "deadbeef00112233".to_string(),
+        kind: FileFailureKindPayload::from(&FileFailureKind::InsufficientBalance {
+            balance_cents: 12,
+            required_cents: 100,
+        }),
+        http_status: Some(402),
+    };
+
+    let json = serde_json::to_value(&payload).expect("payload must serialise for the Tauri channel");
+
+    assert_eq!(json.get("label").and_then(|v| v.as_str()), Some("drive-a"));
+    assert_eq!(json.get("path").and_then(|v| v.as_str()), Some("over-budget.bin"));
+    assert_eq!(
+        json.get("fileId").and_then(|v| v.as_str()),
+        Some("deadbeef00112233"),
+        "outer struct must rename `file_id` → `fileId` per `serde(rename_all = \"camelCase\")`"
+    );
+    assert_eq!(
+        json.get("httpStatus").and_then(serde_json::Value::as_i64),
+        Some(402),
+        "outer struct must rename `http_status` → `httpStatus`"
+    );
+    let kind = json.get("kind").expect("kind tag must exist");
+    assert_eq!(kind.get("kind").and_then(|v| v.as_str()), Some("insufficientBalance"));
+}

--- a/src-tauri/tests/hippius_relative_path_backfill.rs
+++ b/src-tauri/tests/hippius_relative_path_backfill.rs
@@ -246,6 +246,7 @@ fn make_client(base_url: &str) -> HcfsClient {
         billing_bypass_token: None,
         ss58_address: TEST_ACCOUNT.to_string(),
         folder_hash: TEST_FOLDER_HASH.to_string(),
+        read_timeout_ms: None,
     };
     HcfsClient::new(config).expect("build HcfsClient")
 }

--- a/src-tauri/tests/hippius_snapshot_failure_status.rs
+++ b/src-tauri/tests/hippius_snapshot_failure_status.rs
@@ -1,0 +1,298 @@
+//! Defense-in-depth regression test for the snapshot-error contract.
+//!
+//! Phase 1 / Task 1.3 of `docs/plans/2026-05-13-sync-402-data-integrity.md`.
+//!
+//! # Why this suite exists
+//!
+//! The end-to-end chain a 402 (Insufficient balance) upload travels is:
+//!
+//! ```text
+//! hcfs-client per-file upload returns Err
+//!   -> finalize_session_for_label runs at end-of-cycle
+//!   -> mark_pending_files_as_failed sets FileStatus::Error
+//!   -> build_snapshot maps FileStatus::Error -> FileProgressStatus::Error
+//!   -> serde renders FileProgressStatus::Error as the JSON string "error"
+//!   -> desktop FE enricher (post Task 1.2) maps status === "error" -> "failed"
+//!   -> SyncStatusIcon renders the red AlertCircle (no pulse)
+//! ```
+//!
+//! The orchestration (`finalize_session_for_label` invoking
+//! `mark_pending_files_as_failed`) lives in `hcfs-client`. Its own tests
+//! cover that orchestration there. This file pins the *desktop-visible
+//! contract*: given the failure-marking entry point the desktop exposes
+//! as `pub fn`, does the resulting `SyncSnapshot.files[].status`
+//! reach the Tauri/IPC boundary as `FileProgressStatus::Error`, whose
+//! `#[serde(rename_all = "camelCase")]` representation is the string
+//! `"error"`?
+//!
+//! Pinning the contract on the desktop side gives us two independent
+//! sentinels: hcfs-client may not break its own contract on its own
+//! tests, but it might rename, retype, or rewire the snapshot in a way
+//! that breaks the desktop view of the chain. This test fails fast
+//! when that happens — *before* the FE's `"error" -> "failed"`
+//! enricher silently sees an unknown status and degrades to the
+//! benign "Completed" branch (which is exactly the original 402 bug
+//! Task 1.2 fixed in the FE renderer).
+//!
+//! # Vocabulary note
+//!
+//! The TypeScript `FileProgressStatus` is
+//! `"pending" | "inProgress" | "encrypting" | "decrypting" | "completed" | "error"`
+//! (see `app/lib/types/syncSnapshot.ts:2`). The user-visible label
+//! `"failed"` is purely a frontend rendering choice that lives in
+//! `app/components/page-sections/files/files-table/index.tsx` (the
+//! Task 1.2 commit). The wire-format string is and remains `"error"`;
+//! this test asserts that wire format.
+//!
+//! # What this suite does NOT do
+//!
+//! - It does not spin a real hcfs-server, a real HTTP transport, or
+//!   any networked endpoint. The 402 condition is simulated by the
+//!   public-API equivalent: `actual_uploads < label_expected_uploads`,
+//!   which is precisely what `mark_pending_files_as_failed` sees when
+//!   an upload's `on_file_synced` callback never fires.
+//! - It does not exercise `finalize_session_for_label`. That symbol
+//!   is private to hcfs-client. The test reaches the same outcome
+//!   through the public IPC funnel the desktop already exposes.
+
+use std::sync::Arc;
+
+use hcfs_client::engine::progress::state::{FileAction, FileStatus, SyncFile, SyncSession};
+use hcfs_client::engine::runner::SyncRunner;
+use hcfs_client::engine::{NoopCallbacks, NoopEventHandler};
+
+// Public re-exports the desktop crate exposes for exactly this kind of
+// snapshot-shape testing. Going through `tauri_project_lib::sync::progress`
+// rather than directly through `hcfs_client::engine::progress::*` ensures
+// the test pins the contract at the *desktop's* public surface — a future
+// refactor that swaps the re-export source still has to satisfy this
+// import.
+use tauri_project_lib::sync::progress::{FileProgressStatus, mark_pending_files_as_failed};
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/// Build a `SyncRunner` using only the public hcfs-client constructor.
+///
+/// Identical shape to `make_sync_runner` in `hippius_activity_truth.rs`
+/// — duplicated rather than shared because each integration test crate
+/// gets its own translation unit, and pulling a shared helper through
+/// a `mod common;` re-export was rejected when the activity-truth suite
+/// was added (no `#[cfg(test)] pub` shims; integration tests use only
+/// the public API). See `src-tauri/CLAUDE.md` and project axiom 111.
+fn make_sync_runner() -> Arc<SyncRunner> {
+    Arc::new(SyncRunner::new(
+        Arc::new(NoopEventHandler),
+        Arc::new(NoopCallbacks),
+        reqwest::Client::new(),
+    ))
+}
+
+/// Build a `SyncFile` that mimics a freshly-staged upload — bytes
+/// already accounted for but the per-file `on_file_synced` callback
+/// has not fired yet (so `status == Pending`).
+///
+/// The 402 failure mode is exactly this shape at the moment
+/// `mark_pending_files_as_failed` runs: the upload was *expected*
+/// (counted in `expected_uploads`), it was never *confirmed* (no
+/// `on_file_synced`), so `actual_uploads < expected_uploads` and the
+/// excess gets demoted.
+fn pending_upload(path: &str, label: &str, size: u64) -> SyncFile {
+    SyncFile {
+        id: Arc::from(path),
+        path: Arc::from(path),
+        file_name: Arc::from(path.rsplit('/').next().unwrap_or(path)),
+        label: Arc::from(label),
+        action: FileAction::Upload,
+        status: FileStatus::Pending,
+        progress: 0,
+        bytes_encrypted: 0,
+        bytes_transferred: 0,
+        total_bytes: size,
+        resumed_from_bytes: None,
+        started_at: 0,
+        completed_at: None,
+        error: None,
+    }
+}
+
+/// Seed the runner's `current_session.files` map with `files` and
+/// declare how many uploads / downloads the session expected.
+///
+/// Reaches into `progress.lock_state()` — a public API used by the
+/// in-tree unit tests in `src/sync/progress.rs`. This is the same
+/// public ingestion path the production sync engine uses to mutate
+/// session state, so a refactor that removes or renames it is a
+/// breaking change that this test will catch.
+fn seed_session(sync: &SyncRunner, files: Vec<SyncFile>, expected_uploads: u32) {
+    let mut state = sync.progress.lock_state();
+    let mut file_map = std::collections::HashMap::new();
+    for f in files {
+        file_map.insert(f.path.to_string(), f);
+    }
+    state.current_session = Some(SyncSession {
+        session_id: Arc::from("test-session"),
+        started_at: 0,
+        completed_at: None,
+        is_active: true,
+        expected_uploads,
+        expected_downloads: 0,
+        expected_local_deletes: 0,
+        expected_remote_deletes: 0,
+        files: file_map,
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+/// Cross-crate contract pin: an unconfirmed upload (the desktop-visible
+/// shape of a 402 response) must surface in the snapshot as
+/// `FileProgressStatus::Error`.
+///
+/// Failure mode this catches: hcfs-client renames `FileStatus::Error`,
+/// changes the `build_snapshot` mapping for `Error`, or alters the
+/// `mark_pending_files_as_failed` semantics so the unconfirmed file
+/// is silently flipped to `Completed` instead of `Error` (which is
+/// exactly the bug the FE used to render as "Completed" / green
+/// checkmark for 402'd uploads).
+#[test]
+fn unconfirmed_upload_surfaces_as_error_status_in_snapshot() {
+    let sync = make_sync_runner();
+    let label = "drive-a";
+
+    // Session expected two uploads. We seed two `Pending` upload rows
+    // — neither of which will receive `on_file_synced` in this test —
+    // and then call the failure-marker with `actual_uploads = 1`. The
+    // resulting `excess_uploads = expected - actual = 1` causes
+    // `mark_pending_files_as_failed` to demote exactly one of the two
+    // to `FileStatus::Error` and pass the other through as
+    // `Completed` (its "the rest must have succeeded silently" branch,
+    // unrelated to this test's assertion).
+    seed_session(
+        &sync,
+        vec![pending_upload("a.txt", label, 1024), pending_upload("b.txt", label, 2048)],
+        /* expected_uploads */ 2,
+    );
+
+    mark_pending_files_as_failed(&sync, /* actual_uploads */ 1, /* actual_downloads */ 0, label)
+        .expect("public mark_pending_files_as_failed must not error on a well-formed session");
+
+    let snapshot = sync.progress.build_snapshot();
+    let failed: Vec<_> = snapshot.files.iter().filter(|f| f.status == FileProgressStatus::Error).collect();
+
+    // Exactly one Error row, AND it must be one of the two we seeded.
+    // The asymmetric `excess = expected - actual = 1` causes the
+    // demoter to pick the first matching pending file; we don't pin
+    // *which* of the two it picks (that's implementation detail) but
+    // we do pin that the one it picked is from our seeded set.
+    assert_eq!(
+        failed.len(),
+        1,
+        "exactly one file should be marked Error after one upload silently failed; \
+         got {} (snapshot.files = {:#?})",
+        failed.len(),
+        snapshot.files
+    );
+    let failed_name = failed[0].file_name.as_ref();
+    assert!(
+        failed_name == "a.txt" || failed_name == "b.txt",
+        "the Error row must be one of the two seeded uploads; got {failed_name:?}"
+    );
+    assert_eq!(
+        snapshot.failed_files, 1,
+        "snapshot.failed_files counter must agree with the per-file Error count — \
+         the FE reads both and they MUST NOT disagree"
+    );
+}
+
+/// Wire-format pin: the JSON the IPC boundary delivers to the FE
+/// MUST contain `"status":"error"` for the failed file.
+///
+/// `FileProgressStatus` derives `Serialize` with
+/// `#[serde(rename_all = "camelCase")]`. Its `Error` variant renames
+/// to the JSON string `"error"`. The FE's discriminated union
+/// (`app/lib/types/syncSnapshot.ts:2`) requires that exact string
+/// to enter the `"error" -> "failed"` enricher branch the Task 1.2
+/// commit added in `files-table/index.tsx`. A serde-attribute drift
+/// (e.g. dropping `rename_all` or renaming the variant to `Failed`)
+/// would silently break the FE without breaking the Rust enum's
+/// `PartialEq` — so the equality assertion above is not enough.
+/// This test pins the on-wire string directly.
+#[test]
+fn failed_file_serializes_status_as_lowercase_error_string() {
+    let sync = make_sync_runner();
+    let label = "drive-a";
+
+    seed_session(&sync, vec![pending_upload("paid.txt", label, 4096)], /* expected_uploads */ 1);
+
+    // actual_uploads = 0 -> excess = 1 -> the single Pending file is
+    // demoted to Error. Mirrors what hcfs-client's
+    // `finalize_session_for_label` does at end-of-cycle when the
+    // per-file confirmation never arrived.
+    mark_pending_files_as_failed(&sync, 0, 0, label).expect("mark_pending_files_as_failed");
+
+    let snapshot = sync.progress.build_snapshot();
+    let json = serde_json::to_value(&snapshot).expect("SyncSnapshot must serialize to JSON; it crosses the Tauri IPC boundary");
+    let files = json
+        .get("files")
+        .and_then(|v| v.as_array())
+        .expect("snapshot must serialize `files` as a JSON array (camelCase, no rename)");
+    let error_row = files
+        .iter()
+        .find(|f| f.get("status").and_then(|s| s.as_str()) == Some("error"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected at least one row with `status: \"error\"` after a failed upload; \
+                 if this assertion fires because the variant now serializes as something else \
+                 (\"failed\", \"Error\", etc.), STOP — the FE enricher in \
+                 `app/components/page-sections/files/files-table/index.tsx` keys on the \
+                 literal \"error\" string and will silently fall through to the \
+                 \"completed\" branch otherwise. See Task 1.2 of the 402 plan. \
+                 Snapshot JSON files: {files:#?}"
+            )
+        });
+    // Confirm it is the file we expected (not some other row).
+    assert_eq!(
+        error_row.get("fileName").and_then(|n| n.as_str()),
+        Some("paid.txt"),
+        "the error row should be the one upload we seeded as failed"
+    );
+}
+
+/// Negative-shape pin: when every expected upload IS confirmed (the
+/// happy path), no row carries the `Error` status and the FE renderer
+/// never enters the "failed" branch.
+///
+/// Without this complement, the two tests above could pass even if
+/// `mark_pending_files_as_failed` always marked everything Error
+/// regardless of `actual_uploads`. The asymmetric pair pins the
+/// directionality of the contract — Error appears iff there was a
+/// shortfall.
+#[test]
+fn confirmed_uploads_produce_no_error_status_in_snapshot() {
+    let sync = make_sync_runner();
+    let label = "drive-a";
+
+    seed_session(&sync, vec![pending_upload("ok.txt", label, 1024)], /* expected_uploads */ 1);
+
+    // actual_uploads >= expected_uploads -> no excess -> no demotion.
+    // The pending row gets carried into Completed by the
+    // "rest must have succeeded silently" branch, which is the
+    // canonical happy-path final state.
+    mark_pending_files_as_failed(&sync, /* actual_uploads */ 1, 0, label).expect("mark_pending_files_as_failed");
+
+    let snapshot = sync.progress.build_snapshot();
+    assert_eq!(
+        snapshot.failed_files, 0,
+        "happy path must not produce any failed files; \
+         snapshot.files = {:#?}",
+        snapshot.files
+    );
+    assert!(
+        snapshot.files.iter().all(|f| f.status != FileProgressStatus::Error),
+        "no file should carry Error status when all expected uploads were confirmed"
+    );
+}

--- a/src-tauri/tests/hippius_upload_processing_watchdog.rs
+++ b/src-tauri/tests/hippius_upload_processing_watchdog.rs
@@ -1,0 +1,195 @@
+//! Regression pins for the upload-processing **banner watchdog** —
+//! Task 4.2 of `docs/plans/2026-05-13-sync-402-data-integrity.md`.
+//!
+//! # What this suite covers
+//!
+//! Four scenarios from the acceptance criteria, exercising the pure
+//! [`UploadProcessingState::drain_expired`] method directly. Each
+//! scenario constructs entries with a controlled `last_set_at` and
+//! a controlled `now`, so the assertion is timestamp-precise and
+//! does NOT depend on wall-clock drift or `tokio::time::pause` (which
+//! does not affect `std::time::Instant`).
+//!
+//! The watchdog spawned by `spawn_watchdog` is a thin loop around
+//! `drain_expired`: `sleep(SCAN_INTERVAL)` → `drain_expired(Instant::now())`
+//! → emit one event per cleared label. Testing `drain_expired` with
+//! injected `Instant`s pins the load-bearing invariants
+//! (`elapsed >= TIMEOUT` triggers, `< TIMEOUT` does not, `last_set_at`
+//! is refreshed on progress) without spawning a tokio task.
+//!
+//! # Why injected `Instant` instead of paused tokio time
+//!
+//! `tokio::time::pause` freezes `tokio::time::Instant::now`, but
+//! `UploadProcessingInner::last_set_at` is `std::time::Instant`. Mixing
+//! the two clocks in a test that asserts "elapsed >= 60s" would be
+//! exquisitely fragile. The watchdog already pulls `Instant::now()`
+//! once per scan and passes it to `drain_expired` — making the
+//! timestamp an explicit parameter on the pure method is the
+//! cleanest way to drive deterministic tests.
+
+use std::time::{Duration, Instant};
+use tauri_project_lib::sync::upload_processing::{BANNER_WATCHDOG_TIMEOUT, UploadProcessingState};
+
+/// Construct an `Instant` `secs_ago` seconds before `now`.
+///
+/// Uses `checked_sub` because `Instant - Duration` can panic on
+/// underflow if a test ever runs in the first 65s of process uptime.
+/// The panic path is unreachable in practice (tests start well after
+/// process init), but the assertion documents the invariant.
+fn instant_secs_before(now: Instant, secs_ago: u64) -> Instant {
+    now.checked_sub(Duration::from_secs(secs_ago))
+        .expect("test fixture: Instant underflow — process uptime < secs_ago")
+}
+
+/// Scenario 1: banner raised, no progress events, `now` past timeout
+/// → cleared.
+///
+/// Pins the basic timeout semantics. An entry stamped 65s ago with no
+/// intervening progress must be drained at `now`.
+#[test]
+fn entry_older_than_timeout_is_cleared() {
+    let state = UploadProcessingState::new();
+    let now = Instant::now();
+    let stamped = instant_secs_before(now, BANNER_WATCHDOG_TIMEOUT.as_secs() + 5);
+    state.begin_for_test_at(stamped, "drive-a", 1, 1);
+
+    let cleared = state.drain_expired_for_test(now);
+    assert_eq!(cleared, vec!["drive-a".to_string()]);
+    assert!(!state.is_active_for("drive-a"));
+}
+
+/// Scenario 2: banner raised, a progress event landed at `t = 30s`,
+/// `now = 90s` → cleared (since refreshed `last_set_at = 30s` is now
+/// 60s old, hits the >= TIMEOUT boundary).
+///
+/// This is the "watchdog respects refreshes" case: the entry started
+/// at t=0 but a same-cycle event (clear_if_session_advanced no-op)
+/// pushed `last_set_at` to t=30s. At t=90s the entry must be drained.
+#[test]
+fn refreshed_entry_clears_after_timeout_from_refresh() {
+    let state = UploadProcessingState::new();
+    let now = Instant::now();
+
+    // Original begin at t=0 (90s before "now"); refresh at t=30s
+    // (60s before "now"). The refresh sets last_set_at = 60s ago,
+    // which equals the boundary BANNER_WATCHDOG_TIMEOUT.
+    let begin_at = instant_secs_before(now, 90);
+    let refresh_at = instant_secs_before(now, BANNER_WATCHDOG_TIMEOUT.as_secs());
+    state.begin_for_test_at(begin_at, "drive-a", 1, 5);
+    // Same-epoch event — clears nothing but refreshes last_set_at.
+    state.clear_if_session_advanced_for_test_at(refresh_at, "drive-a", 5);
+
+    let cleared = state.drain_expired_for_test(now);
+    assert_eq!(cleared, vec!["drive-a".to_string()]);
+}
+
+/// Scenario 3: banner raised, progress event at `t = 50s`,
+/// `now = 90s` → NOT cleared (only 40s elapsed since refresh, under
+/// the 60s threshold).
+///
+/// Pins that a recent progress signal protects the entry from the
+/// watchdog. This is the user-visible "active sync should not have
+/// its banner cleared" invariant.
+#[test]
+fn recent_refresh_protects_entry() {
+    let state = UploadProcessingState::new();
+    let now = Instant::now();
+
+    // Begin at t=0 (90s ago); refresh at t=50s (40s ago).
+    let begin_at = instant_secs_before(now, 90);
+    let refresh_at = instant_secs_before(now, 40);
+    state.begin_for_test_at(begin_at, "drive-a", 1, 5);
+    state.clear_if_session_advanced_for_test_at(refresh_at, "drive-a", 5);
+
+    let cleared = state.drain_expired_for_test(now);
+    assert!(cleared.is_empty(), "fresh refresh must protect entry from watchdog");
+    assert!(state.is_active_for("drive-a"));
+}
+
+/// Scenario 4: a banner cleared normally via `clear_if_session_advanced`
+/// → watchdog does not try to clear it again.
+///
+/// Idempotence with the epoch-gated clear path: once the entry is
+/// removed, a subsequent `drain_expired` is a no-op for that label.
+#[test]
+fn normally_cleared_entry_is_not_double_cleared() {
+    let state = UploadProcessingState::new();
+    let now = Instant::now();
+    let stamped = instant_secs_before(now, BANNER_WATCHDOG_TIMEOUT.as_secs() + 5);
+    state.begin_for_test_at(stamped, "drive-a", 1, 1);
+    // Epoch advance — normal clear path removes the entry.
+    state.clear_if_session_advanced_for_test_at(now, "drive-a", 2);
+    assert!(!state.is_active_for("drive-a"));
+
+    let cleared = state.drain_expired_for_test(now);
+    assert!(cleared.is_empty(), "watchdog must not re-clear an already-removed entry");
+}
+
+/// Watchdog only clears labels whose entries are individually stale —
+/// it must NOT touch labels whose `last_set_at` is fresh. This is the
+/// per-label isolation invariant that the rest of `upload_processing`
+/// is built on.
+#[test]
+fn watchdog_only_clears_stale_labels() {
+    let state = UploadProcessingState::new();
+    let now = Instant::now();
+    let stale_at = instant_secs_before(now, BANNER_WATCHDOG_TIMEOUT.as_secs() + 1);
+    let fresh_at = instant_secs_before(now, 5);
+
+    state.begin_for_test_at(stale_at, "drive-stale", 1, 1);
+    state.begin_for_test_at(fresh_at, "drive-fresh", 1, 1);
+
+    let cleared = state.drain_expired_for_test(now);
+    assert_eq!(cleared, vec!["drive-stale".to_string()]);
+    assert!(!state.is_active_for("drive-stale"));
+    assert!(state.is_active_for("drive-fresh"), "fresh entry must survive the scan");
+}
+
+/// Below-threshold elapsed time is a no-op even at the exact boundary
+/// minus one second. The watchdog uses `>= TIMEOUT`, so this exercises
+/// the closed-interval edge.
+#[test]
+fn just_under_timeout_is_noop() {
+    let state = UploadProcessingState::new();
+    let now = Instant::now();
+    let stamped = instant_secs_before(now, BANNER_WATCHDOG_TIMEOUT.as_secs() - 1);
+    state.begin_for_test_at(stamped, "drive-a", 1, 1);
+
+    let cleared = state.drain_expired_for_test(now);
+    assert!(cleared.is_empty());
+    assert!(state.is_active_for("drive-a"));
+}
+
+/// At the exact boundary (`elapsed == TIMEOUT`), the entry MUST be
+/// cleared. The watchdog comparison is `>=`, so the boundary case
+/// counts as "expired". This pin protects against a silent flip to
+/// `>` (strict inequality), which would extend the effective timeout
+/// by one scan tick.
+#[test]
+fn exactly_at_timeout_is_cleared() {
+    let state = UploadProcessingState::new();
+    let now = Instant::now();
+    let stamped = instant_secs_before(now, BANNER_WATCHDOG_TIMEOUT.as_secs());
+    state.begin_for_test_at(stamped, "drive-a", 1, 1);
+
+    let cleared = state.drain_expired_for_test(now);
+    assert_eq!(cleared, vec!["drive-a".to_string()]);
+}
+
+/// Multiple stale entries are reported in sorted order. The
+/// downstream emit loop in `spawn_watchdog` walks the returned `Vec`
+/// in order; deterministic ordering keeps the emitted-event log
+/// reproducible for log-driven debugging.
+#[test]
+fn drain_expired_returns_sorted_labels() {
+    let state = UploadProcessingState::new();
+    let now = Instant::now();
+    let stamped = instant_secs_before(now, BANNER_WATCHDOG_TIMEOUT.as_secs() + 1);
+    // Insert in non-sorted order; HashMap iteration is unspecified.
+    state.begin_for_test_at(stamped, "zebra", 1, 1);
+    state.begin_for_test_at(stamped, "alpha", 1, 1);
+    state.begin_for_test_at(stamped, "mango", 1, 1);
+
+    let cleared = state.drain_expired_for_test(now);
+    assert_eq!(cleared, vec!["alpha".to_string(), "mango".to_string(), "zebra".to_string()]);
+}

--- a/src-tauri/tests/intent_lifecycle.rs
+++ b/src-tauri/tests/intent_lifecycle.rs
@@ -84,6 +84,60 @@ async fn record_plan_with_planner_style_payload_persists_rows() {
     assert_eq!(total_bytes, 4_251_024, "size_bytes sum mismatch");
 }
 
+/// Pins the contract `build_file_synced_callback` relies on (Task 6
+/// wiring): calling `mark_completed` after `record_plan` flips the
+/// matching row to completed in the per-drive totals, and a second fire
+/// is a no-op so a hcfs-client retry of the per-file callback cannot
+/// double-count bytes.
+///
+/// The closure itself can't be exercised end-to-end here — the spawn
+/// inside `build_file_synced_callback` resolves `tauri::State<AppState>`
+/// at runtime, which only the real Tauri AppHandle has. What this test
+/// guards against is the case where a refactor of `IntentRepo`'s public
+/// API silently breaks the closure's call site (it still compiles but
+/// stops moving totals).
+#[tokio::test]
+async fn mark_completed_after_record_plan_updates_totals_idempotently() {
+    let pool = fresh_pool().await;
+    let repo = IntentRepo::new(pool);
+
+    repo.record_plan("acct", "default", &[("photos/img1.jpg".into(), 4_000_000)])
+        .await
+        .expect("record_plan failed");
+    let before = repo.totals_for_drive("acct", "default").await.expect("totals before");
+    assert_eq!(before.completed_files, 0, "no rows completed yet");
+    assert_eq!(before.completed_bytes, 0, "no bytes completed yet");
+
+    // First completion: row flips, totals advance.
+    repo.mark_completed("acct", "default", "photos/img1.jpg", 1_000_000)
+        .await
+        .expect("mark_completed first call failed");
+    let after_first = repo
+        .totals_for_drive("acct", "default")
+        .await
+        .expect("totals after first mark");
+    assert_eq!(after_first.completed_files, 1, "one file completed");
+    // Completed bytes counts the FULL file size, not the mark timestamp.
+    assert_eq!(after_first.completed_bytes, 4_000_000, "completed bytes match plan size");
+
+    // Second completion (e.g. hcfs-client retry after a transient widget
+    // event drop). The `AND completed_at_ms IS NULL` guard inside
+    // `mark_completed` enforces first-write-wins at the SQL layer, so
+    // the totals must not move.
+    repo.mark_completed("acct", "default", "photos/img1.jpg", 2_000_000)
+        .await
+        .expect("mark_completed second call failed");
+    let after_second = repo
+        .totals_for_drive("acct", "default")
+        .await
+        .expect("totals after second mark");
+    assert_eq!(after_second.completed_files, 1, "still exactly one file completed");
+    assert_eq!(
+        after_second.completed_bytes, 4_000_000,
+        "completed bytes unchanged on duplicate callback"
+    );
+}
+
 /// Calling `record_plan` with an empty plan must compact every pending row
 /// for the (account, drive) pair.
 ///

--- a/src-tauri/tests/intent_lifecycle.rs
+++ b/src-tauri/tests/intent_lifecycle.rs
@@ -320,3 +320,71 @@ async fn clear_drive_via_repo_drops_intent_rows_for_target_drive_only() {
     assert_eq!(other.total_files, 1, "other_acct's drive_a is isolated");
     assert_eq!(other.total_bytes, 999);
 }
+
+/// Pins the `IntentRepo::clear_account` contract that `logout_full` in
+/// `src-tauri/src/auth/logout.rs` wires into as its step 4. The widget's
+/// "X of Y" overlay is the only consumer of intent rows, so on full
+/// logout we must drop every row for the account across ALL drives —
+/// otherwise the next user logging in on the same machine inherits the
+/// previous account's totals. Three invariants matter:
+///
+///   1. Every drive for the target account is wiped (both pending AND
+///      completed halves) — verified by asserting `total_files == 0` for
+///      two different drive labels on the same account.
+///   2. Other accounts sharing the SQLite file are untouched — account
+///      scoping is enforced by the SQL WHERE clause in `clear_account`,
+///      not by the caller.
+///   3. Mixed pending/completed state is fully cleared — a stale
+///      completed row would otherwise inflate next-session totals.
+///
+/// The full `logout_full` flow can't be exercised from cargo-test (it
+/// needs the Tauri runtime + managed AppState); the end-to-end check
+/// is the manual smoke test in task 11. What this test guards against
+/// is a refactor of `clear_account` that drops the account scope (e.g.
+/// switches to unconditional `DELETE FROM sync_intent`) — the wiring
+/// at the logout site still compiles but silently corrupts other
+/// accounts' widget state.
+#[tokio::test]
+async fn clear_account_via_repo_drops_all_intent_for_account_preserving_others() {
+    let pool = fresh_pool().await;
+    let repo = IntentRepo::new(pool);
+
+    repo.record_plan("victim_acct", "drive_a", &[("a.txt".into(), 100), ("b.txt".into(), 200)])
+        .await
+        .expect("record_plan victim_acct/drive_a");
+    repo.record_plan("victim_acct", "drive_b", &[("c.txt".into(), 300)])
+        .await
+        .expect("record_plan victim_acct/drive_b");
+    // Mix completed + pending state so the assertion also pins that
+    // clear_account drops BOTH halves, not just pending rows.
+    repo.mark_completed("victim_acct", "drive_a", "a.txt", 1_000)
+        .await
+        .expect("mark_completed victim_acct/drive_a/a.txt");
+    repo.record_plan("other_acct", "drive_a", &[("z.txt".into(), 999)])
+        .await
+        .expect("record_plan other_acct/drive_a");
+
+    repo.clear_account("victim_acct").await.expect("clear_account victim_acct");
+
+    // Invariant 1: every drive for victim_acct is empty (drive_a had
+    // both a completed and a pending row; drive_b had a pending row).
+    let ta = repo
+        .totals_for_drive("victim_acct", "drive_a")
+        .await
+        .expect("totals victim_acct/drive_a");
+    let tb = repo
+        .totals_for_drive("victim_acct", "drive_b")
+        .await
+        .expect("totals victim_acct/drive_b");
+    assert_eq!(ta.total_files, 0, "drive_a wiped across pending + completed");
+    assert_eq!(tb.total_files, 0, "drive_b wiped");
+
+    // Invariant 2: other_acct's rows are untouched — account scoping
+    // holds even when the two accounts share a drive label.
+    let other = repo
+        .totals_for_drive("other_acct", "drive_a")
+        .await
+        .expect("totals other_acct/drive_a");
+    assert_eq!(other.total_files, 1, "other_acct survives victim_acct clear");
+    assert_eq!(other.total_bytes, 999, "other_acct bytes preserved");
+}

--- a/src-tauri/tests/intent_lifecycle.rs
+++ b/src-tauri/tests/intent_lifecycle.rs
@@ -1,0 +1,127 @@
+//! Integration test that exercises the wiring between hcfs-client's
+//! plan-ready callback and the desktop's `IntentRepo`.
+//!
+//! This file pins the contract that `build_plan_ready_callback` in
+//! `src-tauri/src/sync/lifecycle.rs` relies on: calling
+//! `IntentRepo::record_plan(account, drive, &[(path, size), ...])` with the
+//! exact shape produced by mapping over `Vec<SyncPlanFile>` results in rows
+//! landing in `sync_intent`. The closure itself can't be unit-tested without
+//! a full Tauri `AppHandle` (the spawned task fetches `tauri::State<AppState>`
+//! at runtime); the end-to-end wiring is covered by the smoke test in
+//! Task 11 of the plan.
+//!
+//! What this test guards against: a future refactor of `record_plan`'s
+//! signature or persistence behavior that the closure's call site would
+//! silently keep compiling against (e.g. signature still typechecks but no
+//! rows land).
+
+use sqlx::Row;
+use sqlx::sqlite::SqlitePoolOptions;
+
+use tauri_project_lib::sync::intent::IntentRepo;
+use tauri_project_lib::utils::schema::ensure_table_schema;
+
+/// Build a fresh in-memory SQLite pool with the project schema applied.
+///
+/// In-memory dbs are scoped to a single connection — `max_connections: 1`
+/// ensures every query in the test sees the same database. The schema is
+/// installed via the public `ensure_table_schema` entry point (the same one
+/// production uses at app startup), so the test exercises the actual table
+/// shape rather than a hand-rolled fixture that could drift.
+async fn fresh_pool() -> sqlx::sqlite::SqlitePool {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("open in-memory db");
+    ensure_table_schema(&pool).await.expect("ensure_table_schema");
+    pool
+}
+
+/// Calling `record_plan` with a planner-shaped payload must persist one
+/// `sync_intent` row per upload, with `size_bytes` matching the plan.
+///
+/// This is the load-bearing contract the spawn inside
+/// `build_plan_ready_callback` depends on: it maps `SyncPlanFile { path,
+/// size_bytes }` into `(String, u64)` and hands the slice to `record_plan`.
+/// If that contract changes, the wiring is silently broken even though it
+/// still compiles.
+#[tokio::test]
+async fn record_plan_with_planner_style_payload_persists_rows() {
+    let pool = fresh_pool().await;
+    let repo = IntentRepo::new(pool.clone());
+
+    // Three uploads of varying sizes, the same shape the callback produces
+    // from `uploads.iter().map(|f| (f.path.clone(), f.size_bytes)).collect()`.
+    let planner_uploads: Vec<(String, u64)> = vec![
+        ("photos/img1.jpg".to_string(), 4_000_000),
+        ("docs/spec.pdf".to_string(), 250_000),
+        ("notes.txt".to_string(), 1_024),
+    ];
+
+    repo.record_plan("test_account", "default", &planner_uploads)
+        .await
+        .expect("record_plan failed");
+
+    let row_count: i64 = sqlx::query(
+        "SELECT COUNT(*) AS n FROM sync_intent \
+         WHERE account_id = 'test_account' AND drive_label = 'default'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .get("n");
+    assert_eq!(row_count, 3, "expected 3 pending rows, got {row_count}");
+
+    let total_bytes: i64 = sqlx::query(
+        "SELECT COALESCE(SUM(size_bytes), 0) AS s FROM sync_intent \
+         WHERE account_id = 'test_account' AND drive_label = 'default'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .get("s");
+    assert_eq!(total_bytes, 4_251_024, "size_bytes sum mismatch");
+}
+
+/// Calling `record_plan` with an empty plan must compact every pending row
+/// for the (account, drive) pair.
+///
+/// This pins the "compaction runs even on empty input" semantic that the
+/// callback wiring relies on: the spawn happens BEFORE the `total == 0`
+/// early-return so the user case "I deleted all the files mid-sync" still
+/// flushes the manifest. If `record_plan` ever grew an empty-input
+/// short-circuit, the widget would be stuck showing stale totals.
+#[tokio::test]
+async fn record_plan_with_empty_uploads_compacts_pending_rows() {
+    let pool = fresh_pool().await;
+    let repo = IntentRepo::new(pool.clone());
+
+    // Seed: two pending uploads.
+    let initial: Vec<(String, u64)> = vec![
+        ("a.txt".to_string(), 100),
+        ("b.txt".to_string(), 200),
+    ];
+    repo.record_plan("acct", "drive", &initial)
+        .await
+        .expect("seed record_plan failed");
+
+    let seeded: i64 = sqlx::query("SELECT COUNT(*) AS n FROM sync_intent")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get("n");
+    assert_eq!(seeded, 2, "seed should have inserted 2 rows");
+
+    // Empty plan — must compact every pending row for (acct, drive).
+    repo.record_plan("acct", "drive", &[])
+        .await
+        .expect("empty record_plan failed");
+
+    let after: i64 = sqlx::query("SELECT COUNT(*) AS n FROM sync_intent")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get("n");
+    assert_eq!(after, 0, "empty plan should have compacted all pending rows");
+}

--- a/src-tauri/tests/intent_lifecycle.rs
+++ b/src-tauri/tests/intent_lifecycle.rs
@@ -250,3 +250,73 @@ async fn totals_for_account_sums_across_drives() {
         "unknown account returns zeros (COALESCE handles SQLite SUM-of-empty NULL)"
     );
 }
+
+/// Pins the `IntentRepo::clear_drive` contract that `remove_drive` in
+/// `src-tauri/src/sync/lifecycle.rs` wires into. Three invariants matter:
+///
+///   1. Both pending AND completed rows for the target `(account, drive)`
+///      pair are removed — a stale completed row would otherwise leak into
+///      "X of Y" totals for a future drive of the same label.
+///   2. Other drives on the SAME account survive untouched — a user with
+///      multiple sync folders must not lose progress on `drive_b` because
+///      they removed `drive_a`.
+///   3. The same `drive_label` on a DIFFERENT account survives untouched —
+///      account scoping is enforced by the WHERE clause, not by the caller.
+///
+/// We can't drive `remove_drive` end-to-end from a cargo-test integration
+/// test: it needs a live Tauri runtime + `AppState`-managed `SqlitePool`.
+/// The full flow is exercised by the manual smoke test in task 11. What
+/// this test guards against is a silent refactor of `clear_drive`'s scoping
+/// (e.g. dropping the `drive_label = ?` predicate) that would still compile
+/// at the wiring site but corrupt user data.
+#[tokio::test]
+async fn clear_drive_via_repo_drops_intent_rows_for_target_drive_only() {
+    let pool = fresh_pool().await;
+    let repo = IntentRepo::new(pool);
+
+    // Two drives on the same account, one of which (drive_a) has both a
+    // pending and a completed row — clear_drive must wipe both halves.
+    repo.record_plan("acct", "drive_a", &[("a.txt".into(), 100)])
+        .await
+        .expect("record_plan acct/drive_a");
+    repo.record_plan("acct", "drive_b", &[("b.txt".into(), 200)])
+        .await
+        .expect("record_plan acct/drive_b");
+    repo.mark_completed("acct", "drive_a", "a.txt", 1_000)
+        .await
+        .expect("mark_completed acct/drive_a/a.txt");
+    // Different account, same drive label — must survive (account scoping).
+    repo.record_plan("other_acct", "drive_a", &[("c.txt".into(), 999)])
+        .await
+        .expect("record_plan other_acct/drive_a");
+
+    repo.clear_drive("acct", "drive_a")
+        .await
+        .expect("clear_drive acct/drive_a");
+
+    // Invariant 1: drive_a on `acct` wiped (both pending and completed
+    // halves gone). `total_files == 0` proves the DELETE didn't skip
+    // either kind.
+    let ta = repo
+        .totals_for_drive("acct", "drive_a")
+        .await
+        .expect("totals acct/drive_a");
+    assert_eq!(ta.total_files, 0, "drive_a wiped: no rows remain");
+    assert_eq!(ta.completed_files, 0, "drive_a wiped: completed gone");
+
+    // Invariant 2: drive_b on the SAME account is untouched.
+    let tb = repo
+        .totals_for_drive("acct", "drive_b")
+        .await
+        .expect("totals acct/drive_b");
+    assert_eq!(tb.total_files, 1, "drive_b on same account preserved");
+    assert_eq!(tb.total_bytes, 200, "drive_b bytes preserved");
+
+    // Invariant 3: same drive_label under a different account is untouched.
+    let other = repo
+        .totals_for_drive("other_acct", "drive_a")
+        .await
+        .expect("totals other_acct/drive_a");
+    assert_eq!(other.total_files, 1, "other_acct's drive_a is isolated");
+    assert_eq!(other.total_bytes, 999);
+}

--- a/src-tauri/tests/intent_lifecycle.rs
+++ b/src-tauri/tests/intent_lifecycle.rs
@@ -179,3 +179,74 @@ async fn record_plan_with_empty_uploads_compacts_pending_rows() {
         .get("n");
     assert_eq!(after, 0, "empty plan should have compacted all pending rows");
 }
+
+/// Pins the contract that `tauri_bridge::build_intent_overlay` depends on:
+/// a single account-scoped aggregate query that sums totals across every
+/// drive the user has. The snapshot overlay shows ONE pair of "X of Y"
+/// numbers (global per account), not per-drive, so the bridge needs an
+/// aggregate primitive — issuing N `totals_for_drive` calls per emit would
+/// be N round-trips against SQLite on a hot path that fires at up to 4 Hz.
+///
+/// What this test fixes in place:
+///   - The cross-drive SUM/COUNT semantics (totals across drives roll up).
+///   - The account scoping (one account's rows never see another's).
+///   - The completed vs. total split is preserved per the same COALESCE
+///     pattern as `totals_for_drive`.
+#[tokio::test]
+async fn totals_for_account_sums_across_drives() {
+    let pool = fresh_pool().await;
+    let repo = IntentRepo::new(pool);
+
+    repo.record_plan(
+        "acct",
+        "drive_a",
+        &[("a.txt".into(), 100), ("b.txt".into(), 200)],
+    )
+    .await
+    .expect("record_plan drive_a");
+    repo.record_plan("acct", "drive_b", &[("c.txt".into(), 300)])
+        .await
+        .expect("record_plan drive_b");
+    // Mark only a.txt complete; drive_a still has b.txt pending and
+    // drive_b's c.txt is pending. Totals across the account should be
+    // 3 files / 600 bytes total, 1 file / 100 bytes completed.
+    repo.mark_completed("acct", "drive_a", "a.txt", 1_000)
+        .await
+        .expect("mark_completed a.txt");
+    // A different account shares the SQLite file. Its rows must NEVER
+    // bleed into "acct"'s totals.
+    repo.record_plan("other_acct", "drive_a", &[("d.txt".into(), 999)])
+        .await
+        .expect("record_plan other_acct");
+
+    let totals = repo
+        .totals_for_account("acct")
+        .await
+        .expect("totals_for_account acct");
+    assert_eq!(totals.total_files, 3, "a + b + c across drive_a + drive_b");
+    assert_eq!(totals.total_bytes, 600, "100 + 200 + 300");
+    assert_eq!(totals.completed_files, 1, "only a.txt is completed");
+    assert_eq!(totals.completed_bytes, 100, "a.txt's size only");
+
+    let other = repo
+        .totals_for_account("other_acct")
+        .await
+        .expect("totals_for_account other_acct");
+    assert_eq!(other.total_files, 1, "other account is isolated");
+    assert_eq!(other.total_bytes, 999);
+
+    let absent = repo
+        .totals_for_account("missing_acct")
+        .await
+        .expect("totals_for_account missing_acct");
+    assert_eq!(
+        absent,
+        tauri_project_lib::sync::intent::IntentTotals {
+            total_files: 0,
+            total_bytes: 0,
+            completed_files: 0,
+            completed_bytes: 0,
+        },
+        "unknown account returns zeros (COALESCE handles SQLite SUM-of-empty NULL)"
+    );
+}

--- a/src-tauri/tests/local_db_commands.rs
+++ b/src-tauri/tests/local_db_commands.rs
@@ -272,7 +272,7 @@ async fn soft_delete_all_includes_system_rows() {
     let bob = "bob";
 
     insert_notification(&pool, alice, None, None, "a1").await;
-    insert_notification(&pool, "system", Some("Hippius"), Some("0.1.99"), "Update Available").await;
+    insert_notification(&pool, "system", Some("Hippius"), Some("0.1.100"), "Update Available").await;
     insert_notification(&pool, bob, None, None, "b1").await;
 
     // Same SQL the production command runs.


### PR DESCRIPTION
## What's New
We've polished a few rough edges around sync feedback and credits.

### Clearer Out of Credits Messages
When an upload can't finish because your account is low on credits, Hippius now shows a clear out of credits banner instead of a generic sync-failed toast. You know exactly what's wrong and what to do next.

### More Accurate Upload Cost Check
Hippius now checks whether you have enough credits based on the actual size of what you're uploading, instead of a simple "any balance" check. You'll get a more reliable read on whether an upload can complete before it starts.

### Failed Files Are Easy to Spot
Files that couldn't sync now show up in the Drive list with a red alert icon, so you can see at a glance what needs attention and retry only those files.

### Numeric Dates Now Use DD/MM/YYYY
Dates shown as numbers throughout the app now use day/month/year format for consistency.

## Reliability Improvements

### Sync Counts Stay Accurate
The upload count shown in the sync widget and the tray menu now stays in sync with what's actually being uploaded, even when the engine retries or reorganizes work in the background. The numbers no longer drift mid-sync.

### No More Stuck "Preparing" Status
The tray status could occasionally stay stuck on "Preparing" after a sync finished. It now clears reliably whenever the sync engine goes idle.

### Faster, More Reliable App Launch
The app no longer hangs on the splash screen when an update is pending. Sync also starts more consistently right after login, so your folders begin uploading without delay.

### Smoother Drive Refresh
The Drive list used to flicker as it refreshed multiple times in quick succession after a sync. Refreshes are now debounced into a single update, so the view stays stable while files are syncing.

### Better Feedback for Local Changes
When Hippius detects a new file change on disk, the sync widget now shows a clear "Preparing" state while it plans the upload, instead of jumping to a misleading progress count.

### No Files Dropped During the First Sync
A rare timing issue during the first sync of a freshly added folder could cause Hippius to skip uploading some files. This has been fixed, your files now reliably make it to the server.
