### PR TITLE
Release 0.1.101

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -158,6 +158,34 @@ jobs:
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      # src-tauri/rust-toolchain.toml pins the build to a specific channel
+      # (1.95.0), which rustup auto-installs at first `cargo` use with ONLY the
+      # host (aarch64) target. The step above only adds the Apple targets to
+      # *stable*, so the universal build still can't find x86_64-apple-darwin.
+      # Parse the pinned channel and add both Apple slices to *that* toolchain.
+      - name: Add Apple targets to the pinned toolchain
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The pin lives in src-tauri/ (the Rust workspace); fall back to the
+          # repo root in case it moves again.
+          channel=""
+          for f in src-tauri/rust-toolchain.toml rust-toolchain.toml; do
+            if [[ -f "$f" ]]; then
+              channel=$(sed -n 's/^channel *= *"\(.*\)"/\1/p' "$f")
+              echo "Pinned toolchain channel: ${channel} (from $f)"
+              break
+            fi
+          done
+          if [[ -z "$channel" ]]; then
+            echo "No rust-toolchain.toml found — stable already has both targets"
+            exit 0
+          fi
+          rustup toolchain install "${channel}" --no-self-update
+          rustup target add --toolchain "${channel}" aarch64-apple-darwin x86_64-apple-darwin
+          rustup show
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:

--- a/.github/workflows/tauri-dev.yml
+++ b/.github/workflows/tauri-dev.yml
@@ -148,6 +148,33 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      # src-tauri/rust-toolchain.toml pins the build to a specific channel
+      # (1.95.0), which rustup auto-installs at first `cargo` use with ONLY the
+      # host (aarch64) target. The step above only adds the Apple targets to
+      # *stable*, so the universal build still can't find x86_64-apple-darwin.
+      # Parse the pinned channel and add both Apple slices to *that* toolchain.
+      - name: Add Apple targets to the pinned toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The pin lives in src-tauri/ (the Rust workspace); fall back to the
+          # repo root in case it moves again.
+          channel=""
+          for f in src-tauri/rust-toolchain.toml rust-toolchain.toml; do
+            if [[ -f "$f" ]]; then
+              channel=$(sed -n 's/^channel *= *"\(.*\)"/\1/p' "$f")
+              echo "Pinned toolchain channel: ${channel} (from $f)"
+              break
+            fi
+          done
+          if [[ -z "$channel" ]]; then
+            echo "No rust-toolchain.toml found — stable already has both targets"
+            exit 0
+          fi
+          rustup toolchain install "${channel}" --no-self-update
+          rustup target add --toolchain "${channel}" aarch64-apple-darwin x86_64-apple-darwin
+          rustup show
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## What's New
This release focuses on making large drives feel fast and keeping sync feedback accurate.
### Sync Conflicts Stay Separate Per Drive
Sync conflicts are now tracked independently for each drive. A conflict on one drive no longer clears or overwrites conflicts on another, so you always see the right issues for the right drive.
### Live Credit Balance
Your credit balance now updates in real time and always shows a number, matching the storage tiles. No more blank or stale values on the home screen.
### Folders Refresh Automatically After Sync
When a sync finishes, the folder you're viewing now refreshes on its own, so your file listing stays current without a manual reload.
### Clearer Out of Credits Messages
When an upload can't finish because your account is low on credits, Hippius now shows a clear out of credits message instead of a generic sync-failed error, so you know exactly what's wrong and what to do next.
## Performance
### Faster File Lists on Large Drives
File lists now render only the rows you can actually see, so opening a drive with thousands of files no longer causes multi-second freezes. Scrolling stays smooth no matter how big the drive is.
### Snappier Sorting and View Switching
Rows that haven't changed now skip unnecessary recomputation when you sort or toggle view modes, keeping the file table responsive even on large drives.
### Lighter Sync Status Dialog
The sync status view now builds its per-file rows only when expanded, cutting wasted work during active syncs.
### Fewer Redundant Notification Requests
Update notifications now share a single app-version lookup instead of making repeated background requests, making the notifications menu lighter.
## Reliability Improvements
### Fixed Unlock Password Setup Error
Setting up your unlock password no longer requires you to setup password again and shows no error. 
### More Reliable Notification Dismissal
Dismissing notifications is now more consistent and aligned with the latest backend behavior.