### PR TITLE
chore: point the X handle at @Hippius_cloud

### DIFF
--- a/app/components/page-sections/referrals/ReferralLinkHeader.tsx
+++ b/app/components/page-sections/referrals/ReferralLinkHeader.tsx
@@ -67,7 +67,7 @@ const ReferralLinkHeader: React.FC<ReferralLinkHeaderProps> = ({
   const handleShareX = useCallback(async () => {
     if (!referralUrl) return;
     const text = encodeURIComponent(
-      `🚀 I'm using @hippius_subnet for decentralized storage, compute & more!\n\nJoin using my referral link and we both earn credits:\n${referralUrl}\n\n#Hippius #Web3 #Decentralized`,
+      `🚀 I'm using @Hippius_cloud for decentralized storage, compute & more!\n\nJoin using my referral link and we both earn credits:\n${referralUrl}\n\n#Hippius #Web3 #Decentralized`,
     );
     try {
       await openUrl(`https://x.com/intent/tweet?text=${text}`);


### PR DESCRIPTION
Our X handle changed from `@hippius_subnet` to `@Hippius_cloud`.

One occurrence in the app: the referral share text, which tags the handle in the tweet it composes for the user.

```
ReferralLinkHeader.tsx  +1 -1
```